### PR TITLE
Update country facet to avoid key munging between API and frontend

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -79,7 +79,7 @@ module V0
         },
         type_name: institution_types,
         state: search_results.filter_count(:state),
-        country: search_results.filter_count(:country),
+        country: embed(search_results.filter_count(:country)),
         caution_flag: search_results.filter_count(:caution_flag),
         student_vet_group: search_results.filter_count(:student_veteran),
         yellow_ribbon_scholarship: search_results.filter_count(:yr),
@@ -88,5 +88,14 @@ module V0
       }
     end
     # rubocop:enable AbcSize
+
+    # Embed search result counts as a list of hashes with "name"/"count"
+    # keys so that open-ended strings such as country names do not
+    # get interpreted/mutated as JSON keys.
+    def embed(group_counts)
+      group_counts.each_with_object([]) do |(k, v), array|
+        array << { name: k, count: v }
+      end
+    end
   end
 end

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end
+
+    it 'has facet metadata' do
+      get :index, name: 'chicago', version: 1
+      facets = JSON.parse(response.body)['meta']['facets']
+      expect(facets['state']['il']).to eq(1)
+      expect(facets['country'].count).to eq(1)
+      expect(facets['country'][0]['name']).to eq('USA')
+    end
   end
 
   context 'institution profile' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/gibct-data-service/issues/224.
though needs a corresponding fix on frontend to consume this structure.

Example facet object with this fix. Only country is embedded in this way since it's the only facet with particularly open-ended values. 
```
"facets": {
  "type":{"school":136,"employer":108},
  "type_name":{"flight":3,"for profit":32,"foreign":5,"ojt":108,"private":55,"public":41},
  "state":{"al":3,"ar":6,"az":4,"ca":10,"co":21,"ct":1,"fl":5,"ga":12,"ia":3,"id":8,"il":4,"in":1,"ky":2,"ma":5,"md":4,"me":4,"mi":2,"mn":4,"mo":4,"ms":2,"mt":7,"nc":25,"nd":2,"nh":4,"nj":17,"nm":1,"ny":13,"oh":9,"ok":1,"or":3,"pa":6,"sd":1,"tn":2,"tx":1,"ut":13,"va":5,"vt":7,"wa":7,"wi":2,"wv":5,"wy":3},
  "country":[{"name":"AUSTRALIA","count":1},{"name":"CANADA","count":4},{"name":"USA","count":239}],
  "caution_flag":{"false":234,"true":10},
  "student_vet_group":{"false":229,"true":15},
  "yellow_ribbon_scholarship":{"false":202,"true":42},
  "principles_of_excellence":{"false":190,"true":54},
  "eight_keys_to_veteran_success":{"false":222,"true":22}}
```