### PR TITLE
Drop `institutions_archives` indexes.  Rename `institutions` indexes

### DIFF
--- a/db/migrate/20191216192736_remove_institutions_archives_indexes.rb
+++ b/db/migrate/20191216192736_remove_institutions_archives_indexes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveInstitutionsArchivesIndexes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      ActiveRecord::Base.connection.indexes('institutions_archives').map(&:name).each do |index_name|
+        remove_index :institutions_archives, name: index_name, algorithm: :concurrently
+      end
+    end
+  end
+end

--- a/db/migrate/20191216192846_rename_indexes.rb
+++ b/db/migrate/20191216192846_rename_indexes.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class RenameIndexes < ActiveRecord::Migration[5.2]
+  def up
+    institutions_indexes = ActiveRecord::Base.connection.indexes('institutions').map(&:name)
+    if institutions_indexes.include?('institutions_temp_lower_idx')
+      rename_index :institutions, 'institutions_temp_lower_idx', 'index_institutions_institution_lprefix'
+    end
+
+    if index_exists?(:institutions, :address_1, name: 'institutions_temp_address_1_idx')
+      rename_index :institutions, 'institutions_temp_address_1_idx', 'index_institutions_on_address_1'
+    end
+
+    if index_exists?(:institutions, :address_2, name: 'institutions_temp_address_2_idx')
+      rename_index :institutions, 'institutions_temp_address_2_idx', 'index_institutions_on_address_2'
+    end
+
+    if index_exists?(:institutions, :address_3, name: 'institutions_temp_address_3_idx')
+      rename_index :institutions, 'institutions_temp_address_3_idx', 'index_institutions_on_address_3'
+    end
+
+    if index_exists?(:institutions, :city, name: 'institutions_temp_city_idx')
+      rename_index :institutions, 'institutions_temp_city_idx', 'index_institutions_on_city'
+    end
+
+    if index_exists?(:institutions, :cross, name: 'institutions_temp_cross_idx')
+      rename_index :institutions, 'institutions_temp_cross_idx', 'index_institutions_on_cross'
+    end
+
+    if index_exists?(:institutions, :distance_learning, name: 'institutions_temp_distance_learning_idx')
+      rename_index :institutions, 'institutions_temp_distance_learning_idx', 'index_institutions_on_distance_learning'
+    end
+
+    if index_exists?(:institutions, :facility_code, name: 'institutions_temp_facility_code_idx')
+      rename_index :institutions, 'institutions_temp_facility_code_idx', 'index_institutions_on_facility_code'
+    end
+
+    if index_exists?(:institutions, :institution, name: 'institutions_temp_institution_idx')
+      rename_index :institutions, 'institutions_temp_institution_idx', 'index_institutions_on_institution'
+    end
+
+    if index_exists?(:institutions, :institution_type_name, name: 'institutions_temp_institution_type_name_idx')
+      rename_index(:institutions,
+                   'institutions_temp_institution_type_name_idx',
+                   'index_institutions_on_institution_type_name')
+    end
+
+    if index_exists?(:institutions, :online_only, name: 'institutions_temp_online_only_idx')
+      rename_index :institutions, 'institutions_temp_online_only_idx', 'index_institutions_on_online_only'
+    end
+
+    if index_exists?(:institutions, :ope, name: 'institutions_temp_ope_idx')
+      rename_index :institutions, 'institutions_temp_ope_idx', 'index_institutions_on_ope'
+    end
+
+    if index_exists?(:institutions, :ope6, name: 'institutions_temp_ope6_idx')
+      rename_index :institutions, 'institutions_temp_ope6_idx', 'index_institutions_on_ope6'
+    end
+
+    if index_exists?(:institutions, :state, name: 'institutions_temp_state_idx')
+      rename_index :institutions, 'institutions_temp_state_idx', 'index_institutions_on_state'
+    end
+
+    if index_exists?(:institutions, :stem_offered, name: 'institutions_temp_stem_offered_idx')
+      rename_index :institutions, 'institutions_temp_stem_offered_idx', 'index_institutions_on_stem_offered'
+    end
+
+    if index_exists?(:institutions,
+                     %i[version parent_facility_code_id],
+                     name: 'institutions_temp_version_parent_facility_code_id_idx')
+      rename_index(:institutions,
+                   'institutions_temp_version_parent_facility_code_id_idx',
+                   'index_institutions_on_version_and_parent_facility_code_id')
+    end
+
+    if index_exists?(:institutions, :version, name: 'institutions_temp_version_idx')
+      rename_index :institutions, 'institutions_temp_version_idx', 'index_institutions_on_version'
+    end
+  end
+  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_192035) do
+ActiveRecord::Schema.define(version: 2019_12_16_192736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -510,23 +510,6 @@ ActiveRecord::Schema.define(version: 2019_12_16_192035) do
     t.boolean "stem_indicator", default: false
     t.string "campus_type"
     t.string "parent_facility_code_id"
-    t.index "lower((institution)::text) text_pattern_ops", name: "index_institutions_institution_lprefix"
-    t.index ["address_1"], name: "index_institutions_on_address_1"
-    t.index ["address_2"], name: "index_institutions_on_address_2"
-    t.index ["address_3"], name: "index_institutions_on_address_3"
-    t.index ["city"], name: "index_institutions_on_city"
-    t.index ["cross"], name: "index_institutions_on_cross"
-    t.index ["distance_learning"], name: "index_institutions_on_distance_learning"
-    t.index ["facility_code"], name: "index_institutions_on_facility_code"
-    t.index ["institution"], name: "index_institutions_on_institution"
-    t.index ["institution_type_name"], name: "index_institutions_on_institution_type_name"
-    t.index ["online_only"], name: "index_institutions_on_online_only"
-    t.index ["ope"], name: "index_institutions_on_ope"
-    t.index ["ope6"], name: "index_institutions_on_ope6"
-    t.index ["state"], name: "index_institutions_on_state"
-    t.index ["stem_offered"], name: "index_institutions_on_stem_offered"
-    t.index ["version", "parent_facility_code_id"], name: "index_institutions_on_version_and_parent_facility_code_id"
-    t.index ["version"], name: "index_institutions_on_version"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_192736) do
+ActiveRecord::Schema.define(version: 2019_12_16_192846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,23 +370,23 @@ ActiveRecord::Schema.define(version: 2019_12_16_192736) do
     t.boolean "stem_indicator", default: false
     t.string "campus_type"
     t.string "parent_facility_code_id"
-    t.index "lower((institution)::text) text_pattern_ops", name: "institutions_temp_lower_idx"
-    t.index ["address_1"], name: "institutions_temp_address_1_idx"
-    t.index ["address_2"], name: "institutions_temp_address_2_idx"
-    t.index ["address_3"], name: "institutions_temp_address_3_idx"
-    t.index ["city"], name: "institutions_temp_city_idx"
-    t.index ["cross"], name: "institutions_temp_cross_idx"
-    t.index ["distance_learning"], name: "institutions_temp_distance_learning_idx"
-    t.index ["facility_code"], name: "institutions_temp_facility_code_idx"
-    t.index ["institution"], name: "institutions_temp_institution_idx"
-    t.index ["institution_type_name"], name: "institutions_temp_institution_type_name_idx"
-    t.index ["online_only"], name: "institutions_temp_online_only_idx"
-    t.index ["ope"], name: "institutions_temp_ope_idx"
-    t.index ["ope6"], name: "institutions_temp_ope6_idx"
-    t.index ["state"], name: "institutions_temp_state_idx"
-    t.index ["stem_offered"], name: "institutions_temp_stem_offered_idx"
-    t.index ["version", "parent_facility_code_id"], name: "institutions_temp_version_parent_facility_code_id_idx"
-    t.index ["version"], name: "institutions_temp_version_idx"
+    t.index "lower((institution)::text) text_pattern_ops", name: "index_institutions_institution_lprefix"
+    t.index ["address_1"], name: "index_institutions_on_address_1"
+    t.index ["address_2"], name: "index_institutions_on_address_2"
+    t.index ["address_3"], name: "index_institutions_on_address_3"
+    t.index ["city"], name: "index_institutions_on_city"
+    t.index ["cross"], name: "index_institutions_on_cross"
+    t.index ["distance_learning"], name: "index_institutions_on_distance_learning"
+    t.index ["facility_code"], name: "index_institutions_on_facility_code"
+    t.index ["institution"], name: "index_institutions_on_institution"
+    t.index ["institution_type_name"], name: "index_institutions_on_institution_type_name"
+    t.index ["online_only"], name: "index_institutions_on_online_only"
+    t.index ["ope"], name: "index_institutions_on_ope"
+    t.index ["ope6"], name: "index_institutions_on_ope6"
+    t.index ["state"], name: "index_institutions_on_state"
+    t.index ["stem_offered"], name: "index_institutions_on_stem_offered"
+    t.index ["version", "parent_facility_code_id"], name: "index_institutions_on_version_and_parent_facility_code_id"
+    t.index ["version"], name: "index_institutions_on_version"
   end
 
   create_table "institutions_archives", id: :integer, default: -> { "nextval('institutions_id_seq'::regclass)" }, force: :cascade do |t|


### PR DESCRIPTION
## Description
* migration to remove all indexes from the `institutions_archives` table
* migration to rename indexes on the `institutions` table, if they are misnamed

These migrations have been created to fix inconsistencies across environments, and do not require rollback paths.

More background can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4309).

## Testing done
local experimentation

## Screenshots


## Acceptance criteria
- [x] indexes are removed and renamed as appropriate

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs