### PR TITLE
Refactor overloaded type_name query parameter to type/category

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.12.1)
     nenv (0.3.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -377,4 +377,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -45,10 +45,10 @@ module V0
       query.tap do
         query[:name].try(:strip!)
         query[:name].try(:downcase!)
-        %i(state country).each do |k|
+        %i(state country type).each do |k|
           query[k].try(:upcase!)
         end
-        %i(type_name student_veteran_group yellow_ribbon_scholarship principles_of_excellence
+        %i(category student_veteran_group yellow_ribbon_scholarship principles_of_excellence
            eight_keys_to_veteran_success caution).each do |k|
           query[k].try(:downcase!)
         end
@@ -61,7 +61,8 @@ module V0
       Institution.version(@version[:number])
                  .search(@query[:name])
                  .filter(:caution_flag, @query[:caution]) # boolean
-                 .filter(:institution_type_name, @query[:type_name])
+                 .filter(:institution_type_name, @query[:type])
+                 .filter(:category, @query[:category])
                  .filter(:country, @query[:country])
                  .filter(:state, @query[:state])
                  .filter(:student_veteran, @query[:student_veteran_group]) # boolean
@@ -73,11 +74,11 @@ module V0
     def facets
       institution_types = search_results.filter_count(:institution_type_name)
       {
-        type: {
+        category: {
           school: institution_types.except(Institution::EMPLOYER).inject(0) { |count, (_t, n)| count + n },
           employer: institution_types[Institution::EMPLOYER].to_i
         },
-        type_name: institution_types,
+        type: institution_types,
         state: search_results.filter_count(:state),
         country: search_results.filter_count(:country),
         caution_flag: search_results.filter_count(:caution_flag),

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -221,17 +221,22 @@ class Institution < ActiveRecord::Base
   scope :filter, lambda { |field, value|
     return if value.blank?
     raise ArgumentError, 'Field name is required' if field.blank?
-    case value
-    when 'true', 'yes'
-      where(field => true)
-    when 'false', 'no'
-      where.not(field => true)
-    when 'school' # field: institution_type_name
-      where.not(field => EMPLOYER)
-    when 'employer' # field: institution_type_name
-      where(field => EMPLOYER)
+    if field == :category
+      case value
+      when 'school'
+        where.not(institution_type_name: EMPLOYER)
+      when 'employer'
+        where(institution_type_name: EMPLOYER)
+      end
     else
-      where(field => value)
+      case value
+      when 'true', 'yes'
+        where(field => true)
+      when 'false', 'no'
+        where.not(field => true)
+      else
+        where(field => value)
+      end
     end
   }
 

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -86,6 +86,42 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
   end
 
+  context 'category and type search results' do
+    before(:each) do
+      create(:version, :production)
+      create(:institution, :in_nyc)
+      create(:institution, :ca_employer)
+    end
+
+    it 'filters by employer category' do
+      get :index, category: 'employer', version: 1
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
+    it 'filters by school category' do
+      get :index, category: 'school', version: 1
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
+    it 'filters by employer type' do
+      get :index, type: 'ojt', version: 1
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
+    it 'filters by school type' do
+      get :index, type: 'private', version: 1
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+  end
+
   context 'institution profile' do
     before(:each) do
       create(:version, :production)

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -49,6 +49,14 @@ FactoryGirl.define do
       country 'USA'
     end
 
+    trait :ca_employer do
+      institution 'ACME INC'
+      city 'LOS ANGELES'
+      state 'CA'
+      country 'USA'
+      institution_type_name 'OJT'
+    end
+
     trait :institution_builder do
       facility_code '1ZZZZZZZ'
       ope '99999999'


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1814
requires corresponding front-end fix to use updated facets and query parameters. 

New parameters are:
`category` = school/employer
`type` = private/for profit/ojt/foreign/etc

That's both what should be sent as query parameters, and what will come back in the facets object for populating the search form.