### PR TITLE
Add institution_id to versioned school certifying officials

### DIFF
--- a/app/models/school_certifying_official.rb
+++ b/app/models/school_certifying_official.rb
@@ -5,6 +5,8 @@ class SchoolCertifyingOfficial < ApplicationRecord
 
   belongs_to :institution
 
+  self.ignored_columns = ['institution_id']
+
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution name' => { column: :institution_name, converter: InstitutionConverter },

--- a/db/migrate/20200212204337_add_institution_id_to_versioned_school_certifying_officials.rb
+++ b/db/migrate/20200212204337_add_institution_id_to_versioned_school_certifying_officials.rb
@@ -1,0 +1,10 @@
+
+class AddInstitutionIdToVersionedSchoolCertifyingOfficials < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :versioned_school_certifying_officials, :institution, foreign_key: true, index: false
+    add_index :versioned_school_certifying_officials, :institution_id, algorithm: :concurrently
+  end
+end
+

--- a/db/migrate/20200212205137_add_institution_id_to_versioned_school_certifying_officials_archives.rb
+++ b/db/migrate/20200212205137_add_institution_id_to_versioned_school_certifying_officials_archives.rb
@@ -1,0 +1,5 @@
+class AddInstitutionIdToVersionedSchoolCertifyingOfficialsArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :versioned_school_certifying_officials_archives, :institution_id, :bigint
+  end
+end

--- a/db/migrate/20200212206022_drop_school_certifying_officials_archives.rb
+++ b/db/migrate/20200212206022_drop_school_certifying_officials_archives.rb
@@ -1,0 +1,5 @@
+class DropSchoolCertifyingOfficialsArchives < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :school_certifying_officials_archives
+  end
+end

--- a/db/migrate/20200213231744_remove_institution_id_from_school_certifying_officials.rb
+++ b/db/migrate/20200213231744_remove_institution_id_from_school_certifying_officials.rb
@@ -1,5 +1,0 @@
-class RemoveInstitutionIdFromSchoolCertifyingOfficials < ActiveRecord::Migration[5.2]
-  def change
-    safety_assured { remove_column :school_certifying_officials, :institution_id, :bigint }
-  end
-end

--- a/db/migrate/20200213231744_remove_institution_id_from_school_certifying_officials.rb
+++ b/db/migrate/20200213231744_remove_institution_id_from_school_certifying_officials.rb
@@ -1,0 +1,5 @@
+class RemoveInstitutionIdFromSchoolCertifyingOfficials < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured { remove_column :school_certifying_officials, :institution_id, :bigint }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_150004) do
+ActiveRecord::Schema.define(version: 2020_02_12_205137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1478,6 +1478,8 @@ ActiveRecord::Schema.define(version: 2020_02_10_150004) do
     t.string "phone_extension"
     t.string "email"
     t.integer "version"
+    t.bigint "institution_id"
+    t.index ["institution_id"], name: "index_versioned_school_certifying_officials_on_institution_id"
   end
 
   create_table "versioned_school_certifying_officials_archives", id: :integer, default: -> { "nextval('versioned_school_certifying_officials_id_seq'::regclass)" }, force: :cascade do |t|
@@ -1492,6 +1494,7 @@ ActiveRecord::Schema.define(version: 2020_02_10_150004) do
     t.string "phone_extension"
     t.string "email"
     t.integer "version"
+    t.bigint "institution_id"
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
@@ -1659,5 +1662,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_150004) do
   add_foreign_key "crosswalk_issues", "weams"
   add_foreign_key "institutions", "versions"
   add_foreign_key "school_certifying_officials", "institutions"
+  add_foreign_key "versioned_school_certifying_officials", "institutions"
   add_foreign_key "zipcode_rates", "versions"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_206022) do
+ActiveRecord::Schema.define(version: 2020_02_13_231744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1191,8 +1191,6 @@ ActiveRecord::Schema.define(version: 2020_02_12_206022) do
     t.string "phone_number"
     t.string "phone_extension"
     t.string "email"
-    t.bigint "institution_id"
-    t.index ["institution_id"], name: "index_school_certifying_officials_on_institution_id"
   end
 
   create_table "school_closures", id: :serial, force: :cascade do |t|
@@ -1646,7 +1644,6 @@ ActiveRecord::Schema.define(version: 2020_02_12_206022) do
   add_foreign_key "crosswalk_issues", "ipeds_hds"
   add_foreign_key "crosswalk_issues", "weams"
   add_foreign_key "institutions", "versions"
-  add_foreign_key "school_certifying_officials", "institutions"
   add_foreign_key "versioned_school_certifying_officials", "institutions"
   add_foreign_key "zipcode_rates", "versions"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_205137) do
+ActiveRecord::Schema.define(version: 2020_02_12_206022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1193,21 +1193,6 @@ ActiveRecord::Schema.define(version: 2020_02_12_205137) do
     t.string "email"
     t.bigint "institution_id"
     t.index ["institution_id"], name: "index_school_certifying_officials_on_institution_id"
-  end
-
-  create_table "school_certifying_officials_archives", id: false, force: :cascade do |t|
-    t.integer "id", default: -> { "nextval('school_certifying_officials_id_seq'::regclass)" }, null: false
-    t.string "facility_code"
-    t.string "institution_name"
-    t.string "priority"
-    t.string "first_name"
-    t.string "last_name"
-    t.string "title"
-    t.string "phone_area_code"
-    t.string "phone_number"
-    t.string "phone_extension"
-    t.string "email"
-    t.bigint "institution_id"
   end
 
   create_table "school_closures", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_231744) do
+ActiveRecord::Schema.define(version: 2020_02_12_206022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1191,6 +1191,8 @@ ActiveRecord::Schema.define(version: 2020_02_13_231744) do
     t.string "phone_number"
     t.string "phone_extension"
     t.string "email"
+    t.bigint "institution_id"
+    t.index ["institution_id"], name: "index_school_certifying_officials_on_institution_id"
   end
 
   create_table "school_closures", id: :serial, force: :cascade do |t|
@@ -1644,6 +1646,7 @@ ActiveRecord::Schema.define(version: 2020_02_13_231744) do
   add_foreign_key "crosswalk_issues", "ipeds_hds"
   add_foreign_key "crosswalk_issues", "weams"
   add_foreign_key "institutions", "versions"
+  add_foreign_key "school_certifying_officials", "institutions"
   add_foreign_key "versioned_school_certifying_officials", "institutions"
   add_foreign_key "zipcode_rates", "versions"
 end


### PR DESCRIPTION
## Description
Database specific PR to add `institution_id` to `versioned_school_certifying_officials` and `versioned_school_certifying_officials_archives` 

and to remove the `school_certifying_officials_archives` table. 

To support PR #550 for [4038](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4038)

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] `institution_id` is added to `versioned_school_certifying_officials`
- [x] `institution_id` is added to `versioned_school_certifying_officials_archives`
- [x] The table `school_certifying_officials_archives` is dropped from the database.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs