### PR TITLE
Remove explict post that breaks form submission

### DIFF
--- a/app/views/crosswalk_issues/find_matches.html.erb
+++ b/app/views/crosswalk_issues/find_matches.html.erb
@@ -41,7 +41,7 @@
                 <td><%= iped["cross"] %></td>
                 <td><%= (iped["match_score"].to_f * 100).round(3) %>%</td>
                 <td>
-                  <%= form_with(url: "/crosswalk_issues/match_ipeds_hd") do %>
+                  <%= form_with(url: crosswalk_issues_match_ipeds_hd_path) do %>
                     <input type="hidden" name="issue_id" value="<%= @issue.id %>" />
                     <input type="hidden" name="iped_id" value="<%= iped["id"] %>" />
                     <%= submit_tag( "Match", class: 'btn dashboard-btn-success', data: { confirm: "Are you sure?" })%>

--- a/app/views/crosswalk_issues/find_matches.html.erb
+++ b/app/views/crosswalk_issues/find_matches.html.erb
@@ -41,7 +41,7 @@
                 <td><%= iped["cross"] %></td>
                 <td><%= (iped["match_score"].to_f * 100).round(3) %>%</td>
                 <td>
-                  <%= form_with(url: "/crosswalk_issues/match_ipeds_hd", method: "post") do %>
+                  <%= form_with(url: "/crosswalk_issues/match_ipeds_hd") do %>
                     <input type="hidden" name="issue_id" value="<%= @issue.id %>" />
                     <input type="hidden" name="iped_id" value="<%= iped["id"] %>" />
                     <%= submit_tag( "Match", class: 'btn dashboard-btn-success', data: { confirm: "Are you sure?" })%>


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/5880

Allows for ipeds_hd matching to work in higher environments.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Can match Ipeds_hd to weams for new/update Crosswalk data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs