### PR TITLE
Updating GI Bill CT Constants (Push on Aug 1st)

### DIFF
--- a/db/seeds/02_data.rb
+++ b/db/seeds/02_data.rb
@@ -20,12 +20,12 @@ end
 
 puts 'Creating sample constants'
 constants = {
-  'TFCAP' => 21970.46,
-  'AVGBAH' => 1611,
+  'TFCAP' => 22805.34,
+  'AVGBAH' => 1681,
   'BSCAP' => 1000,
   'BSOJTMONTH' => 83,
-  'FLTTFCAP' => 12554.54,
-  'CORRESPONDTFCAP' => 10671.35,
+  'FLTTFCAP' => 13031.61,
+  'CORRESPONDTFCAP' => 11076.86,
   'MGIB3YRRATE' => 1857,
   'MGIB2YRRATE' => 1509,
   'SRRATE' => 369,


### PR DESCRIPTION
The Post-9/11 GI Bill rates increase every year on August 1st. This updates those rates for upcoming school year.

http://www.benefits.va.gov/GIBILL/resources/benefits_resources/rates/ch33/ch33rates080117.asp