### PR TITLE
Pv add search indexes

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -206,12 +206,12 @@ class Institution < ActiveRecord::Base
   scope :search, lambda { |search_term|
     return if search_term.blank?
     clause = [
-      'lower(facility_code) = (?)',
+      'facility_code = (?)',
       'lower(institution) LIKE (?)',
       'lower(city) LIKE (?)'
     ].join(' OR ')
     terms = [
-      search_term,
+      search_term.upcase,
       "%#{search_term}%",
       "%#{search_term}%"
     ]

--- a/db/migrate/20170410203534_add_index_institutions.rb
+++ b/db/migrate/20170410203534_add_index_institutions.rb
@@ -1,0 +1,7 @@
+class AddIndexInstitutions < ActiveRecord::Migration
+  def change
+    add_index :institutions, :version
+    add_index :institutions, :cross
+    add_index :institutions, :ope6
+  end
+end

--- a/db/migrate/20170410215512_add_search_indexes.rb
+++ b/db/migrate/20170410215512_add_search_indexes.rb
@@ -1,0 +1,10 @@
+class AddSearchIndexes < ActiveRecord::Migration
+  def up
+    execute "CREATE INDEX index_institutions_institution_lprefix 
+             ON institutions (lower(institution) text_pattern_ops);"
+  end
+
+  def down
+    execute "DROP INDEX index_institutions_institution_lprefix;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330161442) do
+ActiveRecord::Schema.define(version: 20170410203534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,10 +261,13 @@ ActiveRecord::Schema.define(version: 20170330161442) do
   end
 
   add_index "institutions", ["city"], name: "index_institutions_on_city", using: :btree
+  add_index "institutions", ["cross"], name: "index_institutions_on_cross", using: :btree
   add_index "institutions", ["facility_code"], name: "index_institutions_on_facility_code", using: :btree
   add_index "institutions", ["institution"], name: "index_institutions_on_institution", using: :btree
   add_index "institutions", ["institution_type_name"], name: "index_institutions_on_institution_type_name", using: :btree
+  add_index "institutions", ["ope6"], name: "index_institutions_on_ope6", using: :btree
   add_index "institutions", ["state"], name: "index_institutions_on_state", using: :btree
+  add_index "institutions", ["version"], name: "index_institutions_on_version", using: :btree
 
   create_table "ipeds_hds", force: :cascade do |t|
     t.string   "cross",                  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170410203534) do
+ActiveRecord::Schema.define(version: 20170410215512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 
-ActiveRecord::Schema.define(version: 20170410205513) do
+ActiveRecord::Schema.define(version: 20170410215512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe Institution, type: :model do
 
     context 'search scope' do
       it 'should return nil if no search term is provided' do
-        expect(described_class.search(name: nil)).to be_empty
+        expect(described_class.search(nil)).to be_empty
       end
 
       it 'should search when attribute is provided' do
-        expect(described_class.search(name: 'chicago').to_sql)
+        expect(described_class.search('chicago').to_sql)
           .to include(
-            "WHERE (lower(facility_code) = ('---\n- :name\n- chicago\n')",
-            "OR lower(institution) LIKE ('%{:name=>\"chicago\"}%')",
-            "OR lower(city) LIKE ('%{:name=>\"chicago\"}%'))"
+            "WHERE (facility_code = ('CHICAGO')",
+            "OR lower(institution) LIKE ('%chicago%')",
+            "OR lower(city) LIKE ('%chicago%'))"
           )
       end
     end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe Institution, type: :model do
         i = create_list :institution, 2, version: 1
         j = create_list :institution, 2, version: 2
 
-        expect(Institution.version(i.first.version)).to eq(i.to_a)
-        expect(Institution.version(j.first.version)).to eq(j.to_a)
+        expect(Institution.version(i.first.version)).to match_array(i.to_a)
+        expect(Institution.version(j.first.version)).to match_array(j.to_a)
       end
 
       it 'returns blank if a nil or non-existent version number is supplied' do


### PR DESCRIPTION
Layers on top of #242. This is the low-hanging fruit of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1306 - leaves aside full-text search of institution name/city for now. 

* Upcases the facility_code query parameter which is already upcased in the database. 
* Uses a functional prefix index of the appropriate case for autocomplete. Increases autocomplete
latency quite a bit. Will do a more formal load test sometime in the future, but casual testing shows autocomplete query latency drops from anywhere in the range of 20-100 ms to < 2 ms. 

One downside of the functional index is that it is not reflected in schema.rb because it is postgres-specific. So there will be a bit of work in devops to make sure that index is created for the one-time database re-setup. 