### PR TITLE
ENV variables won't be boolean because they are set via Python.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,7 +16,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "#{ENV['GOVDELIVERY_STAGING_SERVICE'] ? 'stage.' : ''}va-notifications@public.govdelivery.com"
+  config.mailer_sender = "#{ENV['GOVDELIVERY_STAGING_SERVICE'] == 'True' ? 'stage.' : ''}va-notifications@public.govdelivery.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,7 +33,7 @@ services:
       SAML_ISSUER: GIDS
       GOVDELIVERY_URL: 'stage-tms.govdelivery.com'
       GOVDELIVERY_TOKEN: 'abc123'
-      GOVDELIVERY_STAGING_SERVICE: 'true'
+      GOVDELIVERY_STAGING_SERVICE: 'True'
     depends_on:
       - postgres
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       ADMIN_PW: 'something...'
       GOVDELIVERY_URL: 'stage-tms.govdelivery.com'
       GOVDELIVERY_TOKEN: 'abc123'
-      GOVDELIVERY_STAGING_SERVICE: 'true'
+      GOVDELIVERY_STAGING_SERVICE: 'True'
     depends_on:
       - postgres
     links:


### PR DESCRIPTION
re: [vets.gov-team#8123](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18123)