### PR TITLE
Avoid table-wide lock during institution build

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -65,12 +65,13 @@ module InstitutionBuilder
   def self.initialize_with_weams(version_number)
     columns = Weam::COLS_USED_IN_INSTITUTION.map(&:to_s)
     timestamp = Time.now.utc.to_s(:db)
+    conn = ActiveRecord::Base.connection
 
     str = "INSERT INTO institutions (#{columns.join(', ')}, version, created_at, updated_at) "
     str += Weam.select(columns)
                .select("#{version_number.to_i} as version")
-               .select("'#{timestamp}' as created_at")
-               .select("'#{timestamp}' as updated_at")
+               .select("#{conn.quote(timestamp)} as created_at")
+               .select("#{conn.quote(timestamp)} as updated_at")
                .where(approved: true).to_sql
     Institution.connection.insert(str)
   end

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -55,9 +55,9 @@ module InstitutionBuilder
       Institution.transaction do
         version = Version.create!(production: false, user: user)
 
-        default_timestamps_to_now
+        # default_timestamps_to_now
         run_insertions(version.number)
-        drop_default_timestamps
+        # drop_default_timestamps
       end
 
       notice = 'Institution build was successful'


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4195

See above for rationale of removing ALTER TABLE statements from transaction. 

Manually pushed to staging and confirmed that query requests can proceed while the generate preview transaction is ongoing. 