### PR TITLE
19790: GIDS: Update sentry-raven to same version as vets-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'cancancan', '~> 1.13', '>= 1.13.1'
 gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 0.15'
-gem 'sentry-raven', '~> 2.3.0'
+gem 'sentry-raven', '~> 2.9.0'
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,7 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (2.3.1)
+    sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     simplecov (0.17.1)
@@ -435,7 +435,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)
-  sentry-raven (~> 2.3.0)
+  sentry-raven (~> 2.9.0)
   simplecov
   sitemap_generator (~> 5.3, >= 5.3.1)
   smarter_csv (= 1.1.4)


### PR DESCRIPTION
#### Description:
As a developer, I need to update sentry-raven so that GIDS uses the same version as vets-api.

#### Issue *(Zenhub)*:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19790

#### Testing:
Local E2E testing passes.