### PR TITLE
refactor migrations to add `approved` and `vet_tec_provider` to `institutions` table

### DIFF
--- a/db/migrate/20190607014201_add_column_approved_and_vet_tec_to_institutions.rb
+++ b/db/migrate/20190607014201_add_column_approved_and_vet_tec_to_institutions.rb
@@ -1,0 +1,16 @@
+class AddColumnApprovedAndVetTecToInstitutions < ActiveRecord::Migration
+  def up
+    change_table(:institutions, bulk: true) do |t|
+      t.column :approved, :boolean 
+      t.column :vet_tec_provider, :boolean
+
+      t.change_default :approved, false
+      t.change_default :vet_tec_provider, false
+    end
+  end
+
+  def down
+    remove_column :institutions, :approved
+    remove_column :institutions, :vet_tec_provider
+  end
+end

--- a/db/migrate/20190607014201_add_column_approved_to_institutions.rb
+++ b/db/migrate/20190607014201_add_column_approved_to_institutions.rb
@@ -1,5 +1,0 @@
-class AddColumnApprovedToInstitutions < ActiveRecord::Migration
-  def change
-    add_column :institutions, :approved, :boolean, null: false, default: false
-  end
-end

--- a/db/migrate/20190613018894_add_column_vet_tec_provider_to_institutions.rb
+++ b/db/migrate/20190613018894_add_column_vet_tec_provider_to_institutions.rb
@@ -1,5 +1,0 @@
-class AddColumnVetTecProviderToInstitutions < ActiveRecord::Migration
-  def change
-    add_column :institutions, :vet_tec_provider, :boolean, default: false, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -303,8 +303,6 @@ ActiveRecord::Schema.define(version: 20190626110700) do
     t.string   "physical_zip"
     t.string   "physical_country"
     t.integer  "dod_bah"
-    t.string   "campus_type"
-    t.string   "parent_facility_code_id"
     t.boolean  "approved",                                            default: false
     t.boolean  "vet_tec_provider",                                    default: false
   end
@@ -323,7 +321,6 @@ ActiveRecord::Schema.define(version: 20190626110700) do
   add_index "institutions", ["ope6"], name: "index_institutions_on_ope6", using: :btree
   add_index "institutions", ["state"], name: "index_institutions_on_state", using: :btree
   add_index "institutions", ["stem_offered"], name: "index_institutions_on_stem_offered", using: :btree
-  add_index "institutions", ["version", "parent_facility_code_id"], name: "index_institutions_on_version_and_parent_facility_code_id", using: :btree
   add_index "institutions", ["version"], name: "index_institutions_on_version", using: :btree
 
   create_table "ipeds_cip_codes", force: :cascade do |t|
@@ -1300,8 +1297,6 @@ ActiveRecord::Schema.define(version: 20190626110700) do
     t.string   "physical_zip"
     t.string   "physical_country"
     t.integer  "dod_bah"
-    t.string   "campus_type"
-    t.string   "parent_facility_code_id"
   end
 
   add_index "weams", ["facility_code"], name: "index_weams_on_facility_code", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -303,8 +303,10 @@ ActiveRecord::Schema.define(version: 20190626110700) do
     t.string   "physical_zip"
     t.string   "physical_country"
     t.integer  "dod_bah"
-    t.boolean  "approved",                                            default: false, null: false
-    t.boolean  "vet_tec_provider",                                    default: false, null: false
+    t.string   "campus_type"
+    t.string   "parent_facility_code_id"
+    t.boolean  "approved",                                            default: false
+    t.boolean  "vet_tec_provider",                                    default: false
   end
 
   add_index "institutions", ["address_1"], name: "index_institutions_on_address_1", using: :btree
@@ -321,6 +323,7 @@ ActiveRecord::Schema.define(version: 20190626110700) do
   add_index "institutions", ["ope6"], name: "index_institutions_on_ope6", using: :btree
   add_index "institutions", ["state"], name: "index_institutions_on_state", using: :btree
   add_index "institutions", ["stem_offered"], name: "index_institutions_on_stem_offered", using: :btree
+  add_index "institutions", ["version", "parent_facility_code_id"], name: "index_institutions_on_version_and_parent_facility_code_id", using: :btree
   add_index "institutions", ["version"], name: "index_institutions_on_version", using: :btree
 
   create_table "ipeds_cip_codes", force: :cascade do |t|
@@ -1297,6 +1300,8 @@ ActiveRecord::Schema.define(version: 20190626110700) do
     t.string   "physical_zip"
     t.string   "physical_country"
     t.integer  "dod_bah"
+    t.string   "campus_type"
+    t.string   "parent_facility_code_id"
   end
 
   add_index "weams", ["facility_code"], name: "index_weams_on_facility_code", unique: true, using: :btree


### PR DESCRIPTION
The previous version of this migration specified `null: false`, which meant that an update was run to populate all 6mm rows after creating the column.  Because of this, it locked up the table, and never successfully completed in production.

This way:
* creates both columns in bulk
* doesn't try to update all those roles.  

We can update the rows' values in batches post db-changes.