### PR TITLE
Facet counts and other suboptimal enhancements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,26 +20,10 @@ pipeline {
       }
     }
 
-    stage('Audit') {
+    stage('Prepare database') {
       steps {
         withEnv(env_vars) {
-          sh 'bash --login -c "bundle exec rake ci"'
-        }
-      }
-    }
-
-    stage('Prepare') {
-      steps {
-        withEnv(env_vars) {
-          sh 'bash --login -c "bundle exec rake db:drop"'
-        }
-      }
-    }
-
-    stage('Ensure database exists') {
-      steps {
-        withEnv(env_vars) {
-          sh 'bash --login -c "bundle exec rake db:create db:migrate"'
+          sh 'bash --login -c "bundle exec rake db:drop db:create db:schema:load"'
         }
       }
     }
@@ -47,7 +31,7 @@ pipeline {
     stage('Run tests') {
       steps {
         withEnv(env_vars) {
-          sh 'bash --login -c "bundle exec rspec"'
+          sh 'bash --login -c "bundle exec rake ci"'
         }
       }
     }

--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -13,7 +13,7 @@ module V0
     # Newest production data version assumed when version param is undefined
     def resolve_version
       v = params[:version]
-      version = v.present? ? Version.find_by_number(v) : Version.default_version
+      version = v.present? ? Version.find_by(number: v) : Version.default_version
       raise ActiveRecord::RecordNotFound, "Version #{v} not found" unless version.try(:number)
       @version = {
         number: version.number,

--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -14,7 +14,7 @@ module V0
     def resolve_version
       v = params[:version]
       version = v.present? ? Version.find_by(number: v) : Version.default_version
-      raise ActiveRecord::RecordNotFound, "Version #{v} not found" unless version.try(:number)
+      raise Common::Exceptions::InvalidFieldValue, "Version #{v} not found" unless version.try(:number)
       @version = {
         number: version.number,
         created_at: version.created_at,

--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -2,12 +2,25 @@
 module V0
   class ApiController < ApplicationController
     skip_before_action :authenticate_user!
+    before_action :resolve_version
 
     def cors_preflight
       head(:ok)
     end
 
     private
+
+    # Newest production data version assumed when version param is undefined
+    def resolve_version
+      v = params[:version]
+      version = v.present? ? Version.find_by_number(v) : Version.default_version
+      raise ActiveRecord::RecordNotFound, "Version #{v} not found" unless version.try(:number)
+      @version = {
+        number: version.number,
+        created_at: version.created_at,
+        preview: version.preview?
+      }
+    end
 
     rescue_from 'Exception' do |exception|
       log_error(exception)

--- a/app/controllers/v0/calculator_constants_controller.rb
+++ b/app/controllers/v0/calculator_constants_controller.rb
@@ -3,10 +3,9 @@ module V0
   class CalculatorConstantsController < ApiController
     # GET /v0/calculator/constants
     def index
-      @version = nil # TODO: params[:version]
-
+      # TODO: implement actual versioning
       @data = CalculatorConstant.version(@version).all
-      @links = { self: v0_calculator_constants_url(version: @version) }
+      @links = { self: v0_calculator_constants_url(version: @version[:number]) }
       @meta = { version: @version }
       render json: @data, meta: @meta, links: @links
     end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -61,13 +61,12 @@ module V0
                  .filter(:poe, params[:principles_of_excellence]) # boolean
                  .filter(:eight_keys, params[:eight_keys_to_veteran_success]) # boolean
     end
-    # rubocop:enable AbcSize
 
     def facets
       institution_types = search_results.filter_count(:institution_type_name)
       {
         type: {
-          school: institution_types.except('ojt').inject(0){|count,(_t,n)| count + n },
+          school: institution_types.except('ojt').inject(0) { |count, (_t, n)| count + n },
           employer: institution_types['ojt'].to_i
         },
         type_name: institution_types,
@@ -80,5 +79,6 @@ module V0
         eight_keys_to_veteran_success: search_results.filter_count(:eight_keys)
       }
     end
+    # rubocop:enable AbcSize
   end
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -104,8 +104,18 @@ class Institution < ActiveRecord::Base
       where(field => true)
     when 'false', 'no'
       where.not(field => true)
+    when 'school' # field: institution_type_name
+      where.not(field => EMPLOYER)
+    when 'employer' # field: institution_type_name
+      where(field => EMPLOYER)
+    else
+      where(field => value)
     end
   }
 
-  scope :version, ->(version) { where(version: version) }
+  scope :filter_count, lambda { |field|
+    group(field).where.not(field => nil).order(field).count
+  }
+
+  scope :version, ->(n) { where(version: n) }
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -30,7 +30,7 @@ class Version < ActiveRecord::Base
   }
 
   def preview?
-    self.number != Version.production_version.number
+    number != Version.production_version.number
   rescue
     true
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -29,6 +29,12 @@ class Version < ActiveRecord::Base
     where('created_at <= ?', time).newest
   }
 
+  def preview?
+    self.number != Version.production_version.number
+  rescue
+    true
+  end
+
   def self.production_version
     Version.production.newest
   end
@@ -37,10 +43,8 @@ class Version < ActiveRecord::Base
     Version.preview.newest
   end
 
-  def self.default_version_number
-    Version.production.newest.number
-  rescue
-    nil
+  def self.default_version
+    Version.production.newest
   end
 
   def self.production_version_by_time(time)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,10 +154,10 @@ ActiveRecord::Schema.define(version: 20170216084207) do
     t.datetime "updated_at",    null: false
   end
 
-  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", using: :btree
+  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", unique: true, using: :btree
   add_index "crosswalks", ["facility_code"], name: "index_crosswalks_on_facility_code", unique: true, using: :btree
   add_index "crosswalks", ["institution"], name: "index_crosswalks_on_institution", using: :btree
-  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", using: :btree
+  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", unique: true, using: :btree
   add_index "crosswalks", ["ope6"], name: "index_crosswalks_on_ope6", using: :btree
 
   create_table "eight_keys", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,10 +154,10 @@ ActiveRecord::Schema.define(version: 20170216084207) do
     t.datetime "updated_at",    null: false
   end
 
-  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", unique: true, using: :btree
+  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", using: :btree
   add_index "crosswalks", ["facility_code"], name: "index_crosswalks_on_facility_code", unique: true, using: :btree
   add_index "crosswalks", ["institution"], name: "index_crosswalks_on_institution", using: :btree
-  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", unique: true, using: :btree
+  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", using: :btree
   add_index "crosswalks", ["ope6"], name: "index_crosswalks_on_ope6", using: :btree
 
   create_table "eight_keys", force: :cascade do |t|

--- a/spec/controllers/v0/api_controller_spec.rb
+++ b/spec/controllers/v0/api_controller_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe V0::ApiController, type: :controller do
 
   context 'Parameter Missing' do
     subject { JSON.parse(response.body)['errors'].first }
-    before(:each) { routes.draw { get 'parameter_missing' => 'v0/api#parameter_missing' } }
+    before(:each) do
+      routes.draw { get 'parameter_missing' => 'v0/api#parameter_missing' }
+      create(:version, :production)
+    end
 
     context 'with Rails.env.test or Rails.env.development' do
       it 'renders json object with developer attributes' do
@@ -45,7 +48,10 @@ RSpec.describe V0::ApiController, type: :controller do
 
   context 'Internal Server Error' do
     subject { JSON.parse(response.body)['errors'].first }
-    before(:each) { routes.draw { get 'internal_server_error' => 'v0/api#internal_server_error' } }
+    before(:each) do
+      routes.draw { get 'internal_server_error' => 'v0/api#internal_server_error' }
+      create(:version, :production)
+    end
 
     context 'with Rails.env.test or Rails.env.development' do
       it 'renders json object with developer attributes' do
@@ -69,7 +75,10 @@ RSpec.describe V0::ApiController, type: :controller do
 
   context 'Unauthorized' do
     subject { JSON.parse(response.body)['errors'].first }
-    before(:each) { routes.draw { get 'unauthorized' => 'v0/api#unauthorized' } }
+    before(:each) do
+      routes.draw { get 'unauthorized' => 'v0/api#unauthorized' }
+      create(:version, :production)
+    end
 
     context 'with Rails.env.test or Rails.env.development' do
       it 'renders json object with developer attributes' do

--- a/spec/controllers/v0/calculator_constants_controller_spec.rb
+++ b/spec/controllers/v0/calculator_constants_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe V0::CalculatorConstantsController, type: :controller do
       create(:calculator_constant, :float)
       create(:calculator_constant, :string)
       create(:calculator_constant, :string)
+      create(:version, :production)
       get :index
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('calculator_constants')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe V0::InstitutionsController, type: :controller do
   context 'autocomplete results' do
     it 'returns collection of matches' do
+      create(:version, :production)
       7.times { create(:institution, :contains_harv) }
       get :autocomplete, term: 'harv', version: 1
       expect(response.content_type).to eq('application/json')
@@ -13,6 +14,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
   context 'search results' do
     before(:each) do
+      create(:version, :production)
       2.times { create(:institution, :in_nyc) }
       create(:institution, :in_chicago)
     end
@@ -33,6 +35,10 @@ RSpec.describe V0::InstitutionsController, type: :controller do
   end
 
   context 'institution profile' do
+    before(:each) do
+      create(:version, :production)
+    end
+
     it 'returns profile details' do
       school = create(:institution, :in_chicago)
 

--- a/spec/support/api/schemas/autocomplete.json
+++ b/spec/support/api/schemas/autocomplete.json
@@ -5,7 +5,20 @@
     "meta": {
       "type": "object",
       "properties": {
-        "version": { "type": ["null", "string"] }
+        "version": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "preview": {
+              "type": "boolean"
+            }
+          }
+        }
       },
       "required": [
         "version"

--- a/spec/support/api/schemas/calculator_constants.json
+++ b/spec/support/api/schemas/calculator_constants.json
@@ -51,7 +51,18 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": "null"
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "preview": {
+              "type": "boolean"
+            }
+          }
         }
       },
       "required": [

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -5,7 +5,20 @@
     "meta": {
       "type": "object",
       "properties": {
-        "version": { "type": ["null", "string"] }
+        "version": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "preview": {
+              "type": "boolean"
+            }
+          }
+        }
       },
       "required": [
         "version"

--- a/spec/support/api/schemas/institutions.json
+++ b/spec/support/api/schemas/institutions.json
@@ -5,7 +5,20 @@
     "meta": {
       "type": "object",
       "properties": {
-        "version": { "type": ["null", "string"] }
+        "version": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "preview": {
+              "type": "boolean"
+            }
+          }
+        }
       },
       "required": [
         "version"


### PR DESCRIPTION
Wherein all API responses return verbose data versioning metadata.
```json
...
"meta": {
  "version": {
    "number": 1,
    "created_at": "2017-02-16T05:23:49.937Z",
    "preview": false
  }
}
```

And search results include filter counts to support the search interface.
```json
...
"facets": {
  "type": {
    "school": 3,
    "employer": 0
  },
  "type_name": {
    "for profit": 2,
    "public": 1
  },
  "state": {
    "ga": 1,
    "mn": 2
  },
  "country": {
     "usa": 3
  },
  "caution_flag": {
    "true": 3
  },
  "student_vet_group": {
    "false": 3
  },
  "yellow_ribbon_scholarship": {
    "false": 3
  },
  "principles_of_excellence": {
    "false": 1,
    "true": 2
  },
  "eight_keys_to_veteran_success": {
    "false": 3
  }
}
```

Upon further reflection the facet objects should probably be arrays.