### PR TITLE
adding uuid to versions and helpful rake task

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'securerandom'
+
 class Version < ActiveRecord::Base
   belongs_to :user, inverse_of: :versions
   alias_attribute :created_by, :user
@@ -7,6 +9,7 @@ class Version < ActiveRecord::Base
   validates :user_id, presence: true
 
   before_validation :check_version
+  before_create :generate_uuid
   before_save :increment_version
 
   def check_version
@@ -14,6 +17,10 @@ class Version < ActiveRecord::Base
       errors.add(:number, "Version number #{number} doesn't exist")
     end
     true
+  end
+
+  def generate_uuid
+    self.uuid = SecureRandom.uuid
   end
 
   def increment_version

--- a/db/migrate/20170410213522_add_populate_and_index_uuid_on_versions.rb
+++ b/db/migrate/20170410213522_add_populate_and_index_uuid_on_versions.rb
@@ -1,0 +1,17 @@
+class AddPopulateAndIndexUuidOnVersions < ActiveRecord::Migration
+  def up
+    add_column :versions, :uuid, :binary, limit: 16
+
+    Version.all.each do |version|
+      version.generate_uuid
+      version.save
+    end
+
+    add_index :versions, :uuid, unique: true
+    change_column :versions, :uuid, :binary, limit: 16, null: false, unique: true
+  end
+
+  def down
+    remove_column :versions, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330161442) do
+ActiveRecord::Schema.define(version: 20170410221932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,19 +86,45 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.string   "facility_code"
     t.string   "closed_reason"
     t.string   "issues"
-    t.integer  "cfc",                default: 0
-    t.integer  "cfbfc",              default: 0
-    t.integer  "cqbfc",              default: 0
-    t.integer  "crbfc",              default: 0
-    t.integer  "cmbfc",              default: 0
-    t.integer  "cabfc",              default: 0
-    t.integer  "cdrbfc",             default: 0
-    t.integer  "cslbfc",             default: 0
-    t.integer  "cgbfc",              default: 0
-    t.integer  "cctbfc",             default: 0
-    t.integer  "cjbfc",              default: 0
-    t.integer  "ctbfc",              default: 0
-    t.integer  "cobfc",              default: 0
+    t.integer  "cfc",                                                 default: 0
+    t.integer  "cfbfc",                                               default: 0
+    t.integer  "cqbfc",                                               default: 0
+    t.integer  "crbfc",                                               default: 0
+    t.integer  "cmbfc",                                               default: 0
+    t.integer  "cabfc",                                               default: 0
+    t.integer  "cdrbfc",                                              default: 0
+    t.integer  "cslbfc",                                              default: 0
+    t.integer  "cgbfc",                                               default: 0
+    t.integer  "cctbfc",                                              default: 0
+    t.integer  "cjbfc",                                               default: 0
+    t.integer  "ctbfc",                                               default: 0
+    t.integer  "cobfc",                                               default: 0
+    t.integer  "complaints_facility_code",                            default: 0
+    t.integer  "complaints_financial_by_fac_code",                    default: 0
+    t.integer  "complaints_quality_by_fac_code",                      default: 0
+    t.integer  "complaints_refund_by_fac_code",                       default: 0
+    t.integer  "complaints_marketing_by_fac_code",                    default: 0
+    t.integer  "complaints_accreditation_by_fac_code",                default: 0
+    t.integer  "complaints_degree_requirements_by_fac_code",          default: 0
+    t.integer  "complaints_student_loans_by_fac_code",                default: 0
+    t.integer  "complaints_grades_by_fac_code",                       default: 0
+    t.integer  "complaints_credit_transfer_by_fac_code",              default: 0
+    t.integer  "complaints_job_by_fac_code",                          default: 0
+    t.integer  "complaints_transcript_by_fac_code",                   default: 0
+    t.integer  "complaints_other_by_fac_code",                        default: 0
+    t.integer  "complaints_main_campus_roll_up",                      default: 0
+    t.integer  "complaints_financial_by_ope_id_do_not_sum",           default: 0
+    t.integer  "complaints_quality_by_ope_id_do_not_sum",             default: 0
+    t.integer  "complaints_refund_by_ope_id_do_not_sum",              default: 0
+    t.integer  "complaints_marketing_by_ope_id_do_not_sum",           default: 0
+    t.integer  "complaints_accreditation_by_ope_id_do_not_sum",       default: 0
+    t.integer  "complaints_degree_requirements_by_ope_id_do_not_sum", default: 0
+    t.integer  "complaints_student_loans_by_ope_id_do_not_sum",       default: 0
+    t.integer  "complaints_grades_by_ope_id_do_not_sum",              default: 0
+    t.integer  "complaints_credit_transfer_by_ope_id_do_not_sum",     default: 0
+    t.integer  "complaints_jobs_by_ope_id_do_not_sum",                default: 0
+    t.integer  "complaints_transcript_by_ope_id_do_not_sum",          default: 0
+    t.integer  "complaints_other_by_ope_id_do_not_sum",               default: 0
     t.string   "case_id"
     t.string   "level"
     t.string   "case_owner"
@@ -108,8 +134,8 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.string   "submitted"
     t.string   "closed"
     t.string   "education_benefits"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                                                      null: false
+    t.datetime "updated_at",                                                      null: false
   end
 
   add_index "complaints", ["facility_code"], name: "index_complaints_on_facility_code", using: :btree
@@ -128,10 +154,10 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.datetime "updated_at",    null: false
   end
 
-  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", using: :btree
+  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", unique: true, using: :btree
   add_index "crosswalks", ["facility_code"], name: "index_crosswalks_on_facility_code", unique: true, using: :btree
   add_index "crosswalks", ["institution"], name: "index_crosswalks_on_institution", using: :btree
-  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", using: :btree
+  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", unique: true, using: :btree
   add_index "crosswalks", ["ope6"], name: "index_crosswalks_on_ope6", using: :btree
 
   create_table "eight_keys", force: :cascade do |t|
@@ -146,9 +172,9 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "eight_keys", ["cross"], name: "index_eight_keys_on_cross", using: :btree
+  add_index "eight_keys", ["cross"], name: "index_eight_keys_on_cross", unique: true, using: :btree
   add_index "eight_keys", ["institution"], name: "index_eight_keys_on_institution", using: :btree
-  add_index "eight_keys", ["ope"], name: "index_eight_keys_on_ope", using: :btree
+  add_index "eight_keys", ["ope"], name: "index_eight_keys_on_ope", unique: true, using: :btree
   add_index "eight_keys", ["ope6"], name: "index_eight_keys_on_ope6", using: :btree
 
   create_table "hcms", force: :cascade do |t|
@@ -1028,8 +1054,8 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.datetime "updated_at",                   null: false
   end
 
-  add_index "scorecards", ["cross"], name: "index_scorecards_on_cross", using: :btree
-  add_index "scorecards", ["ope"], name: "index_scorecards_on_ope", using: :btree
+  add_index "scorecards", ["cross"], name: "index_scorecards_on_cross", unique: true, using: :btree
+  add_index "scorecards", ["ope"], name: "index_scorecards_on_ope", unique: true, using: :btree
 
   create_table "sec702_schools", force: :cascade do |t|
     t.string   "facility_code", null: false
@@ -1088,7 +1114,7 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "svas", ["cross"], name: "index_svas_on_cross", using: :btree
+  add_index "svas", ["cross"], name: "index_svas_on_cross", unique: true, using: :btree
 
   create_table "uploads", force: :cascade do |t|
     t.integer  "user_id",                    null: false
@@ -1128,10 +1154,12 @@ ActiveRecord::Schema.define(version: 20170330161442) do
     t.boolean  "production", default: false, null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.binary   "uuid",                       null: false
   end
 
   add_index "versions", ["number"], name: "index_versions_on_number", using: :btree
   add_index "versions", ["user_id"], name: "index_versions_on_user_id", using: :btree
+  add_index "versions", ["uuid"], name: "index_versions_on_uuid", unique: true, using: :btree
 
   create_table "vsocs", force: :cascade do |t|
     t.string   "facility_code",    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330161442) do
+ActiveRecord::Schema.define(version: 20170410221932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170410221932) do
+ActiveRecord::Schema.define(version: 20170330161442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,45 +86,19 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.string   "facility_code"
     t.string   "closed_reason"
     t.string   "issues"
-    t.integer  "cfc",                                                 default: 0
-    t.integer  "cfbfc",                                               default: 0
-    t.integer  "cqbfc",                                               default: 0
-    t.integer  "crbfc",                                               default: 0
-    t.integer  "cmbfc",                                               default: 0
-    t.integer  "cabfc",                                               default: 0
-    t.integer  "cdrbfc",                                              default: 0
-    t.integer  "cslbfc",                                              default: 0
-    t.integer  "cgbfc",                                               default: 0
-    t.integer  "cctbfc",                                              default: 0
-    t.integer  "cjbfc",                                               default: 0
-    t.integer  "ctbfc",                                               default: 0
-    t.integer  "cobfc",                                               default: 0
-    t.integer  "complaints_facility_code",                            default: 0
-    t.integer  "complaints_financial_by_fac_code",                    default: 0
-    t.integer  "complaints_quality_by_fac_code",                      default: 0
-    t.integer  "complaints_refund_by_fac_code",                       default: 0
-    t.integer  "complaints_marketing_by_fac_code",                    default: 0
-    t.integer  "complaints_accreditation_by_fac_code",                default: 0
-    t.integer  "complaints_degree_requirements_by_fac_code",          default: 0
-    t.integer  "complaints_student_loans_by_fac_code",                default: 0
-    t.integer  "complaints_grades_by_fac_code",                       default: 0
-    t.integer  "complaints_credit_transfer_by_fac_code",              default: 0
-    t.integer  "complaints_job_by_fac_code",                          default: 0
-    t.integer  "complaints_transcript_by_fac_code",                   default: 0
-    t.integer  "complaints_other_by_fac_code",                        default: 0
-    t.integer  "complaints_main_campus_roll_up",                      default: 0
-    t.integer  "complaints_financial_by_ope_id_do_not_sum",           default: 0
-    t.integer  "complaints_quality_by_ope_id_do_not_sum",             default: 0
-    t.integer  "complaints_refund_by_ope_id_do_not_sum",              default: 0
-    t.integer  "complaints_marketing_by_ope_id_do_not_sum",           default: 0
-    t.integer  "complaints_accreditation_by_ope_id_do_not_sum",       default: 0
-    t.integer  "complaints_degree_requirements_by_ope_id_do_not_sum", default: 0
-    t.integer  "complaints_student_loans_by_ope_id_do_not_sum",       default: 0
-    t.integer  "complaints_grades_by_ope_id_do_not_sum",              default: 0
-    t.integer  "complaints_credit_transfer_by_ope_id_do_not_sum",     default: 0
-    t.integer  "complaints_jobs_by_ope_id_do_not_sum",                default: 0
-    t.integer  "complaints_transcript_by_ope_id_do_not_sum",          default: 0
-    t.integer  "complaints_other_by_ope_id_do_not_sum",               default: 0
+    t.integer  "cfc",                default: 0
+    t.integer  "cfbfc",              default: 0
+    t.integer  "cqbfc",              default: 0
+    t.integer  "crbfc",              default: 0
+    t.integer  "cmbfc",              default: 0
+    t.integer  "cabfc",              default: 0
+    t.integer  "cdrbfc",             default: 0
+    t.integer  "cslbfc",             default: 0
+    t.integer  "cgbfc",              default: 0
+    t.integer  "cctbfc",             default: 0
+    t.integer  "cjbfc",              default: 0
+    t.integer  "ctbfc",              default: 0
+    t.integer  "cobfc",              default: 0
     t.string   "case_id"
     t.string   "level"
     t.string   "case_owner"
@@ -134,8 +108,8 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.string   "submitted"
     t.string   "closed"
     t.string   "education_benefits"
-    t.datetime "created_at",                                                      null: false
-    t.datetime "updated_at",                                                      null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
   end
 
   add_index "complaints", ["facility_code"], name: "index_complaints_on_facility_code", using: :btree
@@ -154,10 +128,10 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.datetime "updated_at",    null: false
   end
 
-  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", unique: true, using: :btree
+  add_index "crosswalks", ["cross"], name: "index_crosswalks_on_cross", using: :btree
   add_index "crosswalks", ["facility_code"], name: "index_crosswalks_on_facility_code", unique: true, using: :btree
   add_index "crosswalks", ["institution"], name: "index_crosswalks_on_institution", using: :btree
-  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", unique: true, using: :btree
+  add_index "crosswalks", ["ope"], name: "index_crosswalks_on_ope", using: :btree
   add_index "crosswalks", ["ope6"], name: "index_crosswalks_on_ope6", using: :btree
 
   create_table "eight_keys", force: :cascade do |t|
@@ -172,9 +146,9 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "eight_keys", ["cross"], name: "index_eight_keys_on_cross", unique: true, using: :btree
+  add_index "eight_keys", ["cross"], name: "index_eight_keys_on_cross", using: :btree
   add_index "eight_keys", ["institution"], name: "index_eight_keys_on_institution", using: :btree
-  add_index "eight_keys", ["ope"], name: "index_eight_keys_on_ope", unique: true, using: :btree
+  add_index "eight_keys", ["ope"], name: "index_eight_keys_on_ope", using: :btree
   add_index "eight_keys", ["ope6"], name: "index_eight_keys_on_ope6", using: :btree
 
   create_table "hcms", force: :cascade do |t|
@@ -1054,8 +1028,8 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.datetime "updated_at",                   null: false
   end
 
-  add_index "scorecards", ["cross"], name: "index_scorecards_on_cross", unique: true, using: :btree
-  add_index "scorecards", ["ope"], name: "index_scorecards_on_ope", unique: true, using: :btree
+  add_index "scorecards", ["cross"], name: "index_scorecards_on_cross", using: :btree
+  add_index "scorecards", ["ope"], name: "index_scorecards_on_ope", using: :btree
 
   create_table "sec702_schools", force: :cascade do |t|
     t.string   "facility_code", null: false
@@ -1114,7 +1088,7 @@ ActiveRecord::Schema.define(version: 20170410221932) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "svas", ["cross"], name: "index_svas_on_cross", unique: true, using: :btree
+  add_index "svas", ["cross"], name: "index_svas_on_cross", using: :btree
 
   create_table "uploads", force: :cascade do |t|
     t.integer  "user_id",                    null: false

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,100 @@
+require 'fileutils'
+
+namespace :db do
+
+    desc "Dumps the database to backups"
+    task :dump => :environment do
+
+        dump_fmt = 'c'      # or 'p', 't', 'd'
+        dump_sfx = suffix_for_format dump_fmt
+        backup_dir = backup_directory true
+        cmd = nil
+        with_config do |app, host, db, user|
+            file_name = Time.now.strftime("%Y%m%d%H%M%S") + "_" + db + '.' + dump_sfx
+            cmd = "pg_dump -F #{dump_fmt} -v -h #{host} -d #{db} -f #{backup_dir}/#{file_name}"
+        end
+        puts cmd
+        exec cmd
+    end
+
+    desc "Show the existing database backups"
+    task :list => :environment do
+        backup_dir = backup_directory
+        puts "#{backup_dir}"
+        exec "/bin/ls -lt #{backup_dir}"
+    end
+
+    desc "Restores the database from a backup using PATTERN"
+    task :restore, [:pat] => :environment do |task,args|
+        if args.pat.present?
+            cmd = nil
+            with_config do |app, host, db, user|
+                backup_dir = backup_directory
+                files = Dir.glob("#{backup_dir}/*#{args.pat}*")
+                case files.size
+                when 0
+                  puts "No backups found for the pattern '#{args.pat}'"
+                when 1
+                  file = files.first
+                  fmt = format_for_file file
+                  if fmt.nil?
+                    puts "No recognized dump file suffix: #{file}"
+                  else
+                    cmd = "pg_restore -F #{fmt} -v -c -C #{file}"
+                  end
+                else
+                  puts "Too many files match the pattern '#{args.pat}':"
+                  puts ' ' + files.join("\n ")
+                  puts "Try a more specific pattern"
+                end
+            end
+            unless cmd.nil?
+              Rake::Task["db:drop"].invoke
+              Rake::Task["db:create"].invoke
+              puts cmd
+              exec cmd
+            end
+        else
+            puts 'Please pass a pattern to the task'
+        end
+    end
+
+    private
+
+    def suffix_for_format suffix
+        case suffix
+        when 'c' then 'dump'
+        when 'p' then 'sql'
+        when 't' then 'tar'
+        when 'd' then 'dir'
+        else nil
+        end
+    end
+
+    def format_for_file file
+        case file
+        when /\.dump$/ then 'c'
+        when /\.sql$/  then 'p'
+        when /\.dir$/  then 'd'
+        when /\.tar$/  then 't'
+        else nil
+        end
+    end
+
+    def backup_directory create=false
+        backup_dir = "#{Rails.root}/db/backups"
+        if create and not Dir.exists?(backup_dir)
+          puts "Creating #{backup_dir} .."
+          FileUtils.mkdir_p(backup_dir)
+        end
+        backup_dir
+    end
+
+    def with_config
+        yield Rails.application.class.parent_name.underscore,
+              (ActiveRecord::Base.connection_config[:host] || 'localhost'),
+              ActiveRecord::Base.connection_config[:database],
+              ActiveRecord::Base.connection_config[:username]
+    end
+
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,100 +1,99 @@
+# frozen_string_literal: true
 require 'fileutils'
 
+# rubocop:disable Metrics/BlockLength
 namespace :db do
+  desc 'Dumps the database to backups'
+  task dump: :environment do
+    dump_fmt = 'c' # or 'p', 't', 'd'
+    dump_sfx = suffix_for_format dump_fmt
+    backup_dir = backup_directory true
+    cmd = nil
+    with_config do |_app, host, db, _user|
+      file_name = Time.current.strftime('%Y%m%d%H%M%S') + '_' + db + '.' + dump_sfx
+      cmd = "pg_dump -F #{dump_fmt} -v -h #{host} -d #{db} -f #{backup_dir}/#{file_name}"
+    end
+    puts cmd
+    exec cmd
+  end
 
-    desc "Dumps the database to backups"
-    task :dump => :environment do
+  desc 'Show the existing database backups'
+  task list: :environment do
+    backup_dir = backup_directory
+    puts backup_dir.to_s
+    exec "/bin/ls -lt #{backup_dir}"
+  end
 
-        dump_fmt = 'c'      # or 'p', 't', 'd'
-        dump_sfx = suffix_for_format dump_fmt
-        backup_dir = backup_directory true
-        cmd = nil
-        with_config do |app, host, db, user|
-            file_name = Time.now.strftime("%Y%m%d%H%M%S") + "_" + db + '.' + dump_sfx
-            cmd = "pg_dump -F #{dump_fmt} -v -h #{host} -d #{db} -f #{backup_dir}/#{file_name}"
+  desc 'Restores the database from a backup using PATTERN'
+  task :restore, [:pat] => :environment do |_task, args|
+    if args.pat.present?
+      cmd = nil
+      with_config do |_app, _host, _db, _user|
+        backup_dir = backup_directory
+        files = Dir.glob("#{backup_dir}/*#{args.pat}*")
+        case files.size
+        when 0
+          puts "No backups found for the pattern '#{args.pat}'"
+        when 1
+          file = files.first
+          fmt = format_for_file file
+          if fmt.nil?
+            puts "No recognized dump file suffix: #{file}"
+          else
+            cmd = "pg_restore -F #{fmt} -v -c -C #{file}"
+          end
+        else
+          puts "Too many files match the pattern '#{args.pat}':"
+          puts ' ' + files.join("\n ")
+          puts 'Try a more specific pattern'
         end
+      end
+      unless cmd.nil?
+        Rake::Task['db:drop'].invoke
+        Rake::Task['db:create'].invoke
         puts cmd
         exec cmd
+      end
+    else
+      puts 'Please pass a pattern to the task'
     end
-
-    desc "Show the existing database backups"
-    task :list => :environment do
-        backup_dir = backup_directory
-        puts "#{backup_dir}"
-        exec "/bin/ls -lt #{backup_dir}"
-    end
-
-    desc "Restores the database from a backup using PATTERN"
-    task :restore, [:pat] => :environment do |task,args|
-        if args.pat.present?
-            cmd = nil
-            with_config do |app, host, db, user|
-                backup_dir = backup_directory
-                files = Dir.glob("#{backup_dir}/*#{args.pat}*")
-                case files.size
-                when 0
-                  puts "No backups found for the pattern '#{args.pat}'"
-                when 1
-                  file = files.first
-                  fmt = format_for_file file
-                  if fmt.nil?
-                    puts "No recognized dump file suffix: #{file}"
-                  else
-                    cmd = "pg_restore -F #{fmt} -v -c -C #{file}"
-                  end
-                else
-                  puts "Too many files match the pattern '#{args.pat}':"
-                  puts ' ' + files.join("\n ")
-                  puts "Try a more specific pattern"
-                end
-            end
-            unless cmd.nil?
-              Rake::Task["db:drop"].invoke
-              Rake::Task["db:create"].invoke
-              puts cmd
-              exec cmd
-            end
-        else
-            puts 'Please pass a pattern to the task'
-        end
-    end
+  end
 
     private
 
-    def suffix_for_format suffix
-        case suffix
-        when 'c' then 'dump'
-        when 'p' then 'sql'
-        when 't' then 'tar'
-        when 'd' then 'dir'
-        else nil
-        end
+  def suffix_for_format(suffix)
+    case suffix
+    when 'c' then 'dump'
+    when 'p' then 'sql'
+    when 't' then 'tar'
+    when 'd' then 'dir'
     end
+  end
 
-    def format_for_file file
-        case file
-        when /\.dump$/ then 'c'
-        when /\.sql$/  then 'p'
-        when /\.dir$/  then 'd'
-        when /\.tar$/  then 't'
-        else nil
-        end
+  def format_for_file(file)
+    case file
+    when /\.dump$/ then 'c'
+    when /\.sql$/  then 'p'
+    when /\.dir$/  then 'd'
+    when /\.tar$/  then 't'
     end
+  end
 
-    def backup_directory create=false
-        backup_dir = "#{Rails.root}/db/backups"
-        if create and not Dir.exists?(backup_dir)
-          puts "Creating #{backup_dir} .."
-          FileUtils.mkdir_p(backup_dir)
-        end
-        backup_dir
+  def backup_directory(create = false)
+    backup_dir = "#{Rails.root}/db/backups"
+    if create && !Dir.exist?(backup_dir)
+      puts "Creating #{backup_dir} .."
+      FileUtils.mkdir_p(backup_dir)
     end
+    backup_dir
+  end
 
-    def with_config
-        yield Rails.application.class.parent_name.underscore,
-              (ActiveRecord::Base.connection_config[:host] || 'localhost'),
-              ActiveRecord::Base.connection_config[:database],
-              ActiveRecord::Base.connection_config[:username]
-    end
+  def with_config
+    yield Rails.application.class.parent_name.underscore,
+          (ActiveRecord::Base.connection_config[:host] || 'localhost'),
+          ActiveRecord::Base.connection_config[:database],
+          ActiveRecord::Base.connection_config[:username]
+  end
 
+  # rubocop:enable Metrics/BlockLength
 end


### PR DESCRIPTION
- Added uuid to versions table
- Added pre-populate method as before_create action on Version.rb
- Migration uses pre-populate method to set the default uuid before setting not null constraint.
- Added index on uuid, with not null and uniqueness constraints
- Added a helpful rake task for dumping the database and restoring from backup (handy for not having to reseed all the damn time for testing purposes)