### PR TITLE
Session cleaning proposal

### DIFF
--- a/app/controllers/concerns/session_cleaning.rb
+++ b/app/controllers/concerns/session_cleaning.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module SessionCleaning
+  extend ActiveSupport::Concern
+
+  def delete_inactive_sessions!
+    ActiveRecord::SessionStore::Session.delete_all ["created_at < ?", 1.week.ago]
+  end
+end

--- a/app/controllers/concerns/session_cleaning.rb
+++ b/app/controllers/concerns/session_cleaning.rb
@@ -3,6 +3,6 @@ module SessionCleaning
   extend ActiveSupport::Concern
 
   def delete_inactive_sessions!
-    ActiveRecord::SessionStore::Session.delete_all ["created_at < ?", 1.week.ago]
+    ActiveRecord::SessionStore::Session.delete_all ['created_at < ?', 1.week.ago]
   end
 end


### PR DESCRIPTION
As a simple solution to our cancerous sessions problem (#139) I propose we call this method to clear inactive sessions every time new data is published.

This avoids adding more gems, cron jobs, or other overhead to our application while still ensuring that old sessions get swept every couple of weeks.

```
class DashboardsController
  include SessionCleaning
  ...

  def publish
    delete_inactive_sessions!
    ...
  end
end
```