### PR TITLE
Working to reduce db migration noise

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,11 +49,13 @@ pipeline {
 
         build job: 'deploys/gi-bill-data-service-vagov-dev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
+          booleanParam(name: 'migration_status', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
 
         build job: 'deploys/gi-bill-data-service-vagov-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),
+          booleanParam(name: 'migration_status', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
       }


### PR DESCRIPTION
**Refs: https://github.com/department-of-veterans-affairs/va.gov-team/issues/2514 && https://github.com/department-of-veterans-affairs/devops/pull/5923**

Working to reduce the duplication of vets-api-worker and vets-api-server warnings for database migrations (we think just having server post will suffice). Setting the parameter for migration_status on the apps specifically for deploys/releases will help accomplish this.