### PR TITLE
update nokogiri to 1.10.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.3)
       nenv (~> 0.1)


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/gibct-data-service/pull/498
is failing due to 

```
ruby-advisory-db: 421 advisories
Name: nokogiri
Version: 1.10.4
Advisory: CVE-2019-13117
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1943
Title: Nokogiri gem, via libxslt, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.10.5

Vulnerabilities found!

Failed. Security vulnerabilities were found.
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs