### PR TITLE
GIDS Generate Preview button not working when a new CSV type is added #10450

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,7 @@ class DashboardsController < ApplicationController
   before_action :verify_buildable, only: :build
 
   def index
-    @uploads = Upload.last_uploads
+    @uploads = Upload.last_uploads_rows
 
     @production_versions = Version.production.newest.includes(:user).limit(1)
     @preview_versions = Version.preview.newest.includes(:user).limit(1)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -68,7 +68,7 @@ class Upload < ActiveRecord::Base
         uploadTest = Upload.new
         uploadTest.csv_type = klass.name
         uploadTest.ok = false
-        uploadTest.comment = 'No initial file uploaded'
+        uploadTest.comment = 'No initial file uploaded!!!'
     
         uploads.push(uploadTest)
       end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -62,7 +62,7 @@ class Upload < ActiveRecord::Base
       uploads_hash[r.csv_type] = r
     end
 
-    # uploads to hash to use in if statement
+    # add csv types that are missing from database to allow for uploads
     InstitutionBuilder::TABLES.each do |klass|
       next if uploads_hash.key?(klass.name)
       missing_upload = Upload.new

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -56,15 +56,11 @@ class Upload < ActiveRecord::Base
 
   def self.last_uploads_rows
     uploads = Upload.last_uploads
-
-    uploads_hash = {}
-    uploads.each do |r|
-      uploads_hash[r.csv_type] = r
-    end
+    upload_csv_types = uploads.map(&:csv_type)
 
     # add csv types that are missing from database to allow for uploads
     InstitutionBuilder::TABLES.each do |klass|
-      next if uploads_hash.key?(klass.name)
+      next if upload_csv_types.include?(klass.name)
       missing_upload = Upload.new
       missing_upload.csv_type = klass.name
       missing_upload.ok = false

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -59,7 +59,7 @@ class Upload < ActiveRecord::Base
 
     uploads_hash = {}
     uploads.each do |r|
-      uploadsHash[r.csv_type] = r
+      uploads_hash[r.csv_type] = r
     end
 
     # uploads to hash to use in if statement

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -75,8 +75,6 @@ class Upload < ActiveRecord::Base
     }
 
     return uploads.sort_by { |upload| upload.csv_type.downcase }
-
-    # InstitutionBuilder::TABLES.
   end
 
   private

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -54,6 +54,11 @@ class Upload < ActiveRecord::Base
     Upload.select('DISTINCT ON("csv_type") *').where(ok: true).order(csv_type: :asc).order(updated_at: :desc)
   end
 
+  def self.last_uploads_rows
+    @uploads = Upload.last_uploads
+    
+  end
+
   private
 
   def initialize_warnings

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -57,24 +57,23 @@ class Upload < ActiveRecord::Base
   def self.last_uploads_rows
     uploads = Upload.last_uploads
 
-    uploadsHash = {}
+    uploads_hash = {}
     uploads.each do |r|
       uploadsHash[r.csv_type] = r
     end
 
     # uploads to hash to use in if statement
-    InstitutionBuilder::TABLES.each{ |klass|
-      if !uploadsHash.has_key?(klass.name)
-        uploadTest = Upload.new
-        uploadTest.csv_type = klass.name
-        uploadTest.ok = false
-        uploadTest.comment = 'No initial file uploaded!!!'
-    
-        uploads.push(uploadTest)
-      end
-    }
+    InstitutionBuilder::TABLES.each do |klass|
+      next if uploads_hash.key?(klass.name)
+      missing_upload = Upload.new
+      missing_upload.csv_type = klass.name
+      missing_upload.ok = false
+      missing_upload.comment = 'No initial file uploaded!!!'
 
-    return uploads.sort_by { |upload| upload.csv_type.downcase }
+      uploads.push(missing_upload)
+    end
+
+    uploads.sort_by { |upload| upload.csv_type.downcase }
   end
 
   private

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -55,8 +55,28 @@ class Upload < ActiveRecord::Base
   end
 
   def self.last_uploads_rows
-    @uploads = Upload.last_uploads
+    uploads = Upload.last_uploads
+
+    uploadsHash = {}
+    uploads.each do |r|
+      uploadsHash[r.csv_type] = r
+    end
+
+    # uploads to hash to use in if statement
+    InstitutionBuilder::TABLES.each{ |klass|
+      if !uploadsHash.has_key?(klass.name)
+        uploadTest = Upload.new
+        uploadTest.csv_type = klass.name
+        uploadTest.ok = false
+        uploadTest.comment = 'No initial file uploaded'
     
+        uploads.push(uploadTest)
+      end
+    }
+
+    return uploads.sort_by { |upload| upload.csv_type.downcase }
+
+    # InstitutionBuilder::TABLES.
   end
 
   private

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -41,6 +41,10 @@ class Version < ActiveRecord::Base
     :no_new_uploads
   end
 
+  def self.buildable_state_msg
+    Version.buildable_state.to_s.split('_').map(&:capitalize).join(' ')
+  end
+
   # public instance methods
   def preview?
     !production?

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -165,7 +165,7 @@ class Weam < ActiveRecord::Base
     return false unless poo_status =~ Regexp.new('aprvd', 'i')
 
     # VET TEC ONLY
-    return vet_tec_flags_for_approved? if applicable_law_code =~ Regexp.new(ALCVT.to_s, 'i')
+    return vet_tec_flags_for_approved? if applicable_law_code =~ Regexp.new(ALCVT, 'i')
 
     # Other
     return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -165,12 +165,11 @@ class Weam < ActiveRecord::Base
     return false unless poo_status =~ Regexp.new('aprvd', 'i')
 
     # VET TEC ONLY
-    return vet_tec_flags_for_approved? if applicable_law_code =~ Regexp.new("#{ALCVT}", 'i')
-    
+    return vet_tec_flags_for_approved? if applicable_law_code =~ Regexp.new(ALCVT.to_s, 'i')
+
     # Other
     return false if applicable_law_code =~ Regexp.new("#{ALC1}|#{ALC2}", 'i')
     flags_for_approved?
-
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/dashboards/_latest_upload.html.erb
+++ b/app/views/dashboards/_latest_upload.html.erb
@@ -1,9 +1,9 @@
-<tr>
+<tr class="<%= 'danger' if !upload.ok? %>">
   <td><%= upload.csv_type %></td>
   <td><%= upload.ok? ? 'Succeeded' : 'Failed' %></td>
-  <td><%= upload.csv %></td>
-  <td><%= upload.created_at.to_formatted_s(:long_ordinal) %></td>
-  <td><%= upload.user.email %></td>
+  <td><%= upload.csv.blank? ? '-' : upload.csv %></td>
+  <td><%= upload.created_at.blank? ? '-' : upload.created_at.to_formatted_s(:long_ordinal) %></td>
+  <td><%= upload.user.blank? ? '-' : upload.user.email %></td>
   <td><%= upload.comment.blank? ? '-' : upload.comment %></td>
   <td>
     <%= link_to 'Upload', new_upload_path(upload.csv_type),

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -29,7 +29,8 @@
         class: "btn btn-warning btn-xs",
         role: "button" %>
   <% else %>
-    <a disabled="disabled" class="btn btn-warning btn-xs", role="button">
+    <a disabled="disabled" class="btn btn-warning btn-xs", role="button"
+     title="<%= Version.buildable_state_msg %>">
       Generate New Preview Version
     </a>
   <% end %>

--- a/sample_csvs/sec109_closed_school.csv
+++ b/sample_csvs/sec109_closed_school.csv
@@ -1,1 +1,2 @@
 facility_code,school_name,closure109
+1V111111,VET TEC TEST SCHOOL,false

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DashboardsController, type: :controller do
     end
 
     it 'populates an array of uploads' do
-      expect(assigns(:uploads).length).to eq(2)
+      expect(assigns(:uploads).length).to eq(29)
     end
 
     it 'returns http success' do


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets-website/issues/10450

Generate Preview button was disabled even though a new CSV had been uploaded.

Issue was due the fact the GIDS database table Uploads was missing a row for Sec109SchoolClosure

Also include are updates to weam.csv and sec109_school_closure.csv

Reproduce by
- Checking out SHA Hash below
```
git fetch origin
git checkout 7e8c75bc9d17754f236f3e5d267823f53f738088
```
- Go to localhost:4000
- Upload a CSV
- Notice "Generate Preview" button is still disabled

## Steps to Reproduce
- Checking out SHA Hash below
```
git fetch origin
git checkout 7e8c75bc9d17754f236f3e5d267823f53f738088
```
- Remove a row from Uploads table using pgadmin
```
delete from uploads where csv_type = 'Scorecard'
```
- Go to localhost:4000
- Notice "Generate Preview" button is still disabled

## To Test
- Use this branch
- Go to localhost:4000
- Notice "Generate Preview" button is still disabled
- Hover text on "Generate Preview" should show why button is disabled
- In Latest Uploads find danger salmon colored rows with "No initial file uploaded!!!"
- Upload missing CSVs
- Notice "Generate Preview" button is now enabled