### PR TITLE
only build-and-deploy on ssoe branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     }
 
     stage('Deploy dev and staging') {
-      when { branch 'master' }
+      when { branch 'pv-ssoe-integration' }
 
       steps {
         // hack to get the commit hash, some plugin is swallowing git variables and I can't figure out which one
@@ -41,10 +41,10 @@ pipeline {
           booleanParam(name: 'release', value: false),
         ], wait: true
 
-//        build job: 'deploys/gi-bill-data-service-dev', parameters: [
-//          booleanParam(name: 'notify_slack', value: true),
-//          stringParam(name: 'ref', value: commit),
-//        ], wait: false
+        build job: 'deploys/gi-bill-data-service-dev', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
 
         build job: 'deploys/gi-bill-data-service-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),


### PR DESCRIPTION
Super duper hacky, but we want this branch to be the auto-deploy one for dev and staging for now.

This is causing issues with folks testing SSOe in that branch because merges to master are auto-deploying to staging.