### PR TITLE
Have institution factory default `approved` attribute to true

### DIFF
--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
   context 'version determination' do
     it 'uses a production version as a default' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: true)
+      create(:institution, :contains_harv)
       get :index
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -14,7 +14,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'accepts invalid version parameter and returns production data' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: true)
+      create(:institution, :contains_harv)
       get :index, version: 'invalid_data'
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -25,7 +25,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     it 'accepts version number as a version parameter and returns preview data' do
       create(:version, :production)
       v = create(:version, :preview)
-      create(:institution, :contains_harv, approved: true, version: Version.current_preview.number)
+      create(:institution, :contains_harv, version: Version.current_preview.number)
       get :index, version: v.uuid
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -37,7 +37,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
   context 'autocomplete results' do
     it 'returns collection of matches' do
       create(:version, :production)
-      2.times { create(:institution, :start_like_harv, approved: true) }
+      2.times { create(:institution, :start_like_harv) }
       get :autocomplete, term: 'harv', version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(2)
       expect(response.content_type).to eq('application/json')
@@ -75,9 +75,9 @@ RSpec.describe V0::InstitutionsController, type: :controller do
   context 'search results' do
     before(:each) do
       create(:version, :production)
-      2.times { create(:institution, :in_nyc, approved: true) }
-      create(:institution, :in_chicago, online_only: true, approved: true)
-      create(:institution, :in_new_rochelle, distance_learning: true, approved: true)
+      2.times { create(:institution, :in_nyc) }
+      create(:institution, :in_chicago, online_only: true)
+      create(:institution, :in_new_rochelle, distance_learning: true)
       # adding a non approved institutions row
       create(:institution, :contains_harv, approved: false)
     end
@@ -210,8 +210,8 @@ RSpec.describe V0::InstitutionsController, type: :controller do
   context 'category and type search results' do
     before(:each) do
       create(:version, :production)
-      create(:institution, :in_nyc, approved: true)
-      create(:institution, :ca_employer, approved: true)
+      create(:institution, :in_nyc)
+      create(:institution, :ca_employer)
     end
 
     it 'filters by employer category' do
@@ -249,7 +249,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
 
     it 'returns profile details' do
-      school = create(:institution, :in_chicago, approved: true)
+      school = create(:institution, :in_chicago)
       get :show, id: school.facility_code, version: school.version
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_profile')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
   end
 
-  fcontext 'autocomplete results' do
+  context 'autocomplete results' do
     it 'returns collection of matches' do
       create(:version, :production)
       2.times { create(:institution, :start_like_harv, approved: true) }

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -34,18 +34,28 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
   end
 
-  context 'autocomplete results' do
+  fcontext 'autocomplete results' do
     it 'returns collection of matches' do
       create(:version, :production)
-      7.times { create(:institution, :contains_harv, approved: true) }
+      2.times { create(:institution, :start_like_harv, approved: true) }
       get :autocomplete, term: 'harv', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(2)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('autocomplete')
+    end
+
+    it 'limits results to 6' do
+      create(:version, :production)
+      7.times { create(:institution, :start_like_harv, approved: true) }
+      get :autocomplete, term: 'harv', version: 'production'
+      expect(JSON.parse(response.body)['data'].count).to eq(6)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('autocomplete')
     end
 
     it 'returns empty collection on missing term parameter' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: false)
+      create(:institution, :start_like_harv, approved: false)
       get :autocomplete, term: nil, version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(0)
       expect(response.content_type).to eq('application/json')
@@ -54,7 +64,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'does not return results for non-approved institutions' do
       create(:version, :production)
-      create(:institution, :contains_harv, approved: false)
+      create(:institution, :start_like_harv, approved: false)
       get :autocomplete, term: 'harv', version: 'production'
       expect(JSON.parse(response.body)['data'].count).to eq(0)
       expect(response.content_type).to eq('application/json')

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     sequence(:insturl) { |n| "www.school.edu/#{n}" }
     institution_type_name 'PRIVATE'
     version 1
+    approved true
 
     trait :in_nyc do
       city 'NEW YORK'
@@ -89,7 +90,6 @@ FactoryGirl.define do
       state 'SC'
       country 'USA'
       vet_tec_provider true
-      approved true
     end
 
     trait :vet_tec_preferred_provider do
@@ -98,7 +98,6 @@ FactoryGirl.define do
       state 'SC'
       country 'USA'
       vet_tec_provider true
-      approved true
       preferred_provider true
     end
 

--- a/spec/request/institutions_request_spec.rb
+++ b/spec/request/institutions_request_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe 'institutions', type: :request do
     end
 
     it 'allow searching by address fields' do
-      institution = create(:institution, address_1: 'address_1', version: Version.current_production.number,
-                                         approved: true)
+      institution = create(:institution, address_1: 'address_1', version: Version.current_production.number)
       get(v0_institutions_path(name: 'address_1', include_address: true))
       data = JSON.parse(response.body)['data'][0]
       expect(data['id'].to_i).to eq(institution.id)
@@ -68,7 +67,7 @@ RSpec.describe 'institutions', type: :request do
 
   context '#show' do
     it 'uses LINK_HOST in self link' do
-      school = create(:institution, :contains_harv, version: Version.current_production.number, approved: true)
+      school = create(:institution, :contains_harv, version: Version.current_production.number)
       get "/v0/institutions/#{school.facility_code}"
       links = JSON.parse(response.body)['links']
       expect(links['self']).to start_with(ENV['LINK_HOST'])


### PR DESCRIPTION
In order to make our specs less brittle, I'm giving the `approved` attribute a default value of true since it's a necessary value for results to be returned by search.
It's too easy to forget to set it every time when writing specs.