### PR TITLE
remove usage of `InstitutionProgram`'s `version` attribute

### DIFF
--- a/app/models/institution_program.rb
+++ b/app/models/institution_program.rb
@@ -86,5 +86,5 @@ class InstitutionProgram < ApplicationRecord
     end
   }
 
-  scope :version, ->(n) { where(version: n) }
+  scope :version, ->(n) { joins(:institution).where(institutions: { version: n }) }
 end

--- a/spec/controllers/v0/institution_programs_controller_spec.rb
+++ b/spec/controllers/v0/institution_programs_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe V0::InstitutionProgramsController, type: :controller do
     end
 
     it 'search returns results for correct version only' do
-      create(:institution_program, version: 2)
+      create(:institution_program, version: 2, institution: create(:institution, version: 2))
       get(:index)
       expect(JSON.parse(response.body)['data'].count).to eq(4)
       expect(response.content_type).to eq('application/json')

--- a/spec/models/institution_program_spec.rb
+++ b/spec/models/institution_program_spec.rb
@@ -52,11 +52,12 @@ RSpec.describe InstitutionProgram, type: :model do
 
   describe 'class methods and scopes' do
     context 'version' do
-      let(:institution) { create :institution, :physical_address }
+      let(:institution_1) { create :institution, :physical_address }
+      let(:institution_2) { create :institution, :physical_address, version: 2 }
 
       it 'retrieves institutions by a specific version number' do
-        i = create_list :institution_program, 2, version: 1, institution: institution
-        j = create_list :institution_program, 2, version: 2, institution: institution
+        i = create_list :institution_program, 2, version: 1, institution: institution_1
+        j = create_list :institution_program, 2, version: 2, institution: institution_2
 
         expect(described_class.version(i.first.version)).to match_array(i.to_a)
         expect(described_class.version(j.first.version)).to match_array(j.to_a)


### PR DESCRIPTION
## Description
This PR removes the need for `InstitutionProgram` to have a `version` attribute.
Since every `Institution` has a `version` and every `InstitutionProgram` `belongs_to` an `Institution`, a `version` attribute on `InstitutionProgram` is extraneous.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs