### PR TITLE
Remove extension institutions from search results

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -106,9 +106,7 @@ module V0
       ].each do |filter_args|
         filter_args << filter_args[0] if filter_args.size == 1
         relation = relation.filter(filter_args[0], @query[filter_args[1]])
-
-        # relation = relation.select { |institution| institution.campus_type != 'E' }
-      end
+    end
 
       relation
     end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -106,6 +106,8 @@ module V0
       ].each do |filter_args|
         filter_args << filter_args[0] if filter_args.size == 1
         relation = relation.filter(filter_args[0], @query[filter_args[1]])
+
+        # relation = relation.select { |institution| institution.campus_type != 'E' }
       end
 
       relation
@@ -170,7 +172,7 @@ module V0
     end
 
     def approved_institutions
-      Institution.version(@version[:number]).where(approved: true)
+      Institution.version(@version[:number]).where(approved: true).where("campus_type != 'E' OR campus_type IS NULL")
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -106,7 +106,7 @@ module V0
       ].each do |filter_args|
         filter_args << filter_args[0] if filter_args.size == 1
         relation = relation.filter(filter_args[0], @query[filter_args[1]])
-    end
+      end
 
       relation
     end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -170,7 +170,7 @@ module V0
     end
 
     def approved_institutions
-      Institution.version(@version[:number]).where(approved: true).where("campus_type != 'E' OR campus_type IS NULL")
+      Institution.version(@version[:number]).no_extentions.where(approved: true)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -269,4 +269,6 @@ class Institution < ActiveRecord::Base
   }
 
   scope :version, ->(n) { where(version: n) }
+
+  scope :no_extentions, -> { where("campus_type != 'E' OR campus_type IS NULL") }
 end

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -54,6 +54,7 @@ module InstitutionBuilder
     add_yellow_ribbon_programs(version_number)
     add_school_closure(version_number)
     add_vet_tec_provider(version_number)
+    add_extension_campus_type(version_number)
     add_sec109_closed_school(version_number)
     build_zip_code_rates_from_weams(version_number)
   end
@@ -497,5 +498,15 @@ module InstitutionBuilder
 
     sql = ZipcodeRate.send(:sanitize_sql, [str, version_number])
     ZipcodeRate.connection.execute(sql)
+  end
+
+  def self.add_extension_campus_type(version_number)
+    str = <<-SQL
+    UPDATE institutions SET campus_type = 'E'
+      WHERE substring(institutions.facility_code, 3 , 1) = 'X'
+        AND institutions.campus_type IS NULL
+        AND institutions.version = #{version_number};
+    SQL
+    Institution.connection.update(str)
   end
 end

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -73,9 +73,11 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'does not return results for extension institutions' do
       create(:version, :production)
-      create(:institution, :contains_harv, campus_type: 'E')
+      create(:institution, :start_like_harv, campus_type: 'E')
+      create(:institution, :start_like_harv, campus_type: 'Y')
+      create(:institution, :start_like_harv)
       get :autocomplete, term: 'harv'
-      expect(JSON.parse(response.body)['data'].count).to eq(0)
+      expect(JSON.parse(response.body)['data'].count).to eq(2)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
     end
@@ -122,8 +124,9 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     it 'do not return results for extension institutions' do
       create(:institution, :contains_harv)
       create(:institution, :contains_harv, campus_type: 'E')
+      create(:institution, :contains_harv, campus_type: 'Y')
       get :index, name: 'harv'
-      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(JSON.parse(response.body)['data'].count).to eq(2)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'does not return results for extension institutions' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: true, campus_type: 'E')
-      get :autocomplete, term: 'harv', version: 'production'
+      create(:institution, :contains_harv, campus_type: 'E')
+      get :autocomplete, term: 'harv'
       expect(JSON.parse(response.body)['data'].count).to eq(0)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
@@ -120,9 +120,9 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
 
     it 'do not return results for extension institutions' do
-      create(:institution, :contains_harv, approved: true)
-      create(:institution, :contains_harv, approved: true, campus_type: 'E')
-      get :index, name: 'harv', version: 'production'
+      create(:institution, :contains_harv)
+      create(:institution, :contains_harv, campus_type: 'E')
+      get :index, name: 'harv'
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
     end
+
+    it 'does not return results for extension institutions' do
+      create(:version, :production)
+      create(:institution, :contains_harv, approved: true, campus_type: 'E')
+      get :autocomplete, term: 'harv', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(0)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('autocomplete')
+    end
   end
 
   context 'search results' do
@@ -95,6 +104,15 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'search with space returns results' do
       get :index, name: 'New Roch', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
+    it 'do not return results for extension institutions' do
+      create(:institution, :contains_harv, approved: true)
+      create(:institution, :contains_harv, approved: true, campus_type: 'E')
+      get :index, name: 'harv', version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -63,6 +63,10 @@ FactoryGirl.define do
       facility_code '1VZZZZZZ'
     end
 
+    trait :extension do
+      facility_code '10X00000'
+    end
+
     trait :higher_learning do
       institution_of_higher_learning_indicator true
     end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -894,13 +894,18 @@ RSpec.describe InstitutionBuilder, type: :model do
     describe 'when setting extension campus_type' do
       before(:each) do
         create(:weam, :extension)
+        create(:weam, facility_code: '10X00001', campus_type: 'Y')
         InstitutionBuilder.run(user)
       end
 
-      let(:institution) { institutions.find_by(facility_code: '10X00000') }
-
       it 'sets campus_type to "E"' do
-        expect(institution.campus_type).to eq('E')
+        extension = institutions.find_by(facility_code: '10X00000')
+        expect(extension.campus_type).to eq('E')
+      end
+
+      it 'ignores for instituions with campus_type' do
+        extension = institutions.find_by(facility_code: '10X00001')
+        expect(extension.campus_type).to eq('Y')
       end
     end
   end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -890,5 +890,18 @@ RSpec.describe InstitutionBuilder, type: :model do
         expect(zipcode_rate.version).to eq(Version.current_preview.number)
       end
     end
+
+    describe 'when setting extension campus_type' do
+      before(:each) do
+        create(:weam, :extension)
+        InstitutionBuilder.run(user)
+      end
+
+      let(:institution) { institutions.find_by(facility_code: '10X00000') }
+
+      it 'sets campus_type to "E"' do
+        expect(institution.campus_type).to eq('E')
+      end
+    end
   end
 end


### PR DESCRIPTION
Remove extension institutions from search results.

```As a comparison tool user, I should not be shown extensions in the search results, because they are not considered separate institutions.```

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19462