### PR TITLE
address issue with builds on branches with slashes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,10 @@ pipeline {
     label 'vetsgov-general-purpose'
   }
 
+  environment {
+    DOCKER_IMAGE = env.BUILD_TAG.replaceAll(/[%\/]/, '')
+  }
+
   stages {
     stage('Checkout Code') {
       steps {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
   gibct:
     build:
       context: .
-    image: "gibct:${BUILD_TAG:-latest}"
+    image: "gibct:${DOCKER_IMAGE:-latest}"
     volumes:
       - ".:/src/gibct"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   gibct:
     build:
       context: .
-    image: "gibct:${BUILD_TAG:-latest}"
+    image: "gibct:${DOCKER_IMAGE:-latest}"
     volumes:
       - ".:/src/gibct"
     ports:


### PR DESCRIPTION
Same fix as https://github.com/department-of-veterans-affairs/vets-api/pull/1864

Addresses issues where Jenkins can't do builds if branch name has a slash in it due to invalid characters in Docker image name.