### PR TITLE
Refactor the establishment of `@version` variable

### DIFF
--- a/app/controllers/v0/api_controller.rb
+++ b/app/controllers/v0/api_controller.rb
@@ -14,15 +14,9 @@ module V0
     # Newest production data version assumed when version param is undefined
     def resolve_version
       v = params[:version]
-      version = Version.find_by(uuid: v) || Version.current_production
+      @version = Version.find_by(uuid: v) || Version.current_production
 
-      raise Common::Exceptions::InvalidFieldValue, "Version #{v} not found" unless version.try(:number)
-
-      @version = {
-        number: version.number,
-        created_at: version.created_at,
-        preview: version.preview?
-      }
+      raise Common::Exceptions::InvalidFieldValue, "Version #{v} not found" unless @version.try(:number)
     end
 
     def self_link

--- a/app/controllers/v0/institution_programs_controller.rb
+++ b/app/controllers/v0/institution_programs_controller.rb
@@ -9,7 +9,7 @@ module V0
       @data = []
       if params[:term].present?
         @search_term = params[:term]&.strip&.downcase
-        @data = InstitutionProgram.version(@version[:number]).autocomplete(@search_term)
+        @data = InstitutionProgram.version(@version.number).autocomplete(@search_term)
       end
       @meta = {
         version: @version,
@@ -46,7 +46,7 @@ module V0
     def search_results
       @query ||= normalized_query_params
 
-      relation = InstitutionProgram.version(@version[:number])
+      relation = InstitutionProgram.version(@version.number)
                                    .joins(:institution)
                                    .search(@query[:name])
                                    .order('institutions.preferred_provider DESC NULLS LAST, institutions.institution')

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -49,7 +49,7 @@ module V0
 
     # GET /v0/institutions/20005123/children
     def children
-      children = Institution.version(@version[:number])
+      children = Institution.version(@version.number)
                             .where(parent_facility_code_id: params[:id])
                             .order(:institution)
                             .page(params[:page])
@@ -146,7 +146,7 @@ module V0
     end
 
     def approved_institutions
-      Institution.version(@version[:number]).no_extentions.where(approved: true)
+      Institution.version(@version.number).no_extentions.where(approved: true)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/controllers/v0/zipcode_rates_controller.rb
+++ b/app/controllers/v0/zipcode_rates_controller.rb
@@ -4,7 +4,7 @@ module V0
   class ZipcodeRatesController < ApiController
     # GET /v0/zipcode_rates/20001
     def show
-      resource = ZipcodeRate.where(version: @version[:number], zip_code: params[:id]).order(:mha_rate).first
+      resource = ZipcodeRate.where(version: @version.number, zip_code: params[:id]).order(:mha_rate).first
 
       raise Common::Exceptions::RecordNotFound, params[:id] unless resource
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -65,7 +65,7 @@ class Version < ApplicationRecord
     "#{ENV['GIBCT_URL']}#{version_info}"
   end
 
-  def as_json(options = nil)
+  def as_json(_options = nil)
     {
       number: number,
       created_at: created_at,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -65,6 +65,14 @@ class Version < ApplicationRecord
     "#{ENV['GIBCT_URL']}#{version_info}"
   end
 
+  def as_json(options = nil)
+    {
+      number: number,
+      created_at: created_at,
+      preview: preview?
+    }
+  end
+
   # private instance methods
   private
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -15,8 +15,13 @@ RSpec.describe Version, type: :model do
     end
 
     it 'has gibct_link based on configuration' do
-      version.save
       expect(version.gibct_link).to eq(ENV['GIBCT_URL'])
+    end
+
+    describe '#as_json' do
+      it 'returns attributes appropriate for API responses' do
+        expect(version.as_json.keys).to eq(%i[number created_at preview])
+      end
     end
   end
 


### PR DESCRIPTION
## Description
Refactor the establishment of `@version` variable for use in controllers to better draw a distinction between the workable object and it's serialized form.

## Testing done
specs

## Screenshots


## Acceptance criteria
- [x] Establish `@version` as a `Version` object instead of a hash
- [x] Overwrites `Version#as_json` to return data appropriate for API responses.

## Definition of done
- [x] Events are logged appropriately
- [ ] ~~Documentation has been updated, if applicable~~
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs