### PR TITLE
Add new columns to yellow_ribbon_program

### DIFF
--- a/db/migrate/20200225144003_add_columns_to_yellow_ribbon_program.rb
+++ b/db/migrate/20200225144003_add_columns_to_yellow_ribbon_program.rb
@@ -1,0 +1,35 @@
+class AddColumnsToYellowRibbonProgram < ActiveRecord::Migration[5.2]
+  def change
+    add_column :yellow_ribbon_programs, :amendment_date, :date
+    add_column :yellow_ribbon_programs, :campus, :string
+    add_column :yellow_ribbon_programs, :city, :string
+    add_column :yellow_ribbon_programs, :consolidated_agreement, :boolean
+    add_column :yellow_ribbon_programs, :date_agreement_received, :date
+    add_column :yellow_ribbon_programs, :date_confirmation_sent, :date
+    add_column :yellow_ribbon_programs, :date_yr_signed_by_yr_official, :date
+    add_column :yellow_ribbon_programs, :facility_code, :string
+    add_column :yellow_ribbon_programs, :flight_school, :boolean
+    add_column :yellow_ribbon_programs, :ineligible, :boolean
+    add_column :yellow_ribbon_programs, :initials_yr_processor, :string
+    add_column :yellow_ribbon_programs, :missed_deadline, :boolean
+    add_column :yellow_ribbon_programs, :modified, :boolean
+    add_column :yellow_ribbon_programs, :new_school, :boolean
+    add_column :yellow_ribbon_programs, :notes, :text
+    add_column :yellow_ribbon_programs, :open_ended_agreement, :boolean
+    add_column :yellow_ribbon_programs, :public_private, :string
+    add_column :yellow_ribbon_programs, :school_name_in_weams, :string
+    add_column :yellow_ribbon_programs, :school_name_in_yr_database, :string
+    add_column :yellow_ribbon_programs, :sco_email_address, :string
+    add_column :yellow_ribbon_programs, :sco_name, :string
+    add_column :yellow_ribbon_programs, :sco_telephone_number, :string
+    add_column :yellow_ribbon_programs, :sfr_email_address, :string
+    add_column :yellow_ribbon_programs, :sfr_name, :string
+    add_column :yellow_ribbon_programs, :sfr_telephone_number, :string
+    add_column :yellow_ribbon_programs, :state, :string
+    add_column :yellow_ribbon_programs, :street_address, :string
+    add_column :yellow_ribbon_programs, :updated_for_2011_2012, :boolean
+    add_column :yellow_ribbon_programs, :withdrawn, :boolean
+    add_column :yellow_ribbon_programs, :year_of_yr_participation, :string
+    add_column :yellow_ribbon_programs, :zip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_206022) do
+ActiveRecord::Schema.define(version: 2020_02_25_144003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1611,6 +1611,37 @@ ActiveRecord::Schema.define(version: 2020_02_12_206022) do
     t.decimal "contribution_amount", precision: 12, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "amendment_date"
+    t.string "campus"
+    t.string "city"
+    t.boolean "consolidated_agreement"
+    t.date "date_agreement_received"
+    t.date "date_confirmation_sent"
+    t.date "date_yr_signed_by_yr_official"
+    t.string "facility_code"
+    t.boolean "flight_school"
+    t.boolean "ineligible"
+    t.string "initials_yr_processor"
+    t.boolean "missed_deadline"
+    t.boolean "modified"
+    t.boolean "new_school"
+    t.text "notes"
+    t.boolean "open_ended_agreement"
+    t.string "public_private"
+    t.string "school_name_in_weams"
+    t.string "school_name_in_yr_database"
+    t.string "sco_email_address"
+    t.string "sco_name"
+    t.string "sco_telephone_number"
+    t.string "sfr_email_address"
+    t.string "sfr_name"
+    t.string "sfr_telephone_number"
+    t.string "state"
+    t.string "street_address"
+    t.boolean "updated_for_2011_2012"
+    t.boolean "withdrawn"
+    t.string "year_of_yr_participation"
+    t.string "zip"
     t.index ["institution_id"], name: "index_yellow_ribbon_programs_on_institution_id"
     t.index ["version"], name: "index_yellow_ribbon_programs_on_version"
   end


### PR DESCRIPTION
## Description
Database specific PR to add the following columns to the `yellow_ribbon_program` table:

```
:amendment_date, :date
:campus, :string
:city, :string
:consolidated_agreement, :boolean
:date_agreement_received, :date
:date_confirmation_sent, :date
:date_yr_signed_by_yr_official, :date
:facility_code, :string
:flight_school, :boolean
:ineligible, :boolean
:initials_yr_processor, :string
:missed_deadline, :boolean
:modified, :boolean
:new_school, :boolean
:notes, :text
:open_ended_agreement, :boolean
:public_private, :string
:school_name_in_weams, :string
:school_name_in_yr_database, :string
:sco_email_address, :string
:sco_name, :string
:sco_telephone_number, :string
:sfr_email_address, :string
:sfr_name, :string
:sfr_telephone_number, :string
:state, :string
:street_address, :string
:updated_for_2011_2012, :boolean
:withdrawn, :boolean
:year_of_yr_participation, :string
:zip, :string
```

To support PR https://github.com/department-of-veterans-affairs/gibct-data-service/pull/584 for https://github.com/department-of-veterans-affairs/va.gov-team/issues/5597

## Testing done
Ran `bundle exec rake ci` and all tests passed locally.

## Screenshots
N/A

## Acceptance criteria
- [x] New columns are added to `yellow_ribbon_program`.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs