### PR TITLE
Two users fetching scorecard data at the same time results in the data being duplicated #5208

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -74,7 +74,9 @@ class DashboardsController < ApplicationController
   def api_fetch
     class_name = CSV_TYPES_HAS_API_TABLE_NAMES.find { |csv_type| csv_type == params[:csv_type] }
 
-    if class_name.present?
+    if Upload.fetching_for?(params[:csv_type])
+      flash.alert = "#{params[:csv_type]} is already being fetched by another user"
+    elsif class_name.present?
       csv = "#{class_name}::API_SOURCE".safe_constantize || "#{class_name} API"
       begin
         api_upload = Upload.new(csv_type: class_name, user: current_user, csv: csv,

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -202,5 +202,12 @@ RSpec.describe DashboardsController, type: :controller do
       get(:api_fetch, params: { csv_type: Scorecard.name })
       expect(flash.alert).to include(message)
     end
+
+    it 'displays already fetching alert' do
+      message = "#{Scorecard.name} is already being fetched by another user"
+      create :upload, :scorecard_in_progress
+      get(:api_fetch, params: { csv_type: Scorecard.name })
+      expect(flash.alert).to include(message)
+    end
   end
 end


### PR DESCRIPTION
## Description
If a user is actively fetching scorecard data, functionality exists to prevent other users from accessing the dashboard and fetching at the same time. However, if the second user has already accessed the dashboard before the first user has clicked fetch, the second user is also able to fetch. If the second user also clicks fetch, the data is duplicated.

1. Login to GIDS as two separate users
2. As user 1, click fetch
3. Once the scorecard fetching message is displayed for user 1, click fetch as user 2.

Once fetching finishes for both users, the scorecards database table will have 14224 rows instead of the expected 7112.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs