### PR TITLE
Match national average seeds to current GIBCT production

### DIFF
--- a/db/seeds/02_data.rb
+++ b/db/seeds/02_data.rb
@@ -39,10 +39,10 @@ constants = {
   'VRE1DEPRATEOJT' => 640.15,
   'VRE2DEPRATEOJT' => 737.77,
   'VREINCRATEOJT' => 47.99,
-  'AVERETENTIONRATE' => 67.9,
-  'AVEGRADRATE' => 41.5,
-  'AVESALARY' => 33_500,
-  'AVEREPAYMENTRATE' => 45.9
+  'AVERETENTIONRATE' => 67.7,
+  'AVEGRADRATE' => 42.3,
+  'AVESALARY' => 33_400,
+  'AVEREPAYMENTRATE' => 67.9
 }.map { |k,v| {name: k, float_value: v} }
 CalculatorConstant.create(constants)
 


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2116
(though will need to do manual DB update in staging to line things up). 

Checked calculator constants against GIBCT production:
https://github.com/department-of-veterans-affairs/gi-bill-comparison-tool/blob/production/app/assets/js/calculator.js
and
https://github.com/department-of-veterans-affairs/gi-bill-comparison-tool/blob/production/app/views/institutions/profile.html.erb