### PR TITLE
Added preview/production views

### DIFF
--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -13,7 +13,9 @@ module V0
     # Newest production data version assumed when version param is undefined
     def resolve_version
       v = params[:version]
-      version = v.present? ? Version.find_by(number: v) : Version.default_version
+      version = v.try(:downcase) == 'preview' ? Version.preview_version : Version.production_version
+
+      # version = v.present? ? Version.find_by(number: v) : Version.default_version
       raise Common::Exceptions::InvalidFieldValue, "Version #{v} not found" unless version.try(:number)
       @version = {
         number: version.number,

--- a/spec/factories/versions.rb
+++ b/spec/factories/versions.rb
@@ -6,5 +6,9 @@ FactoryGirl.define do
     trait :production do
       production true
     end
+
+    trait :preview do
+      production false
+    end
   end
 end


### PR DESCRIPTION
Allows GIBCT to specify query parameter to retrieve product or preview data: `?version=production` or `version=preview`. If `version` is omitted or incorrect, it defaults to production.