### PR TITLE
update VET TEC law code constant

### DIFF
--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -10,7 +10,7 @@
 class Weam < ActiveRecord::Base
   include CsvHelper
 
-  REQUIRED_VET_TEC_LAW_CODE = 'Educational Institution is Approved For Vet Tec Only'
+  REQUIRED_VET_TEC_LAW_CODE = 'educational institution is approved for vet tec only'
 
   LAW_CODES_BLOCKING_APPROVED_STATUS = [
     'educational institution is not approved',

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -12,7 +12,7 @@ class Weam < ActiveRecord::Base
 
   ALC1 = 'educational institution is not approved'
   ALC2 = 'educational institution is approved for chapter 31 only'
-  ALCVT = 'vet tec only'
+  ALCVT = 'Educational Institution is Approved For Vet Tec Only'
 
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -12,7 +12,7 @@ class Weam < ActiveRecord::Base
 
   ALC1 = 'educational institution is not approved'
   ALC2 = 'educational institution is approved for chapter 31 only'
-  ALCVT = 'Educational Institution is Approved For Vet Tec Only'
+  ALCVT = 'educational institution is approved for vet tec only'
 
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -109,7 +109,7 @@ FactoryGirl.define do
 
     trait :as_vet_tec_provider do
       poo_status 'aprvd'
-      applicable_law_code 'vet tec only'
+      applicable_law_code 'Educational Institution is Approved For Vet Tec Only'
       non_college_degree_indicator true
     end
 

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -110,7 +110,7 @@ FactoryGirl.define do
     trait :as_vet_tec_provider do
       facility_code '1VZZZZZZ'
       poo_status 'aprvd'
-      applicable_law_code 'Educational Institution is Approved For Vet Tec Only'
+      applicable_law_code 'educational institution is approved for vet tec only'
       non_college_degree_indicator true
     end
 


### PR DESCRIPTION
As a developer, I need to update the logic that determines when to show a VET TEC provider to use the correct applicable law code so that the comparison tool continues to display the correct information.

The associated constant used to be "VET TEC ONLY".

When GIDS ingests the weams.csv file, facilities with the applicable law code "Educational Institution is Approved For Vet Tec Only" are considered approved vet tec providers.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19470