### PR TITLE
improve InstitutionProgram factory

### DIFF
--- a/spec/factories/institution_programs.rb
+++ b/spec/factories/institution_programs.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     vet_tec_program { 'COMPUTER SCIENCE' }
     tuition_amount { '360' }
     length_in_weeks { '1001' }
+    institution
 
     trait :start_like_harv do
       sequence(:description) { |n| ["HARV#{n}", "HARV #{n}"].sample }
@@ -31,36 +32,19 @@ FactoryBot.define do
     end
 
     trait :in_nyc do
-      before :create do |institution_program|
-        institution = create(:institution, physical_city: 'NEW YORK', physical_country: 'USA', physical_state: 'NY')
-        institution_program.institution = institution
-      end
+      institution { create(:institution, physical_city: 'NEW YORK', physical_country: 'USA', physical_state: 'NY') }
     end
 
     trait :in_new_rochelle do
-      before :create do |institution_program|
-        institution = create(:institution, physical_city: 'NEW ROCHELLE', physical_country: 'USA', physical_state: 'NY')
-        institution_program.institution = institution
-      end
+      institution { create(:institution, physical_city: 'NEW ROCHELLE', physical_country: 'USA', physical_state: 'NY') }
     end
 
     trait :in_chicago do
-      before :create do |institution_program|
-        institution = create(:institution, physical_city: 'CHICAGO', physical_country: 'USA', physical_state: 'IL')
-        institution_program.institution = institution
-      end
+      institution { create(:institution, physical_city: 'CHICAGO', physical_country: 'USA', physical_state: 'IL') }
     end
 
     trait :preferred_provider do
-      before :create do |institution_program|
-        institution = create(:institution, preferred_provider: true)
-        institution_program.institution = institution
-      end
-    end
-
-    before :create do |institution_program|
-      institution = create :institution
-      institution_program.institution = institution
+      institution { create(:institution, preferred_provider: true) }
     end
   end
 end

--- a/spec/models/institution_program_spec.rb
+++ b/spec/models/institution_program_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe InstitutionProgram, type: :model do
   describe 'when validating' do
-    subject { create :institution_program, institution_id: institution.id }
+    subject { create :institution_program, institution: institution }
 
     let(:institution) { create :institution, :physical_address }
 
@@ -13,15 +13,15 @@ RSpec.describe InstitutionProgram, type: :model do
     end
 
     it 'requires a version' do
-      expect(build(:institution_program, institution_id: institution.id, version: nil)).not_to be_valid
+      expect(build(:institution_program, institution: institution, version: nil)).not_to be_valid
     end
 
     it 'requires an institution' do
-      expect(build(:institution_program)).not_to be_valid
+      expect(build(:institution_program, institution: nil)).not_to be_valid
     end
 
     it 'requires a description' do
-      expect(build(:institution_program, institution_id: institution.id, description: nil)).not_to be_valid
+      expect(build(:institution_program, institution: institution, description: nil)).not_to be_valid
     end
   end
 
@@ -55,15 +55,15 @@ RSpec.describe InstitutionProgram, type: :model do
       let(:institution) { create :institution, :physical_address }
 
       it 'retrieves institutions by a specific version number' do
-        i = create_list :institution_program, 2, version: 1, institution_id: institution.id
-        j = create_list :institution_program, 2, version: 2, institution_id: institution.id
+        i = create_list :institution_program, 2, version: 1, institution: institution
+        j = create_list :institution_program, 2, version: 2, institution: institution
 
         expect(described_class.version(i.first.version)).to match_array(i.to_a)
         expect(described_class.version(j.first.version)).to match_array(j.to_a)
       end
 
       it 'returns blank if a nil or non-existent version number is supplied' do
-        create :institution_program, institution_id: institution.id
+        create :institution_program, institution: institution
 
         expect(described_class.version(-1)).to eq([])
         expect(described_class.version(nil)).to eq([])


### PR DESCRIPTION
## Description
Because of presence of the below block in the `InstitutionProgram` factory, extraneous `Institution` records are created when if you specify an `institution` when creating your `InstitutionProgram` factory object (e.g. `create(:institution_program, institution: inst)`)
```
   before :create do |institution_program|
      institution = create :institution
      institution_program.institution = institution
    end
```
In this PR, we refactor `InstitutionProgram` factory so that extraneous `Institution` objects are not created upon creation of `InstitutionProgram` objects

Note: this is a PR to another feature branch

## Testing done
specs

## Acceptance criteria
- [x] expected number of `Institution` objects are created upon creation of `InstitutionProgram` objects

## Definition of done
- [ ] ~~Events are logged appropriately~~
- [ ] ~~Documentation has been updated, if applicable~~
- [ ] ~~A link has been provided to the originating GitHub issue (or connected to it via ZenHub)~~
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs