### PR TITLE
Exclude VET TEC institutions from search and autocomplete only

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -10,7 +10,7 @@ module V0
       @data = []
       if params[:term]
         @search_term = params[:term]&.strip&.downcase
-        @data = approved_institutions.autocomplete(@search_term)
+        @data = approved_institutions.where(vet_tec_provider: false).autocomplete(@search_term)
       end
       @meta = {
         version: @version,
@@ -81,7 +81,7 @@ module V0
     # rubocop:disable Metrics/MethodLength
     def search_results
       @query ||= normalized_query_params
-      relation = approved_institutions.search(@query[:name], @query[:include_address])
+      relation = approved_institutions.where(vet_tec_provider: false).search(@query[:name], @query[:include_address])
       [
         %i[institution_type_name type],
         [:category],
@@ -140,7 +140,7 @@ module V0
     end
 
     def approved_institutions
-      Institution.version(@version[:number]).no_extentions.where(approved: true, vet_tec_provider: false)
+      Institution.version(@version[:number]).no_extentions.where(approved: true)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       create(:version, :production)
     end
 
-    it 'returns profile details ' do
+    it 'returns profile details' do
       school = create(:institution, :in_chicago)
       get(:show, params: { id: school.facility_code, version: school.version })
       expect(response.content_type).to eq('application/json')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -299,8 +299,15 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       create(:version, :production)
     end
 
-    it 'returns profile details' do
+    it 'returns profile details ' do
       school = create(:institution, :in_chicago)
+      get(:show, params: { id: school.facility_code, version: school.version })
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institution_profile')
+    end
+
+    it 'returns profile details for VET TEC institution' do
+      school = create(:institution, :vet_tec_provider)
       get(:show, params: { id: school.facility_code, version: school.version })
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_profile')


### PR DESCRIPTION
## Description
Removed vet_tec_program exclusion from `approved programs` to allow the institutions controller to only filter out VET TEC institutions on search and autocomplete.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/5641

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Profile data returned for VET TEC institution

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs