### PR TITLE
Update brakeman to 4.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     bcrypt (3.1.13)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    brakeman (4.6.1)
+    brakeman (4.7.1)
     builder (3.2.3)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)


### PR DESCRIPTION
## Description
Builds fails when running `bundle exec rake ci` with message

```
== Warning Types ==


No warnings found

running bundle-audit to check for insecure dependencies...
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
   75e23ae..d21defa  master     -> origin/master
Updating 75e23ae..d21defa
Fast-forward
 CONTRIBUTING.md                            | 30 ++++++++++++++++--------------
 CONTRIBUTORS.md                            |  1 +
 README.md                                  | 26 ++++++++++++++------------
 gems/brakeman/CVE-2019-18409.yml           | 26 ++++++++++++++++++++++++++
 gems/chartkick/CVE-2019-18841.yml          | 13 +++++++++++++
 gems/ruby_parser-legacy/CVE-2019-18409.yml | 16 ++++++++++++++++
 6 files changed, 86 insertions(+), 26 deletions(-)
 create mode 100644 gems/brakeman/CVE-2019-18409.yml
 create mode 100644 gems/chartkick/CVE-2019-18841.yml
 create mode 100644 gems/ruby_parser-legacy/CVE-2019-18409.yml
Updated ruby-advisory-db
ruby-advisory-db: 411 advisories
Name: brakeman
Version: 4.6.1
Advisory: CVE-2019-18409
Criticality: Medium
URL: https://brakemanscanner.org/blog/2019/10/14/brakeman-4-dot-7-dot-1-released
Title: brakeman world writable files allow local privilege escalation
Solution: upgrade to >= 4.7.1

Vulnerabilities found!
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs