### PR TITLE
Include active search terms in facets

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -70,7 +70,7 @@ module V0
 
     def facets
       institution_types = search_results.filter_count(:institution_type_name)
-      {
+      result = {
         category: {
           school: institution_types.except(Institution::EMPLOYER).inject(0) { |count, (_t, n)| count + n },
           employer: institution_types[Institution::EMPLOYER].to_i
@@ -84,7 +84,27 @@ module V0
         principles_of_excellence: search_results.filter_count(:poe),
         eight_keys_to_veteran_success: search_results.filter_count(:eight_keys)
       }
+      add_active_search_facets(result)
     end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Style/GuardClause
+    def add_active_search_facets(raw_facets)
+      if @query[:state].present?
+        key = @query[:state].downcase
+        raw_facets[:state][key] = 0 unless raw_facets[:state].key? key
+      end
+      if @query[:type].present?
+        key = @query[:type].downcase
+        raw_facets[:type][key] = 0 unless raw_facets[:type].key? key
+      end
+      if @query[:country].present?
+        key = @query[:country].upcase
+        raw_facets[:country] << { name: key, count: 0 } unless
+          raw_facets[:country].any? { |c| c[:name] == key }
+      end
+      raw_facets
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Style/GuardClause
 
     # Embed search result counts as a list of hashes with "name"/"count"
     # keys so that open-ended strings such as country names do not

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -126,6 +126,29 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(facets['country'].count).to eq(1)
       expect(facets['country'][0]['name']).to eq('USA')
     end
+
+    it 'includes type search term in facets' do
+      get :index, name: 'chicago', type: 'foreign'
+      facets = JSON.parse(response.body)['meta']['facets']
+      expect(facets['type']['foreign']).not_to be_nil
+      expect(facets['type']['foreign']).to eq(0)
+    end
+
+    it 'includes state search term in facets' do
+      get :index, name: 'chicago', state: 'WY'
+      facets = JSON.parse(response.body)['meta']['facets']
+      expect(facets['state']['wy']).not_to be_nil
+      expect(facets['state']['wy']).to eq(0)
+
+    end
+
+    it 'includes country search term in facets' do
+      get :index, name: 'chicago', country: 'france'
+      facets = JSON.parse(response.body)['meta']['facets']
+      match = facets['country'].select { |c| c['name'] == 'FRANCE' }.first
+      expect(match).not_to be nil
+      expect(match['count']).to eq(0)
+    end
   end
 
   context 'category and type search results' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2096 
by ensuring that any active search terms are included in the facets result so that they will be present in the drop down menus and can be un-selected. 

Not wild about having to disable those rubocops, but it's an awkward method by its nature because we had to tweak the facet structure for countries. And I don't know why it wanted me to use a guard instead of an if clause for only the country clause but not the first two...