### PR TITLE
Pv zero facet counts

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -77,14 +77,30 @@ module V0
         },
         type: institution_types,
         state: search_results.filter_count(:state),
-        country: embed(search_results.filter_count(:country)),
-        caution_flag: search_results.filter_count(:caution_flag),
-        student_vet_group: search_results.filter_count(:student_veteran),
-        yellow_ribbon_scholarship: search_results.filter_count(:yr),
-        principles_of_excellence: search_results.filter_count(:poe),
-        eight_keys_to_veteran_success: search_results.filter_count(:eight_keys)
+        country: embed(search_results.filter_count(:country))
       }
+      result.merge!(boolean_facets)
       add_active_search_facets(result)
+    end
+
+    DEFAULT_BOOLEAN_FACET = { true: nil, false: nil }.freeze
+
+    def boolean_facets
+      if ENV['ENABLE_FILTER_COUNTS'] == 'true'
+        {
+          student_vet_group: search_results.filter_count(:student_veteran),
+          yellow_ribbon_scholarship: search_results.filter_count(:yr),
+          principles_of_excellence: search_results.filter_count(:poe),
+          eight_keys_to_veteran_success: search_results.filter_count(:eight_keys)
+        }
+      else
+        {
+          student_vet_group: DEFAULT_BOOLEAN_FACET,
+          yellow_ribbon_scholarship: DEFAULT_BOOLEAN_FACET,
+          principles_of_excellence: DEFAULT_BOOLEAN_FACET,
+          eight_keys_to_veteran_success: DEFAULT_BOOLEAN_FACET
+        }
+      end
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -68,6 +68,12 @@ module V0
                  .filter(:eight_keys, @query[:eight_keys_to_veteran_success]) # boolean
     end
 
+    # rubocop:disable Style/MutableConstant
+    DEFAULT_BOOLEAN_FACET = { true: nil, false: nil }
+    # rubocop:enable Style/MutableConstant
+
+    # TODO: If filter counts are desired in the future, change boolean facets
+    # to use search_results.filter_count(param) instead of default value
     def facets
       institution_types = search_results.filter_count(:institution_type_name)
       result = {
@@ -77,30 +83,13 @@ module V0
         },
         type: institution_types,
         state: search_results.filter_count(:state),
-        country: embed(search_results.filter_count(:country))
+        country: embed(search_results.filter_count(:country)),
+        student_vet_group: DEFAULT_BOOLEAN_FACET,
+        yellow_ribbon_scholarship: DEFAULT_BOOLEAN_FACET,
+        principles_of_excellence: DEFAULT_BOOLEAN_FACET,
+        eight_keys_to_veteran_success: DEFAULT_BOOLEAN_FACET
       }
-      result.merge!(boolean_facets)
       add_active_search_facets(result)
-    end
-
-    DEFAULT_BOOLEAN_FACET = { true: nil, false: nil }.freeze
-
-    def boolean_facets
-      if ENV['ENABLE_FILTER_COUNTS'] == 'true'
-        {
-          student_vet_group: search_results.filter_count(:student_veteran),
-          yellow_ribbon_scholarship: search_results.filter_count(:yr),
-          principles_of_excellence: search_results.filter_count(:poe),
-          eight_keys_to_veteran_success: search_results.filter_count(:eight_keys)
-        }
-      else
-        {
-          student_vet_group: DEFAULT_BOOLEAN_FACET,
-          yellow_ribbon_scholarship: DEFAULT_BOOLEAN_FACET,
-          principles_of_excellence: DEFAULT_BOOLEAN_FACET,
-          eight_keys_to_veteran_success: DEFAULT_BOOLEAN_FACET
-        }
-      end
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -157,26 +157,6 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(facets['principles_of_excellence'].keys).to include('true', 'false')
       expect(facets['eight_keys_to_veteran_success'].keys).to include('true', 'false')
     end
-
-    context 'with filter count feature enabled' do
-      before(:each) do
-        ENV['ENABLE_FILTER_COUNTS'] = 'true'
-        create(:institution, :in_chicago, yr: true, student_veteran: true)
-      end
-
-      after(:each) do
-        ENV['ENABLE_FILTER_COUNTS'] = 'false'
-      end
-
-      it 'includes boolean facet counts' do
-        get :index, name: 'chicago'
-        facets = JSON.parse(response.body)['meta']['facets']
-        expect(facets['yellow_ribbon_scholarship'].keys).to include('true')
-        expect(facets['yellow_ribbon_scholarship']['true']).to eq(1)
-        expect(facets['student_vet_group'].keys).to include('true')
-        expect(facets['student_vet_group']['true']).to eq(1)
-      end
-    end
   end
 
   context 'category and type search results' do

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -148,6 +148,35 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(match).not_to be nil
       expect(match['count']).to eq(0)
     end
+
+    it 'includes boolean facets' do
+      get :index
+      facets = JSON.parse(response.body)['meta']['facets']
+      expect(facets['student_vet_group'].keys).to include('true', 'false')
+      expect(facets['yellow_ribbon_scholarship'].keys).to include('true', 'false')
+      expect(facets['principles_of_excellence'].keys).to include('true', 'false')
+      expect(facets['eight_keys_to_veteran_success'].keys).to include('true', 'false')
+    end
+
+    context 'with filter count feature enabled' do
+      before(:each) do
+        ENV['ENABLE_FILTER_COUNTS'] = 'true'
+        create(:institution, :in_chicago, yr: true, student_veteran: true)
+      end
+
+      after(:each) do
+        ENV['ENABLE_FILTER_COUNTS'] = 'false'
+      end
+
+      it 'includes boolean facet counts' do
+        get :index, name: 'chicago'
+        facets = JSON.parse(response.body)['meta']['facets']
+        expect(facets['yellow_ribbon_scholarship'].keys).to include('true')
+        expect(facets['yellow_ribbon_scholarship']['true']).to eq(1)
+        expect(facets['student_vet_group'].keys).to include('true')
+        expect(facets['student_vet_group']['true']).to eq(1)
+      end
+    end
   end
 
   context 'category and type search results' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2196
Set boolean facets to a default value that still declares the possible dimensions (true/false) without bothering to calculate counts. Sets value to `nil` instead of `0` to better indicate intentional lack of information. Still return filter counts for other facets like country/state/etc because returning the counts is no more expensive than returning the list of countries/states/etc which are needed for populating dropdown menus. 

You'll see two commits, one with this behind a feature flag, then one without. I think the feature flag is unnecessary as it will still be total 1 PR to enable this whether we set a feature flag in devops or just do a code change here. Left a TODO as a breadcrumb. 