### PR TITLE
Pv add inst indexes

### DIFF
--- a/db/migrate/20170410203534_add_index_institutions.rb
+++ b/db/migrate/20170410203534_add_index_institutions.rb
@@ -1,0 +1,7 @@
+class AddIndexInstitutions < ActiveRecord::Migration
+  def change
+    add_index :institutions, :version
+    add_index :institutions, :cross
+    add_index :institutions, :ope6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330161442) do
+ActiveRecord::Schema.define(version: 20170410203534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,10 +261,13 @@ ActiveRecord::Schema.define(version: 20170330161442) do
   end
 
   add_index "institutions", ["city"], name: "index_institutions_on_city", using: :btree
+  add_index "institutions", ["cross"], name: "index_institutions_on_cross", using: :btree
   add_index "institutions", ["facility_code"], name: "index_institutions_on_facility_code", using: :btree
   add_index "institutions", ["institution"], name: "index_institutions_on_institution", using: :btree
   add_index "institutions", ["institution_type_name"], name: "index_institutions_on_institution_type_name", using: :btree
+  add_index "institutions", ["ope6"], name: "index_institutions_on_ope6", using: :btree
   add_index "institutions", ["state"], name: "index_institutions_on_state", using: :btree
+  add_index "institutions", ["version"], name: "index_institutions_on_version", using: :btree
 
   create_table "ipeds_hds", force: :cascade do |t|
     t.string   "cross",                  null: false

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe Institution, type: :model do
         i = create_list :institution, 2, version: 1
         j = create_list :institution, 2, version: 2
 
-        expect(Institution.version(i.first.version)).to eq(i.to_a)
-        expect(Institution.version(j.first.version)).to eq(j.to_a)
+        expect(Institution.version(i.first.version)).to match_array(i.to_a)
+        expect(Institution.version(j.first.version)).to match_array(j.to_a)
       end
 
       it 'returns blank if a nil or non-existent version number is supplied' do


### PR DESCRIPTION
Avoids full table scan of ever-growing institutions table, primarily via addition of version index.
Reduces time for "generate preview" from 5 minutes down to 30-40 seconds. 

Pulled this branch into staging and applied the db migration there for verification. 