### PR TITLE
Added `IF EXISTS` to index delete

### DIFF
--- a/db/migrate/20200203122100_remove_institutions_address_indexes.rb
+++ b/db/migrate/20200203122100_remove_institutions_address_indexes.rb
@@ -2,7 +2,7 @@ class RemoveInstitutionsAddressIndexes < ActiveRecord::Migration[5.2]
 
   def change
     safety_assured do
-      execute "DROP INDEX index_institutions_institution_lprefix;"
+      execute "DROP INDEX IF EXISTS index_institutions_institution_lprefix;"
     end
 
     remove_index :institutions, :institution


### PR DESCRIPTION
## Description
Migrations on Staging and Dev are currently broken because a index being dropped doesn't exist.

This migration has NOT been ran on upper environments yet and can be updated

## Testing done
Tested locally & QA review

## Screenshots
N/A

## Acceptance criteria
- [x] Index is checked for before dropping

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs