### PR TITLE
Match up header conversion with SmarterCSV behavior

### DIFF
--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -67,7 +67,7 @@ module CsvHelper
 
       klass::CSV_CONVERTER_INFO.each_pair do |csv_column, info|
         value_converters[info[:column]] = info[:converter]
-        key_mapping[csv_column.tr(' ', '_').to_sym] = info[:column]
+        key_mapping[csv_column.tr(' -', '_').to_sym] = info[:column]
       end
 
       options.reverse_merge(key_mapping: key_mapping, value_converters: value_converters)


### PR DESCRIPTION
SmarterCSV converts dashes to underscores in headers. We have a dash in the weams header non-college degree indicator. We were not mapping accordingly in csv_helper/loader.rb, causing this column to not get mapped in AWS dev environment - all entries were nil. This in turn caused thousands of institutions to have approved? = false.

I still can't account for why this didn't happen in our local environments, but pushing this fix to dev and re-uploading weams.csv made the database look correct.