### PR TITLE
Remove quotation marks from SCO csv during upload

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -57,7 +57,12 @@ class UploadsController < ApplicationController
     upload = Upload.new(csv_type: csv_type)
     upload.skip_lines = defaults(csv_type)['skip_lines']
     upload.col_sep = defaults(csv_type)['col_sep']
-
+    unless defaults(csv_type)['force_simple_split'].nil?
+      upload.force_simple_split = defaults(csv_type)['force_simple_split']
+    end
+    unless defaults(csv_type)['strip_chars_from_headers'].nil?
+      upload.strip_chars_from_headers = defaults(csv_type)['strip_chars_from_headers']
+    end
     upload
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -88,19 +88,19 @@ class UploadsController < ApplicationController
     @upload_params ||= params.require(:upload).permit(:csv_type, :skip_lines, :col_sep, :upload_file, :comment)
   end
 
-  def call_load
-    file = @upload.upload_file.tempfile
+  def set_options
     csv_type = @upload.csv_type
-    options = {}
-    options[:skip_lines] = @upload.skip_lines.try(:to_i)
-    options[:col_sep] = @upload.col_sep
-    unless defaults(csv_type)['force_simple_split'].nil?
+    options = { skip_lines: @upload.skip_lines.try(:to_i), col_sep: @upload.col_sep }
+    unless defaults(csv_type)['force_simple_split'].nil? && defaults(csv_type)['strip_chars_from_headers'].nil?
       options[:force_simple_split] = defaults(csv_type)['force_simple_split']
-    end
-    unless defaults(csv_type)['strip_chars_from_headers'].nil?
       options[:strip_chars_from_headers] = defaults(csv_type)['strip_chars_from_headers']
     end
+    options
+  end
 
+  def call_load
+    file = @upload.upload_file.tempfile
+    options = set_options
 
     CrosswalkIssue.delete_all if [Crosswalk, IpedsHd, Weam].include?(klass)
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -90,9 +90,15 @@ class UploadsController < ApplicationController
 
   def call_load
     file = @upload.upload_file.tempfile
-    skip_lines = @upload.skip_lines.try(:to_i)
-    col_sep = @upload.col_sep
-    data = klass.load(file, skip_lines: skip_lines, col_sep: col_sep)
+    csv_type = @upload.csv_type
+    options = {}
+    unless defaults(csv_type)['force_simple_split'].nil?
+      options[:force_simple_split] = defaults(csv_type)['force_simple_split']
+    end
+    unless defaults(csv_type)['strip_chars_from_headers'].nil?
+      options[:strip_chars_from_headers] = defaults(csv_type)['strip_chars_from_headers']
+    end
+    data = klass.load(file, options)
 
     @upload.update(ok: data.present? && data.ids.present?)
     error_msg = "There was no saved #{klass} data. Please check \"Skip lines before header\" or \"Column separator\"."

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -92,12 +92,15 @@ class UploadsController < ApplicationController
     file = @upload.upload_file.tempfile
     csv_type = @upload.csv_type
     options = {}
+    options[:skip_lines] = @upload.skip_lines
+    options[:col_sep] = @upload.col_sep
     unless defaults(csv_type)['force_simple_split'].nil?
       options[:force_simple_split] = defaults(csv_type)['force_simple_split']
     end
     unless defaults(csv_type)['strip_chars_from_headers'].nil?
       options[:strip_chars_from_headers] = defaults(csv_type)['strip_chars_from_headers']
     end
+
     data = klass.load(file, options)
 
     @upload.update(ok: data.present? && data.ids.present?)

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -92,7 +92,7 @@ class UploadsController < ApplicationController
     file = @upload.upload_file.tempfile
     csv_type = @upload.csv_type
     options = {}
-    options[:skip_lines] = @upload.skip_lines
+    options[:skip_lines] = @upload.skip_lines.try(:to_i)
     options[:col_sep] = @upload.col_sep
     unless defaults(csv_type)['force_simple_split'].nil?
       options[:force_simple_split] = defaults(csv_type)['force_simple_split']

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -57,12 +57,9 @@ class UploadsController < ApplicationController
     upload = Upload.new(csv_type: csv_type)
     upload.skip_lines = defaults(csv_type)['skip_lines']
     upload.col_sep = defaults(csv_type)['col_sep']
-    unless defaults(csv_type)['force_simple_split'].nil?
-      upload.force_simple_split = defaults(csv_type)['force_simple_split']
-    end
-    unless defaults(csv_type)['strip_chars_from_headers'].nil?
-      upload.strip_chars_from_headers = defaults(csv_type)['strip_chars_from_headers']
-    end
+    upload.force_simple_split = defaults(csv_type)['force_simple_split']
+    upload.strip_chars_from_headers = defaults(csv_type)['strip_chars_from_headers']
+    # end
     upload
   end
 
@@ -90,11 +87,10 @@ class UploadsController < ApplicationController
 
   def set_options
     csv_type = @upload.csv_type
-    options = { skip_lines: @upload.skip_lines.try(:to_i), col_sep: @upload.col_sep }
-    unless defaults(csv_type)['force_simple_split'].nil? && defaults(csv_type)['strip_chars_from_headers'].nil?
-      options[:force_simple_split] = defaults(csv_type)['force_simple_split']
-      options[:strip_chars_from_headers] = defaults(csv_type)['strip_chars_from_headers']
-    end
+    options = { skip_lines: @upload.skip_lines.try(:to_i),
+                col_sep: @upload.col_sep,
+                force_simple_split: defaults(csv_type)['force_simple_split'],
+                strip_chars_from_headers: defaults(csv_type)['strip_chars_from_headers'] }
     options
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -59,7 +59,6 @@ class UploadsController < ApplicationController
     upload.col_sep = defaults(csv_type)['col_sep']
     upload.force_simple_split = defaults(csv_type)['force_simple_split']
     upload.strip_chars_from_headers = defaults(csv_type)['strip_chars_from_headers']
-    # end
     upload
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Upload < ApplicationRecord
-  attr_accessor :skip_lines, :col_sep, :upload_file, :missing_headers, :extra_headers
+  attr_accessor :skip_lines, :col_sep, :upload_file, :missing_headers, :extra_headers,
+                :force_simple_split, :strip_chars_from_headers
 
   belongs_to :user, inverse_of: :versions
 

--- a/config/csv_file_defaults.yml
+++ b/config/csv_file_defaults.yml
@@ -129,6 +129,8 @@ Program:
 SchoolCertifyingOfficial:
   skip_lines: 0
   col_sep: ","
+  force_simple_split: true
+  strip_chars_from_headers: /[\-"]/
 
 EduProgram:
   skip_lines: 0

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -6,7 +6,8 @@ module CsvHelper
 
     SMARTER_CSV_OPTIONS = {
       force_utf8: true, remove_zero_values: false, remove_empty_hashes: true,
-      remove_empty_values: true, convert_values_to_numeric: false, remove_unmapped_keys: true
+      remove_empty_values: true, convert_values_to_numeric: false, remove_unmapped_keys: true,
+      force_simple_split: true, strip_chars_from_headers: /[\-"]/
     }.freeze
 
     def load(file, options = {})

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -6,8 +6,7 @@ module CsvHelper
 
     SMARTER_CSV_OPTIONS = {
       force_utf8: true, remove_zero_values: false, remove_empty_hashes: true,
-      remove_empty_values: true, convert_values_to_numeric: false, remove_unmapped_keys: true,
-      force_simple_split: true, strip_chars_from_headers: /[\-"]/
+      remove_empty_values: true, convert_values_to_numeric: false, remove_unmapped_keys: true
     }.freeze
 
     def load(file, options = {})

--- a/sample_csvs/program.csv
+++ b/sample_csvs/program.csv
@@ -1,2 +1,3 @@
 Facility Code|Institution Name|Program Type| Description |Full time Undergraduate|Graduate|Full Time Modifier|Length 
 3V000113|CODE PLATOON|NCD|COMPUTER SCIENCE|60|42|S|680
+3V000119|CODE PLATOON|NCD|COMPUTER "SCIENCE2020"|60|42|S|680

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'])
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
     end
 
@@ -75,7 +77,9 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'])
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
 
       post(:build)
@@ -105,7 +109,9 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'])
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
 
       post(:build)

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -160,7 +160,8 @@ RSpec.describe UploadsController, type: :controller do
         expect do
           post(:create,
                params: {
-                   upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'SchoolCertifyingOfficial', col_sep: ',' }
+                 upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'SchoolCertifyingOfficial',
+                           col_sep: ',' }
                })
         end.to change(SchoolCertifyingOfficial, :count).by(2)
       end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -153,6 +153,18 @@ RSpec.describe UploadsController, type: :controller do
         expect(message).to match(/Independent study is a missing header/)
       end
     end
+
+    context 'when specifying SchoolCertifyingOfficial csv_type' do
+      it 'Uploads a SchoolCertifyingOfficial file' do
+        file = build(:upload, csv_name: 'school_certifying_official.csv').upload_file
+        expect do
+          post(:create,
+               params: {
+                   upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'SchoolCertifyingOfficial', col_sep: '|' }
+               })
+        end.to change(SchoolCertifyingOfficial, :count).by(2)
+      end
+    end
   end
 
   describe 'GET show' do

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe UploadsController, type: :controller do
         expect do
           post(:create,
                params: {
-                   upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'SchoolCertifyingOfficial', col_sep: '|' }
+                   upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'SchoolCertifyingOfficial', col_sep: ',' }
                })
         end.to change(SchoolCertifyingOfficial, :count).by(2)
       end

--- a/spec/fixtures/school_certifying_official.csv
+++ b/spec/fixtures/school_certifying_official.csv
@@ -1,3 +1,3 @@
 Facility Code,Institution Name,Priority ,First Name,Last Name,Title,Phone - Area Code,Phone - Number,Phone - Extension ,Email
-11900146,OLD DOMINION UNIVERSITY,PRIMARY,James,Jackson,Certifying Official for Programs,757,6483878,3324,jamesajackson@odu.edu
+11900146,OLD DOMINION UNIVERSITY,PRIMARY,James "Jay",Jackson,Certifying Official for Programs,757,6483878,3324,jamesajackson@odu.edu
 11815146,VIRGINIA POLYTECHNIC INSTITUTE AND STATE UNIVERSITY,PRIMARY,Charles,Snyder,Certifying Official for Programs,540,5423153,9448,charlestsynder@vt.edu


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4308

There are cases where we have quotation marks within fields of the SCO file that causes [SmarterCSV](https://www.rubydoc.info/github/tilo/smarter_csv) to throw an invalid quotation mark error. We are using the fix as suggested by [SmarterCSV's](https://www.rubydoc.info/github/tilo/smarter_csv) documentation to fix the nested quotation marks issue that comes up when uploading the SCO csv.


## Testing done


## Screenshots


## Acceptance criteria
- [x] Able to upload a SCO file.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs