### PR TITLE
CT 116: Add "Preferred Providers" filter on the VET TEC search results #19340

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -83,6 +83,7 @@ module V0
         [:distance_learning],
         [:priority_enrollment], # boolean
         [:vet_tec_provider], # boolean
+        [:preferred_provider], # boolean
       ].each do |filter_args|
         filter_args << filter_args[0] if filter_args.size == 1
         relation = relation.filter(filter_args[0], @query[filter_args[1]])

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -138,6 +138,13 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
 
+    it 'filters by preferred_provider' do
+      create(:institution, :vet_tec_provider)
+      create(:institution, :vet_tec_preferred_provider)
+      get :index, vet_tec_provider: true, preferred_provider: true, version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+    end
+
     it 'filter by lowercase state returns results' do
       get :index, name: 'new', state: 'ny', version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(3)


### PR DESCRIPTION
## Description
As a comparison tool user, I need to be able to filter by preferred providers only so that I can limit the providers I am considering to preferred providers

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19340

## Assumptions:
1. This work will be completed behind a flag so that it is only available in the staging environments and below.
2. Preferred providers are indicated  on the WEAMS file that is loaded via GIDS.


## Testing done
- local testing

## Screenshots
<img width="530" alt="Screen Shot 2019-07-22 at 4 25 32 PM" src="https://user-images.githubusercontent.com/1094999/61662898-607a9500-ac9d-11e9-9305-02211c9f9c57.png">
<img width="905" alt="Screen Shot 2019-07-22 at 4 25 41 PM" src="https://user-images.githubusercontent.com/1094999/61662900-61abc200-ac9d-11e9-87d6-edcea4c3a765.png">


## Acceptance criteria
- [ ] There is a "Filter By" section in the "Refine Search" section of the VET TEC Search Results.
- [ ] The only option available under "Filter By" is "Preferred Providers (star img) (Learn More)"
- [ ] Clicking the "Learn More" link next to the "Preferred Providers" filter opens a modal with the following text:

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
