### PR TITLE
GIDS: Use Scorecard API to replace flat-file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The following are required, but related to a SAML login flow only available when
 7. `SAML_IDP_SSO_URL`: URL where the user should be directed to authenticate to the IdP
 8. `SAML_ISSUER`: shared between the GIDS and SSOe team.
 
+The following is for use with Scorecard API.
+
+9. `Settings.scorecard.api_key`: api_key for accessing Scorecard API see https://collegescorecard.ed.gov/data/documentation/ for how to obtain an api_key
+
 To create these variables, you will need to create an `application.yml` file under /config. An example is posted below:
 
 ```
@@ -75,25 +79,6 @@ You can create additional users by adding them to the `/db/seeds/01_users.rb` fi
 
 ```
 User.create(email: 'xxxxxx', password: 'xxxxxx')
-```
-
-### Settings
-The following settings need to be configured for **GIDS**:
-
-GIDS uses https://github.com/rubyconfig/config for various settings throughout the application. Some of these settings 
-are not set within the repository for security reasons as such you will need to set these up within 
-a `config/settings.local.yml` file
-
-#### Scorecard API
-Scorecard data can be retrieved via an API detailed at https://collegescorecard.ed.gov/data/documentation/ . 
-This requires an `api_key`. Check https://collegescorecard.ed.gov/data/documentation/ for latest information.
-
-1. Go to https://api.data.gov/signup and get an API key
-2. In `config/settings.local.yml` add
-
-```
-scorecard:
-  api_key: "YOUR_API_KEY"
 ```
 
 ## Development Instructions

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following are required, but related to a SAML login flow only available when
 
 The following is for use with Scorecard API.
 
-9. `Settings.scorecard.api_key`: api_key for accessing Scorecard API see https://collegescorecard.ed.gov/data/documentation/ for how to obtain an api_key
+9. `SCORECARD_API_KEY`: api_key for accessing Scorecard API see https://collegescorecard.ed.gov/data/documentation/ for how to obtain an api_key
 
 To create these variables, you will need to create an `application.yml` file under /config. An example is posted below:
 

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -9,7 +9,7 @@ Config.setup do |config|
   # Overwrite an existing value when merging a `nil` value.
   # When set to `false`, the existing value is retained after merge.
   #
-  config.merge_nil_values = false
+  # config.merge_nil_values = true
 
   # Overwrite arrays found in previously loaded settings file. When set to `false`, arrays will be merged.
   #
@@ -17,11 +17,11 @@ Config.setup do |config|
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
   #
-  config.use_env = true
+  # config.use_env = false
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  config.env_prefix = 'Settings'
+  # config.env_prefix = 'Settings'
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -9,7 +9,7 @@ Config.setup do |config|
   # Overwrite an existing value when merging a `nil` value.
   # When set to `false`, the existing value is retained after merge.
   #
-  # config.merge_nil_values = true
+  config.merge_nil_values = false
 
   # Overwrite arrays found in previously loaded settings file. When set to `false`, arrays will be merged.
   #
@@ -17,11 +17,11 @@ Config.setup do |config|
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
   #
-  # config.use_env = false
+  config.use_env = true
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  # config.env_prefix = 'Settings'
+  config.env_prefix = 'Settings'
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,4 +13,4 @@ csv_upload:
 
 scorecard:
   url: "https://api.data.gov/ed/collegescorecard/v1"
-  api_key:
+  api_key: <%= ENV['SCORECARD_API_KEY'] %>


### PR DESCRIPTION
## Description
Allow environment variables to set `scorecard.api_key` setting in settings.yml
https://github.com/department-of-veterans-affairs/va.gov-team/issues/4380

This change was done in response to changes requested for https://github.com/department-of-veterans-affairs/devops/pull/6271

See https://github.com/rubyconfig/config#fine-tuning
See https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/initializers/config.rb

## Testing done
- local testing by setting value in `application.yml`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs