### PR TITLE
CT 116 - Only display approved VET TEC providers in the Search Results #19291

### DIFF
--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -156,6 +156,9 @@ class Weam < ActiveRecord::Base
   # an approved applicable law code that is not restrictive of GI Bill
   # benefits, and be a higher learning institution, OJT, flight,
   # correspondence or an institution that is a degree-granting concern.
+  #
+  # If school is a vet tec provider, applicable law code is VET TEC ONLY,
+  # and be a non college degree indicator
   def approved?
     return false if poo_status.blank? || applicable_law_code.blank?
 

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -164,13 +164,13 @@ class Weam < ActiveRecord::Base
 
     return false unless poo_status =~ Regexp.new('aprvd', 'i')
 
-    if applicable_law_code =~ Regexp.new("#{ALCVT}", 'i')
-      vet_tec_flags_for_approved?
-    else 
-      return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')
+    # VET TEC ONLY
+    return vet_tec_flags_for_approved? if applicable_law_code =~ Regexp.new("#{ALCVT}", 'i')
+    
+    # Other
+    return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')
+    flags_for_approved?
 
-      flags_for_approved?
-    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -12,6 +12,7 @@ class Weam < ActiveRecord::Base
 
   ALC1 = 'educational institution is not approved'
   ALC2 = 'educational institution is approved for chapter 31 only'
+  ALCVT = 'vet tec only'
 
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip
@@ -147,6 +148,10 @@ class Weam < ActiveRecord::Base
       flight_indicator || non_college_degree_indicator
   end
 
+  def vet_tec_flags_for_approved?
+    non_college_degree_indicator
+  end
+
   # To be approved, a school must be marked 'aprvd' in the poo-status, have
   # an approved applicable law code that is not restrictive of GI Bill
   # benefits, and be a higher learning institution, OJT, flight,
@@ -155,9 +160,14 @@ class Weam < ActiveRecord::Base
     return false if poo_status.blank? || applicable_law_code.blank?
 
     return false unless poo_status =~ Regexp.new('aprvd', 'i')
-    return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')
 
-    flags_for_approved?
+    if applicable_law_code =~ Regexp.new("#{ALCVT}", 'i')
+      vet_tec_flags_for_approved?
+    else 
+      return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')
+
+      flags_for_approved?
+    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -103,6 +103,12 @@ FactoryGirl.define do
       non_college_degree_indicator true
     end
 
+    trait :as_vet_tec_provider do
+      poo_status 'aprvd'
+      applicable_law_code 'vet tec only'
+      non_college_degree_indicator true
+    end
+
     # Facility_code second digit is 0
     trait :zipcode_rate do
       bah 1100

--- a/spec/models/weam_spec.rb
+++ b/spec/models/weam_spec.rb
@@ -219,6 +219,7 @@ RSpec.describe Weam, type: :model do
     let(:non_approved_law_code) { build :weam, :approved_poo_and_non_approved_law_code }
     let(:title_31_law_code) { build :weam, :approved_poo_and_non_approved_law_code }
     let(:false_indicators) { build :weam }
+    let(:vet_tec_provider) { build :weam, :as_vet_tec_provider }
 
     it 'is true if poo and law code are approved with at least one true indicator' do
       expect(subject.approved?).to be_truthy
@@ -232,6 +233,10 @@ RSpec.describe Weam, type: :model do
 
     it 'is false if there are no truthful indicators' do
       expect(false_indicators.approved?).to be_falsy
+    end
+
+    it 'is true if poo and law code are vet tec only with non college degree indicator' do
+      expect(vet_tec_provider.approved?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19291
As a Comparison Tool user, I should only see approved VET TEC providers in the search results so that I can choose a provider where I can use my benefits.

## Assumptions:
1. This work is completed behind a flag so that it is only available in the staging environment and below.
2. The "Applicable Law Code" of "VET TEC Only" will be received in the GIDS Weams.csv file in the future.

## Acceptance Criteria:
- [ ] VET TEC providers are only displayed in the "Search Results" page if ALL of the following criteria are met:
- "POO Status" = "APRVD"
- "Applicable Law Code" = "VET TEC ONLY"
- "Non-College Degree Indicator" = "Yes"

## Supporting Artifacts:
1. N/A

## Testing
- Pull branch locally
- Upload weam.csv into local GIDS
- Generate New Preview
- Publish
- Go to http://localhost:3001/gi-bill-comparison-tool/search?vetTecProvider=true