### PR TITLE
Adds filename parameter to content-disposition header

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -29,7 +29,7 @@ class DashboardsController < ApplicationController
     klass = csv_model(params[:csv_type])
 
     respond_to do |format|
-      format.csv { send_data klass.export, type: 'text/csv' }
+      format.csv { send_data klass.export, type: 'text/csv', filename: "#{klass.name}.csv" }
     end
   rescue ArgumentError, ActionController::UnknownFormat => e
     Rails.logger.error e.message

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe DashboardsController, type: :controller do
       get :export, csv_type: 'Weam', format: :csv
     end
 
+    it 'includes filename parameter in content-disposition header' do
+      get :export, csv_type: 'Sva', format: :csv
+      expect(response.headers['Content-Disposition']).to include('filename="Sva.csv"')
+    end
+
+    it 'includes filename parameter in content-disposition header for institution' do
+      get :export, csv_type: 'Institution', format: :csv
+      expect(response.headers['Content-Disposition']).to include('filename="Institution.csv"')
+    end
+
     it 'redirects to index on error' do
       expect(get(:export, csv_type: 'BlahBlah', format: :csv)).to redirect_to(action: :index)
       expect(get(:export, csv_type: 'Weam', format: :xml)).to redirect_to(action: :index)


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/gibct-data-service/issues/251

Will need confirmation that this better addresses the issue on Windows where it was observed, but it's certainly not any worse. 