### PR TITLE
Use helper path instead of hardcoded path for build csv link

### DIFF
--- a/app/views/dashboards/_introduction.html.erb
+++ b/app/views/dashboards/_introduction.html.erb
@@ -24,7 +24,7 @@
       <div class="row row-space-6">
         <div class="col-xs-12">
           <%= link_to 'Build New data.csv', 
-            '/dashboards', method: :post, class: "btn btn-primary btn-xs", 
+            dashboards_path, method: :post, class: "btn btn-primary btn-xs", 
             role: "button" %>
         </div>
       </div>


### PR DESCRIPTION
Fix for #143. Uses path helper instead of hard-coded path. Reproduced issue and verified with manual fix in staging environment. 
