### PR TITLE
Avoid 500 error on missing autocomplete term

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -3,14 +3,17 @@ module V0
   class InstitutionsController < ApiController
     # GET /v0/institutions/autocomplete?term=harv
     def autocomplete
-      @search_term = params[:term].strip.downcase
-      @data = Institution.version(@version[:number]).autocomplete(@search_term)
+      @data = []
+      if params[:term]
+        @search_term = params[:term]&.strip&.downcase
+        @data = Institution.version(@version[:number]).autocomplete(@search_term)
+      end
       @meta = {
         version: @version,
         term: @search_term
       }
       @links = {
-        self: autocomplete_v0_institutions_url(term: params[:term])
+        self: autocomplete_v0_institutions_url(term: @search_term)
       }
       render json: { data: @data, links: @links, meta: @meta }, adapter: :json
     end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -13,7 +13,7 @@ module V0
         term: @search_term
       }
       @links = {
-        self: autocomplete_v0_institutions_url(term: @search_term)
+        self: autocomplete_v0_institutions_url(term: params[:term])
       }
       render json: { data: @data, links: @links, meta: @meta }, adapter: :json
     end

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
     end
+
+    it 'returns empty collection on missing term parameter' do
+      create(:version, :production)
+      7.times { create(:institution, :contains_harv) }
+      get :autocomplete, term: nil, version: 1
+      expect(JSON.parse(response.body)['data'].count).to eq(0)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('autocomplete')
+    end
   end
 
   context 'search results' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1386

Perhaps more proper to raise a `MissingParameter` Exception, but then would also need to plumb that through as a BackendService exception in vets-api, which seems high-touch for the autocomplete which is by its nature a fire-and-forget kind of API. 
