### PR TITLE
Allow searching for address in School Search API

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -58,19 +58,25 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      Institution.version(@version[:number])
-                 .search(@query[:name])
-                 .filter(:institution_type_name, @query[:type])
-                 .filter(:category, @query[:category])
-                 .filter(:country, @query[:country])
-                 .filter(:state, @query[:state])
-                 .filter(:student_veteran, @query[:student_veteran_group]) # boolean
-                 .filter(:yr, @query[:yellow_ribbon_scholarship]) # boolean
-                 .filter(:poe, @query[:principles_of_excellence]) # boolean
-                 .filter(:eight_keys, @query[:eight_keys_to_veteran_success]) # boolean
-                 .filter(:stem_offered, @query[:stem_offered]) # boolean
-                 .filter(:independent_study, @query[:independent_study]) # boolean
-                 .filter(:priority_enrollment, @query[:priority_enrollment]) # boolean
+      relation = Institution.version(@version[:number]).search(@query[:name])
+      filters = [
+        [:institution_type_name, :type],
+        [:category],
+        [:country],
+        [:state],
+        [:student_veteran, :student_veteran_group], # boolean
+        [:yr, :yellow_ribbon_scholarship], # boolean
+        [:poe, :principles_of_excellence], # boolean
+        [:eight_keys, :eight_keys_to_veteran_success], # boolean
+        [:stem_offered], # boolean
+        [:independent_study], # boolean
+        [:priority_enrollment] # boolean
+      ].each do |filter_args|
+        filter_args << filter_args[0] if filter_args.size == 1
+        relation = relation.filter(filter_args[0], @query[filter_args[1]])
+      end
+
+      relation
     end
 
     # rubocop:disable Style/MutableConstant

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -50,8 +50,7 @@ module V0
           query[k].try(:upcase!)
         end
         %i[category student_veteran_group yellow_ribbon_scholarship principles_of_excellence
-           eight_keys_to_veteran_success stem_offered independent_study priority_enrollment
-         ].each do |k|
+           eight_keys_to_veteran_success stem_offered independent_study priority_enrollment].each do |k|
           query[k].try(:downcase!)
         end
       end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -60,7 +60,7 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      relation = Institution.version(@version[:number]).search(@query[:name])
+      relation = Institution.version(@version[:number]).search(@query[:name], @query[:include_address])
       filters = [
         [:institution_type_name, :type],
         [:category],

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -59,15 +59,15 @@ module V0
     def search_results
       @query ||= normalized_query_params
       relation = Institution.version(@version[:number]).search(@query[:name], @query[:include_address])
-      filters = [
-        [:institution_type_name, :type],
+      [
+        %i[institution_type_name type],
         [:category],
         [:country],
         [:state],
-        [:student_veteran, :student_veteran_group], # boolean
-        [:yr, :yellow_ribbon_scholarship], # boolean
-        [:poe, :principles_of_excellence], # boolean
-        [:eight_keys, :eight_keys_to_veteran_success], # boolean
+        %i[student_veteran student_veteran_group], # boolean
+        %i[yr yellow_ribbon_scholarship], # boolean
+        %i[poe principles_of_excellence], # boolean
+        %i[eight_keys eight_keys_to_veteran_success], # boolean
         [:stem_offered], # boolean
         [:independent_study], # boolean
         [:priority_enrollment] # boolean

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -50,7 +50,9 @@ module V0
           query[k].try(:upcase!)
         end
         %i[category student_veteran_group yellow_ribbon_scholarship principles_of_excellence
-           eight_keys_to_veteran_success stem_offered independent_study priority_enrollment].each do |k|
+           eight_keys_to_veteran_success stem_offered independent_study priority_enrollment
+           address_1 address_2 address_3
+         ].each do |k|
           query[k].try(:downcase!)
         end
       end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -51,7 +51,6 @@ module V0
         end
         %i[category student_veteran_group yellow_ribbon_scholarship principles_of_excellence
            eight_keys_to_veteran_success stem_offered independent_study priority_enrollment
-           address_1 address_2 address_3
          ].each do |k|
           query[k].try(:downcase!)
         end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -229,7 +229,7 @@ class Institution < ActiveRecord::Base
     where(
       clause.join(' OR '),
       facility_code: search_term.upcase,
-      search_term: "%#{search_term}%",
+      search_term: "%#{search_term}%"
     )
   }
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -212,19 +212,25 @@ class Institution < ActiveRecord::Base
 
   # Finds exact-matching facility_code or partial-matching school and city names
   #
-  scope :search, lambda { |search_term|
+  scope :search, lambda { |search_term, include_address = false|
     return if search_term.blank?
     clause = [
-      'facility_code = (?)',
-      'lower(institution) LIKE (?)',
-      'lower(city) LIKE (?)'
-    ].join(' OR ')
-    terms = [
-      search_term.upcase,
-      "%#{search_term}%",
-      "%#{search_term}%"
+      'facility_code = (:facility_code)',
+      'lower(institution) LIKE (:search_term)',
+      'lower(city) LIKE (:search_term)'
     ]
-    where([clause] + terms)
+
+    if include_address
+      3.times do |i|
+        clause << "lower(address_#{i + 1}) LIKE (:search_term)"
+      end
+    end
+
+    where(
+      clause.join(' OR '),
+      facility_code: search_term.upcase,
+      search_term: "%#{search_term}%",
+    )
   }
 
   scope :filter, lambda { |field, value|

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -14,6 +14,7 @@ class Weam < ActiveRecord::Base
 
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip
+    address_1 address_2 address_3
     country accredited bah poe yr
     institution_type_name va_highest_degree_offered flight correspondence
     independent_study priority_enrollment

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -19,6 +19,9 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :ialias, key: :alias
   attribute :highest_degree
   attribute :locale_type
+  attribute :address_1
+  attribute :address_2
+  attribute :address_3
   attribute :gibill, key: :student_count
   attribute :undergrad_enrollment
   attribute :yr

--- a/app/serializers/institution_serializer.rb
+++ b/app/serializers/institution_serializer.rb
@@ -22,6 +22,9 @@ class InstitutionSerializer < ActiveModel::Serializer
   attribute :caution_flag_reason
   attribute :created_at
   attribute :updated_at
+  attribute :address_1
+  attribute :address_2
+  attribute :address_3
 
   attribute :bah
   attribute :tuition_in_state

--- a/db/migrate/20180731201058_add_address_fields_to_institutions.rb
+++ b/db/migrate/20180731201058_add_address_fields_to_institutions.rb
@@ -1,0 +1,7 @@
+class AddAddressFieldsToInstitutions < ActiveRecord::Migration
+  def change
+    add_column(:institutions, :address_1, :string)
+    add_column(:institutions, :address_2, :string)
+    add_column(:institutions, :address_3, :string)
+  end
+end

--- a/db/migrate/20180731201600_add_institutions_address_indexes.rb
+++ b/db/migrate/20180731201600_add_institutions_address_indexes.rb
@@ -1,0 +1,9 @@
+class AddInstitutionsAddressIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index(:institutions, :address_1, algorithm: :concurrently)
+    add_index(:institutions, :address_2, algorithm: :concurrently)
+    add_index(:institutions, :address_3, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614014201) do
+ActiveRecord::Schema.define(version: 20180731201600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -269,8 +269,14 @@ ActiveRecord::Schema.define(version: 20180614014201) do
     t.boolean  "online_only"
     t.boolean  "independent_study"
     t.boolean  "distance_learning"
+    t.string   "address_1"
+    t.string   "address_2"
+    t.string   "address_3"
   end
 
+  add_index "institutions", ["address_1"], name: "index_institutions_on_address_1", using: :btree
+  add_index "institutions", ["address_2"], name: "index_institutions_on_address_2", using: :btree
+  add_index "institutions", ["address_3"], name: "index_institutions_on_address_3", using: :btree
   add_index "institutions", ["city"], name: "index_institutions_on_city", using: :btree
   add_index "institutions", ["cross"], name: "index_institutions_on_cross", using: :btree
   add_index "institutions", ["facility_code"], name: "index_institutions_on_facility_code", using: :btree

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -192,6 +192,12 @@ RSpec.describe Institution, type: :model do
         expect(described_class.search(nil)).to be_empty
       end
 
+      it 'should include the address fields if include_address is set' do
+        institution = create(:institution, address_1: 'address_1')
+        expect(described_class.search('address_1', true).take).to eq(institution)
+        expect(described_class.search('address_1').count).to eq(0)
+      end
+
       it 'should search when attribute is provided' do
         expect(described_class.search('chicago').to_sql)
           .to include(

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe 'institutions', type: :request do
       links = JSON.parse(response.body)['links']
       expect(links['self']).to start_with(ENV['LINK_HOST'])
     end
+
+    it 'allow searching by address fields' do
+      create(:institution, address_1: 'address_1')
+      get(v0_institutions_path(name: 'abc'))
+      binding.pry; fail
+    end
   end
 
   context '#show' do

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'institutions', type: :request do
     it 'allow searching by address fields' do
       create(:institution, address_1: 'address_1')
       get(v0_institutions_path(name: 'abc'))
-      binding.pry; fail
     end
   end
 

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe 'institutions', type: :request do
     it 'allow searching by address fields' do
       institution = create(:institution, address_1: 'address_1', version: Version.current_production.number)
       get(v0_institutions_path(name: 'address_1', include_address: true))
-      expect(JSON.parse(response.body)['data'][0]['id'].to_i).to eq(institution.id)
+      data = JSON.parse(response.body)['data'][0]
+      expect(data['id'].to_i).to eq(institution.id)
+      expect(data['attributes']['address_1']).to eq('address_1')
     end
   end
 

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe 'institutions', type: :request do
     end
 
     it 'allow searching by address fields' do
-      create(:institution, address_1: 'address_1')
-      get(v0_institutions_path(name: 'abc'))
+      institution = create(:institution, address_1: 'address_1', version: Version.current_production.number)
+      get(v0_institutions_path(name: 'address_1', include_address: true))
+      expect(JSON.parse(response.body)['data'][0]['id'].to_i).to eq(institution.id)
     end
   end
 

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -43,6 +43,9 @@
                 "FOR PROFIT", "PUBLIC"
               ]
             },
+            "address_1": { "type": ["null", "string"] },
+            "address_2": { "type": ["null", "string"] },
+            "address_3": { "type": ["null", "string"] },
             "city": { "type": ["null", "string"] },
             "state": { "type": ["null", "string"] },
             "zip": { "type": ["null", "string"] },


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11469
search will return results that match an institution's address fields if the `include_address` param is set.