### PR TITLE
Remove institution_archives constraint from db

### DIFF
--- a/db/migrate/20200210150004_remove_institutions_archives_version_constraint.rb
+++ b/db/migrate/20200210150004_remove_institutions_archives_version_constraint.rb
@@ -1,0 +1,7 @@
+
+class RemoveInstitutionsArchivesVersionConstraint < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    change_column_null :institutions_archives, :version, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_03_122400) do
+ActiveRecord::Schema.define(version: 2020_02_10_150004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -403,7 +403,7 @@ ActiveRecord::Schema.define(version: 2020_02_03_122400) do
   end
 
   create_table "institutions_archives", id: :integer, default: -> { "nextval('institutions_id_seq'::regclass)" }, force: :cascade do |t|
-    t.integer "version", null: false
+    t.integer "version"
     t.string "institution_type_name"
     t.string "facility_code"
     t.string "institution"


### PR DESCRIPTION
## Description
In order to refactor to refactor the GIDS archiver it is necessary to remove the non-null constraint for `institutions_archives`. 

This PR is related to:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4038

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] Non-Null constraint on `versions` column is removed from the `institutions_archives` table.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs