### PR TITLE
use factories appropriate for testing autocomplete

### DIFF
--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
   end
 
-  fcontext 'autocomplete results' do
+  context 'autocomplete results' do
     it 'returns collection of matches' do
       create(:version, :production)
       2.times { create(:institution, :start_like_harv, approved: true) }

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -34,18 +34,28 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
   end
 
-  context 'autocomplete results' do
+  fcontext 'autocomplete results' do
     it 'returns collection of matches' do
       create(:version, :production)
-      7.times { create(:institution, :contains_harv, approved: true) }
+      2.times { create(:institution, :start_like_harv, approved: true) }
       get :autocomplete, term: 'harv', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(2)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('autocomplete')
+    end
+
+    it 'limits results to 6' do
+      create(:version, :production)
+      7.times { create(:institution, :start_like_harv, approved: true) }
+      get :autocomplete, term: 'harv', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(6)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
     end
 
     it 'returns empty collection on missing term parameter' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: false)
+      create(:institution, :start_like_harv, approved: false)
       get :autocomplete, term: nil, version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(0)
       expect(response.content_type).to eq('application/json')
@@ -54,7 +64,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'does not return results for non-approved institutions' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: false)
+      create(:institution, :start_like_harv, approved: false)
       get :autocomplete, term: 'harv', version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(0)
       expect(response.content_type).to eq('application/json')


### PR DESCRIPTION
Autocomplete [only matches institutions that _start_ with the search term](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/9e2dbed9455fe491e803a68243408899458a59e0/app/models/institution.rb#L216).  
I changed the used factories as appropriate.

Autocomplete also limits search to 6 by default.  Added spec for that.