### PR TITLE
Pv add sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "puma", "~> 3.6"
 gem 'figaro'
 
 # Sentry
-gem 'sentry-raven'
+gem 'sentry-raven', '~> 2.3.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'virtus', '~> 1.0.5'
 gem "puma", "~> 3.6"
 gem 'figaro'
 
+# Sentry
+gem 'sentry-raven'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.7.2)
       i18n (~> 0.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.17)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -174,6 +176,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     nenv (0.3.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
@@ -281,6 +284,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sentry-raven (2.1.2)
+      faraday (>= 0.7.6, < 0.10.x)
     shellany (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -365,6 +370,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)
+  sentry-raven
   simplecov
   smarter_csv
   sniffybara!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.7.2)
       i18n (~> 0.5)
-    faraday (0.9.2)
+    faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.17)
     figaro (1.1.1)
@@ -284,8 +284,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sentry-raven (2.1.2)
-      faraday (>= 0.7.6, < 0.10.x)
+    sentry-raven (2.3.1)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -370,7 +370,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)
-  sentry-raven
+  sentry-raven (~> 2.3.0)
   simplecov
   smarter_csv
   sniffybara!


### PR DESCRIPTION
Sentry DSN endpoint is already defined/configured in devops repo - this should be sufficient to start injecting exceptions into Sentry.