### PR TITLE
Log exceptions to Sentry

### DIFF
--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -47,6 +47,7 @@ module V0
     end
 
     def log_error(exception)
+      Raven.capture_exception(exception) if ENV['SENTRY_DSN'].present?
       Rails.logger.error "#{exception.message}."
       Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
     end


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4158

Sentry is configured and gem is added but rescue block in api_controller is not re-raising so nothing ever makes it to Sentry unless we log it explicitly. If we decide later we need to filter/exclude anything, we can, but I'm guessing the range of GIDS errors will be much smaller than vets-api.

