### PR TITLE
Update loofah

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       activesupport (>= 4.2)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-schema (~> 1.0)
-    crass (1.0.4)
+    crass (1.0.5)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
@@ -210,7 +210,7 @@ GEM
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.3.0)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -284,7 +284,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -462,4 +462,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,4 +462,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19824

Update `loofah` to resolve security vulnerability

Updated rake version to resolve:

```

  In Gemfile:
    jquery-ui-rails was resolved to 6.0.1, which depends on
      railties (>= 3.2.16) was resolved to 5.2.3, which depends on
        rake (>= 0.8.7)

    scss_lint was resolved to 0.58.0, which depends on
      rake (< 13, >= 0.9)

```


https://github.com/flavorjones/loofah/issues/171