### PR TITLE
For CSV upload, add batch_size to CSV active_record#import

### DIFF
--- a/app/models/gibct_site_mapper.rb
+++ b/app/models/gibct_site_mapper.rb
@@ -32,7 +32,7 @@ class GibctSiteMapper
     SitemapGenerator::Sitemap.create do
       add '/search', priority: 0.9, changefreq: 'monthly'
 
-      Institution.version(version).find_each(batch_size: Settings.active_record.batch_size) do |institution|
+      Institution.version(version).find_each(batch_size: Settings.active_record.batch_size.find_each) do |institution|
         add "/profile/#{institution.facility_code}", priority: 0.8, changefreq: 'weekly'
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,5 @@
 active_record:
-  batch_size: 5000
+  batch_size: 50000
 
 archiver:
   archive: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 active_record:
-  batch_size: 50000
+  batch_size:
+    find_each: 5000
+    import: 50000
 
 archiver:
   archive: true

--- a/lib/csv_helper/exporter.rb
+++ b/lib/csv_helper/exporter.rb
@@ -40,13 +40,13 @@ module CsvHelper
     end
 
     def write_row(csv, csv_headers)
-      klass.find_each(batch_size: Settings.active_record.batch_size) do |record|
+      klass.find_each(batch_size: Settings.active_record.batch_size.find_each) do |record|
         csv << csv_headers.keys.map { |k| format(k, record.public_send(k)) }
       end
     end
 
     def write_institution_row(csv, csv_headers, number)
-      Institution.where(version: number).find_each(batch_size: Settings.active_record.batch_size) do |record|
+      Institution.where(version: number).find_each(batch_size: Settings.active_record.batch_size.find_each) do |record|
         csv << csv_headers.keys.map { |k| record.public_send(k) == false ? nil : format(k, record.public_send(k)) }
       end
     end

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -20,7 +20,7 @@ module CsvHelper
       records = []
 
       records = klass == Institution ? load_csv_with_version(file, records, options) : load_csv(file, records, options)
-      results = klass.import records, ignore: true, batch_size: Settings.active_record.batch_size
+      results = klass.import records, ignore: true, batch_size: Settings.active_record.batch_size.import
       after_import_validations(records, results.failed_instances, options)
       results
     end

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -20,7 +20,7 @@ module CsvHelper
       records = []
 
       records = klass == Institution ? load_csv_with_version(file, records, options) : load_csv(file, records, options)
-      results = klass.import records, ignore: true
+      results = klass.import records, ignore: true, batch_size: Settings.active_record.batch_size
       after_import_validations(records, results.failed_instances, options)
       results
     end


### PR DESCRIPTION
## Description
Add a configurable batch size property to the active_record#import statement for CSV uploads
Bumping property value from 5000 to 50,000 as file that is requiring this change has almost 400,000 rows and next largest file only has around 70,000 rows
## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] can upload a CSV through GIDs frontend
- [ ] can "publish to production" 
- [ ] sitemap generation succeeds in the server log during "publish to production"
- [ ] can export a CSV type through GIDs frontend

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs