### PR TITLE
remove dir at the end of a ci run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,7 @@ pipeline {
   post {
     always {
       sh 'make clean'
+      deleteDir()
     }
   }
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,8 +6,6 @@ services:
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
-    volumes:
-      - "./data:/var/lib/postgresql/data"
     command: "postgres -c 'bytea_output=escape'"
   gibct:
     build:


### PR DESCRIPTION
## Description

fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/4603

The attempted `data` directory cleanup wasn't working. This was happening because the CI runs were mounting a volume to the pwd to store the database. We weren't influencing the user running in the container in any way, so the files were ending up being owned by an unknown user and root group. This prevented the Jenkins user from doing anything with the directory to clean it up.

I discovered that we already had a separate `test` Docker Compose file, so we could just prevent this situation in the first place by not using an image when running in CI. It doesn't change the behavior for local development.

I also added a `deleteDir()` at the end of the Jenkinsfile to clean up the workspace directory and make sure any future items like this get caught by CI.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs