### PR TITLE
allow searching for address in School Autocomplete widget api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ gem 'figaro'
 # Sentry
 gem 'sentry-raven', '~> 2.3.0'
 
-gem 'zero_downtime_migrations'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'figaro'
 # Sentry
 gem 'sentry-raven', '~> 2.3.0'
 
+gem 'zero_downtime_migrations'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,8 +342,6 @@ GEM
     will_paginate (3.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zero_downtime_migrations (0.0.7)
-      activerecord
 
 PLATFORMS
   ruby
@@ -393,7 +391,6 @@ DEPENDENCIES
   virtus (~> 1.0.5)
   web-console (~> 2.0)
   will_paginate
-  zero_downtime_migrations
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,8 @@ GEM
     will_paginate (3.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zero_downtime_migrations (0.0.7)
+      activerecord
 
 PLATFORMS
   ruby
@@ -391,6 +393,7 @@ DEPENDENCIES
   virtus (~> 1.0.5)
   web-console (~> 2.0)
   will_paginate
+  zero_downtime_migrations
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     multi_json (1.12.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -8,7 +8,10 @@ module V0
       @data = []
       if params[:term]
         @search_term = params[:term]&.strip&.downcase
-        @data = Institution.version(@version[:number]).autocomplete(@search_term)
+        @data = Institution.version(@version[:number]).autocomplete(
+          @search_term,
+          include_address: params[:include_address]
+        )
       end
       @meta = {
         version: @version,

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -201,8 +201,8 @@ class Institution < ActiveRecord::Base
     institution_type_name != 'OJT'
   end
 
-  # Given a search term representing a partial school name, returns all
-  # schools starting with the search term.
+  # Given a search term representing a partial school name or address, returns all
+  # schools that match the search term.
   #
   def self.autocomplete(search_term, limit: 6, include_address: false)
     where_statement = 'lower(institution) LIKE (:institution_search)'

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -204,10 +204,19 @@ class Institution < ActiveRecord::Base
   # Given a search term representing a partial school name, returns all
   # schools starting with the search term.
   #
-  def self.autocomplete(search_term, limit = 6)
-    Institution.select('id, facility_code as value, institution as label')
-               .where('lower(institution) LIKE (?)', "#{search_term}%")
-               .limit(limit)
+  def self.autocomplete(search_term, limit: 6, include_address: false)
+    where_statement = 'lower(institution) LIKE (:institution_search)'
+
+    if include_address
+      3.times do |i|
+        column = "address_#{i + 1}"
+        where_statement += " OR lower(#{column}) LIKE (:address_search)"
+      end
+    end
+
+    select('id, facility_code as value, institution as label')
+      .where(where_statement, institution_search: "#{search_term}%", address_search: "%#{search_term}%")
+      .limit(limit)
   end
 
   # Finds exact-matching facility_code or partial-matching school and city names

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -14,6 +14,7 @@ class Weam < ActiveRecord::Base
 
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip
+    address_1 address_2 address_3
     country accredited bah poe yr
     institution_type_name va_highest_degree_offered flight correspondence
     independent_study priority_enrollment

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -71,6 +71,9 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :priority_enrollment
   attribute :created_at
   attribute :updated_at
+  attribute :address_1
+  attribute :address_2
+  attribute :address_3
 
   link(:website) { object.website_link }
   link(:scorecard) { object.scorecard_link }

--- a/db/migrate/20180712010252_add_address_fields_to_institutions.rb
+++ b/db/migrate/20180712010252_add_address_fields_to_institutions.rb
@@ -1,4 +1,7 @@
 class AddAddressFieldsToInstitutions < ActiveRecord::Migration
   def change
+    add_column(:institutions, :address_1, :string)
+    add_column(:institutions, :address_2, :string)
+    add_column(:institutions, :address_3, :string)
   end
 end

--- a/db/migrate/20180712010252_add_address_fields_to_institutions.rb
+++ b/db/migrate/20180712010252_add_address_fields_to_institutions.rb
@@ -1,0 +1,4 @@
+class AddAddressFieldsToInstitutions < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/migrate/20180712012935_add_institutions_address_indexes.rb
+++ b/db/migrate/20180712012935_add_institutions_address_indexes.rb
@@ -1,0 +1,9 @@
+class AddInstitutionsAddressIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index(:institutions, :address_1, algorithm: :concurrently)
+    add_index(:institutions, :address_2, algorithm: :concurrently)
+    add_index(:institutions, :address_3, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180712010252) do
+ActiveRecord::Schema.define(version: 20180712012935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -274,6 +274,9 @@ ActiveRecord::Schema.define(version: 20180712010252) do
     t.string   "address_3"
   end
 
+  add_index "institutions", ["address_1"], name: "index_institutions_on_address_1", using: :btree
+  add_index "institutions", ["address_2"], name: "index_institutions_on_address_2", using: :btree
+  add_index "institutions", ["address_3"], name: "index_institutions_on_address_3", using: :btree
   add_index "institutions", ["city"], name: "index_institutions_on_city", using: :btree
   add_index "institutions", ["cross"], name: "index_institutions_on_cross", using: :btree
   add_index "institutions", ["facility_code"], name: "index_institutions_on_facility_code", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614014201) do
+ActiveRecord::Schema.define(version: 20180712010252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -269,6 +269,9 @@ ActiveRecord::Schema.define(version: 20180614014201) do
     t.boolean  "online_only"
     t.boolean  "independent_study"
     t.boolean  "distance_learning"
+    t.string   "address_1"
+    t.string   "address_2"
+    t.string   "address_3"
   end
 
   add_index "institutions", ["city"], name: "index_institutions_on_city", using: :btree

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -153,6 +153,31 @@ RSpec.describe Institution, type: :model do
     end
   end
 
+  describe '#autocomplete' do
+    def sorted_ids(institutions)
+      institutions.map(&:id).sort
+    end
+
+    let!(:institution_ids) do
+      institutions = []
+      3.times do |i|
+        institutions << create(:institution, "address_#{i + 1}" => "address#{i}")
+      end
+
+      sorted_ids(institutions)
+    end
+
+    context 'with include_address' do
+      it 'should search the institution and address fields' do
+        institutions = described_class.autocomplete('address', include_address: true)
+        expect(sorted_ids(institutions)).to eq(institution_ids)
+
+        institutions = described_class.autocomplete('institution', include_address: true)
+        expect(sorted_ids(institutions)).to eq(institution_ids)
+      end
+    end
+  end
+
   describe 'class methods and scopes' do
     context 'version' do
       it 'should retrieve institutions by a specific version number' do

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -167,6 +167,15 @@ RSpec.describe Institution, type: :model do
       sorted_ids(institutions)
     end
 
+    context 'without include_address' do
+      it 'should search the institution field' do
+        expect(described_class.autocomplete('address').size).to eq(0)
+
+        institutions = described_class.autocomplete('institution')
+        expect(sorted_ids(institutions)).to eq(institution_ids)
+      end
+    end
+
     context 'with include_address' do
       it 'should search the institution and address fields' do
         institutions = described_class.autocomplete('address', include_address: true)

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe 'institutions', type: :request do
   end
 
   context '#autocomplete' do
+    it 'will include address if the param is set' do
+      expect(Institution).to receive(:autocomplete).with('foo', include_address: 'true')
+      get '/v0/institutions/autocomplete', term: 'foo', include_address: true
+    end
+
     it 'uses LINK_HOST in self link' do
       create(:institution, :in_chicago)
       get '/v0/institutions/autocomplete?term=uni'

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -43,6 +43,9 @@
                 "FOR PROFIT", "PUBLIC"
               ]
             },
+            "address_1": { "type": ["null", "string"] },
+            "address_2": { "type": ["null", "string"] },
+            "address_3": { "type": ["null", "string"] },
             "city": { "type": ["null", "string"] },
             "state": { "type": ["null", "string"] },
             "zip": { "type": ["null", "string"] },


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11469
modifies autocomplete api to allow an optional `include_address` param which will use the search term to query address fields