### PR TITLE
Add no-auth status endpoint outside of v0/ namespace

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class StatusController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def status
+    app_status = { "status": 'ok' }
+    render json: app_status
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   match '/v0/*path', to: 'api#cors_preflight', via: [:options]
 
+  get 'status' => 'status#status'
+
   devise_for :user
 
   # For active? helper

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'json'
+
+RSpec.describe StatusController, type: :controller do
+  describe 'GET #status' do
+    it 'returns ok' do
+      get :status
+      expect(response.content_type).to eq('application/json')
+      expect(JSON.parse(response.body)['status']).to eq('ok')
+    end
+  end
+end


### PR DESCRIPTION
In support of devops monitoring. While there are some non-authenticated API endpoints already, I want to be able to hide all of the /v0/ namespace as accessible internally only (mediating all API operations through vets-api). Whereas the status endpoint needs to be accessible externally for blackbox monitoring.