### PR TITLE
use safety_assured and change_table for CT 116 Preferred Provider

### DIFF
--- a/db/migrate/20190712019179_add_preferred_provider_column_to_institutions.rb
+++ b/db/migrate/20190712019179_add_preferred_provider_column_to_institutions.rb
@@ -1,5 +1,15 @@
 class AddPreferredProviderColumnToInstitutions < ActiveRecord::Migration
-  def change
-    add_column :institutions, :preferred_provider, :boolean, default: false
+  def up
+    safety_assured do
+        change_table(:institutions, bulk: true) do |t|
+        t.column :preferred_provider, :boolean 
+
+        t.change_default :preferred_provider, false
+      end
+    end
+  end
+
+  def down
+    remove_column :institutions, :preferred_provider
   end
 end

--- a/db/migrate/20190712019179_add_preferred_provider_column_to_institutions.rb
+++ b/db/migrate/20190712019179_add_preferred_provider_column_to_institutions.rb
@@ -1,12 +1,7 @@
 class AddPreferredProviderColumnToInstitutions < ActiveRecord::Migration
   def up
-    safety_assured do
-        change_table(:institutions, bulk: true) do |t|
-        t.column :preferred_provider, :boolean 
-
-        t.change_default :preferred_provider, false
-      end
-    end
+    add_column :institutions, :preferred_provider, :boolean
+    change_column_default :institutions, :preferred_provider, false
   end
 
   def down

--- a/db/migrate/20190717019179_add_preferred_provider_column_to_weams.rb
+++ b/db/migrate/20190717019179_add_preferred_provider_column_to_weams.rb
@@ -1,12 +1,7 @@
 class AddPreferredProviderColumnToWeams < ActiveRecord::Migration
     def up
-      safety_assured do
-        change_table(:weams, bulk: true) do |t|
-          t.column :preferred_provider, :boolean 
-    
-          t.change_default :preferred_provider, false
-        end
-      end
+      add_column :weams, :preferred_provider, :boolean
+      change_column_default :weams, :preferred_provider, false
     end
   
     def down

--- a/db/migrate/20190717019179_add_preferred_provider_column_to_weams.rb
+++ b/db/migrate/20190717019179_add_preferred_provider_column_to_weams.rb
@@ -1,5 +1,15 @@
 class AddPreferredProviderColumnToWeams < ActiveRecord::Migration
-    def change
-      add_column :weams, :preferred_provider, :boolean, default: false
+    def up
+      safety_assured do
+        change_table(:weams, bulk: true) do |t|
+          t.column :preferred_provider, :boolean 
+    
+          t.change_default :preferred_provider, false
+        end
+      end
+    end
+  
+    def down
+      remove_column :weams, :preferred_provider
     end
   end


### PR DESCRIPTION
Previous version of scripts produced in a staging environment

```
standardError: An error has occurred, this and all later migrations canceled:

=== Dangerous operation detected #strong_migrations ===

Adding a column with a non-null default causes the entire table to be rewritten.
Instead, add the column without a default value, then change the default.

class AddPreferredProviderColumnToInstitutions < ActiveRecord::Migration
  def up
    add_column :institutions, :preferred_provider, :boolean
    change_column_default :institutions, :preferred_provider, false
  end

  def down
    remove_column :institutions, :preferred_provider
  end
end

Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.

class BackfillAddPreferredProviderColumnToInstitutions < ActiveRecord::Migration
  disable_ddl_transaction!

  def change
    Institution.find_in_batches do |records|
      Institution.where(id: records.map(&:id)).update_all preferred_provider: false
    end
  end
end
```