### PR TITLE
add institution index

### DIFF
--- a/db/migrate/20190708211726_add_index_index_institutions_index_institution.rb
+++ b/db/migrate/20190708211726_add_index_index_institutions_index_institution.rb
@@ -3,6 +3,7 @@ class AddIndexIndexInstitutionsIndexInstitution < ActiveRecord::Migration
 
   def up
     safety_assured do
+      # This index will not be properly represented in schema.rb but it will be present on db's that run this migration.
       execute 'CREATE INDEX CONCURRENTLY version_institutions_lower_institutions_idx ON institutions("version", lower(institution));'
     end
   end

--- a/db/migrate/20190708211726_add_index_index_institutions_index_institution.rb
+++ b/db/migrate/20190708211726_add_index_index_institutions_index_institution.rb
@@ -1,0 +1,15 @@
+class AddIndexIndexInstitutionsIndexInstitution < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute 'CREATE INDEX CONCURRENTLY version_institutions_lower_institutions_idx ON institutions("version", lower(institution));'
+    end
+  end
+
+  def down
+    safety_assured do
+      execute 'DROP INDEX version_institutions_lower_institutions_idx'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190626110700) do
+ActiveRecord::Schema.define(version: 20190708211726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -322,6 +322,7 @@ ActiveRecord::Schema.define(version: 20190626110700) do
   add_index "institutions", ["state"], name: "index_institutions_on_state", using: :btree
   add_index "institutions", ["stem_offered"], name: "index_institutions_on_stem_offered", using: :btree
   add_index "institutions", ["version"], name: "index_institutions_on_version", using: :btree
+  add_index "institutions", ["version"], name: "version_institutions_lower_institutions_idx", using: :btree
 
   create_table "ipeds_cip_codes", force: :cascade do |t|
     t.string   "cross",      null: false


### PR DESCRIPTION
we were seeing 100% cpu on the database today, mostly due to queries from autocomplete like 

`SELECT  id, facility_code as value, institution as label FROM "institutions" WHERE "institutions"."version" = $1 AND
"institutions"."approved" = $2 AND (lower(institution) LIKE ('university%')) LIMIT 6`

adding an index, on institution should help substantially. 

Unfortunately, schema.rb won't accurately reflect this index.  In the long term, the project could either move to [rails 5.0](https://blog.bigbinary.com/2016/07/20/rails-5-adds-support-for-expression-indexes-for-postgresql.html) or [structure.sql](https://guides.rubyonrails.org/v4.2/active_record_migrations.html#types-of-schema-dumps) to fix.