### PR TITLE
rubocop to 0.53.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :development, :test do
   gem 'pry-nav'
 
   # Linters
-  gem 'rubocop', '~> 0.52.1', require: false
+  gem 'rubocop', '~> 0.53.0', require: false
   gem 'scss_lint', require: false
   gem 'jshint', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,15 +193,15 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    parallel (1.12.1)
-    parser (2.5.1.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (0.19.0)
     poltergeist (1.12.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -269,14 +269,14 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.52.1)
+    rubocop (0.53.0)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.1)
     ruby-saml (1.7.2)
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
@@ -331,7 +331,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.6.0)
     vcr (3.0.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -384,7 +384,7 @@ DEPENDENCIES
   rails (~> 4.2.11)
   rainbow
   rspec-rails
-  rubocop (~> 0.52.1)
+  rubocop (~> 0.53.0)
   ruby-saml
   rubyzip (~> 1.2, >= 1.2.1)
   sass-rails (~> 5.0)
@@ -405,4 +405,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 # Load rake support files
 Dir[Rails.root.join('lib', 'tasks', 'support', '**', '*.rb')].each { |f| require f }

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -36,6 +36,6 @@ class AuthController < ApplicationController
   end
 
   def saml_settings
-    @settings ||= SAML::Settings.settings
+    @saml_settings ||= SAML::Settings.settings
   end
 end

--- a/app/controllers/storages_controller.rb
+++ b/app/controllers/storages_controller.rb
@@ -52,7 +52,7 @@ class StoragesController < ApplicationController
   end
 
   def upload_params
-    @u ||= params.require(:storage).permit(:upload_file, :comment)
+    @upload_params ||= params.require(:storage).permit(:upload_file, :comment)
   end
 
   def find_storage

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -65,7 +65,7 @@ class UploadsController < ApplicationController
   end
 
   def original_filename
-    @f ||= upload_params[:upload_file].try(:original_filename)
+    @original_filename ||= upload_params[:upload_file].try(:original_filename)
   end
 
   def defaults(csv_type)
@@ -77,7 +77,7 @@ class UploadsController < ApplicationController
   end
 
   def upload_params
-    @u ||= params.require(:upload).permit(:csv_type, :skip_lines, :upload_file, :comment)
+    @upload_params ||= params.require(:upload).permit(:csv_type, :skip_lines, :upload_file, :comment)
   end
 
   def call_load

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -132,7 +132,7 @@ module V0
       end
       raw_facets
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Style/GuardClause
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # Embed search result counts as a list of hashes with "name"/"count"
     # keys so that open-ended strings such as country names do not

--- a/app/models/gibct_site_mapper.rb
+++ b/app/models/gibct_site_mapper.rb
@@ -28,11 +28,11 @@ class GibctSiteMapper
     SitemapGenerator.verbose = verbose
   end
 
-  def generate_sitemap(v)
+  def generate_sitemap(version)
     SitemapGenerator::Sitemap.create do
       add '/search', priority: 0.9, changefreq: 'monthly'
 
-      Institution.version(v).find_each do |institution|
+      Institution.version(version).find_each do |institution|
         add "/profile/#{institution.facility_code}", priority: 0.8, changefreq: 'weekly'
       end
     end

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -55,9 +55,9 @@ module CsvHelper
       record.errors.any? ? records[:invalid] << record : records[:valid] << record
     end
 
-    def row_to_record(row, i)
+    def row_to_record(row, index)
       record = klass.new(row)
-      record.errors.add(:row, "Line #{i}") unless record.valid?
+      record.errors.add(:row, "Line #{index}") unless record.valid?
 
       record
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,7 +54,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   # Allow skip_before_action in rspec controller tests
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.include Warden::Test::Helpers, type: :request
 


### PR DESCRIPTION
Spun off of https://github.com/department-of-veterans-affairs/gibct-data-service/pull/383

- updated rubocop to 0.53.0 to remove deprecation warnings
- `Devise::TestHelpers` to `Devise::Test::ControllerHelpers` for deprecation warnings when running tests