### PR TITLE
upgrade to latest version of pip in virtualenv

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -33,6 +33,7 @@ pipeline {
       steps {
         dir('ansible') {
           sh 'virtualenv venv'
+          sh 'venv/bin/pip install --upgrade pip'
           sh 'venv/bin/pip install -r requirements.txt'
         }
       }


### PR DESCRIPTION
This fixes issue doc'ed in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4505

It addresses an issue where an outdated version of pip cannot correctly upgrade packages listed in requirements.txt.