### PR TITLE
Changed the way caution flags are updated

### DIFF
--- a/app/models/concerns/standardizable.rb
+++ b/app/models/concerns/standardizable.rb
@@ -56,7 +56,7 @@ module Standardizable
         #######################################################################
         when :ope
           define_method(:ope=) do |v|
-            v = v.try(:strip).try(:downcase) if v.is_a?(String)
+            v = v.try(:strip).try(:upcase) if v.is_a?(String)
             v = nil if self.class.forbidden_word?(v)
 
             write_attribute(:ope, self.class.pad(v, 8)) 


### PR DESCRIPTION
@plusjeff @ayaleloehr 
The "Fix" is in. I've changed the way all relevant CSVs update the caution flags. Because some CSVs have all caution flags on a single row while others have a separate row per caution flag, it was necessary to ensure that (1) all rows were included and (2) that the caution flag text doesn't repeat - either for the same CSV or for related CSVs (e.g., Sec 702 and Sec 702 Schools).

There are only 3 changed files, but the changes are large, and the SQL is convoluted (for me), I will be reachable - so let me know if there are any issues!
