### PR TITLE
Flush stdout to display error output in jenkins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,18 +48,18 @@ Style/ClassAndModuleChildren:
 Style/GuardClause:
   Enabled: false
 
-#Metrics/LineLength:
-#  Max: 120
-#  Exclude:
-#    - "app/controllers/v0/institutions_controller.rb"
-#    - "spec/models/shared_examples/shared_examples_for_archivable_by_version_id.rb"
-#    - "app/models/gibct_site_mapper.rb"
-#    - "app/models/archiver.rb"
-#    - "app/models/institution_tree.rb"
-#    - "spec/models/institution_tree_spec.rb"
-#    - "spec/controllers/v0/institutions_controller_spec.rb"
-#    - "spec/models/institution_spec.rb"
-#    - "spec/factories/institution_programs.rb"
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - "app/controllers/v0/institutions_controller.rb"
+    - "spec/models/shared_examples/shared_examples_for_archivable_by_version_id.rb"
+    - "app/models/gibct_site_mapper.rb"
+    - "app/models/archiver.rb"
+    - "app/models/institution_tree.rb"
+    - "spec/models/institution_tree_spec.rb"
+    - "spec/controllers/v0/institutions_controller_spec.rb"
+    - "spec/models/institution_spec.rb"
+    - "spec/factories/institution_programs.rb"
 
 # removing rule because get_session implies HTTP GET, and informs method
 Naming/AccessorMethodName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,18 +48,18 @@ Style/ClassAndModuleChildren:
 Style/GuardClause:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 120
-  Exclude:
-    - "app/controllers/v0/institutions_controller.rb"
-    - "spec/models/shared_examples/shared_examples_for_archivable_by_version_id.rb"
-    - "app/models/gibct_site_mapper.rb"
-    - "app/models/archiver.rb"
-    - "app/models/institution_tree.rb"
-    - "spec/models/institution_tree_spec.rb"
-    - "spec/controllers/v0/institutions_controller_spec.rb"
-    - "spec/models/institution_spec.rb"
-    - "spec/factories/institution_programs.rb"
+#Metrics/LineLength:
+#  Max: 120
+#  Exclude:
+#    - "app/controllers/v0/institutions_controller.rb"
+#    - "spec/models/shared_examples/shared_examples_for_archivable_by_version_id.rb"
+#    - "app/models/gibct_site_mapper.rb"
+#    - "app/models/archiver.rb"
+#    - "app/models/institution_tree.rb"
+#    - "spec/models/institution_tree_spec.rb"
+#    - "spec/controllers/v0/institutions_controller_spec.rb"
+#    - "spec/models/institution_spec.rb"
+#    - "spec/factories/institution_programs.rb"
 
 # removing rule because get_session implies HTTP GET, and informs method
 Naming/AccessorMethodName:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+$stdout.sync = true
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm gibct bash --login

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -27,3 +27,5 @@ namespace :spec do
     exit exit_status
   end
 end
+
+$stdout.sync = false

--- a/lib/tasks/support/shell_command.rb
+++ b/lib/tasks/support/shell_command.rb
@@ -5,6 +5,8 @@ class ShellCommand
   # returns boolean depending on the success of the command
   def self.run(command)
     success = false
+    old_sync = $stdout.sync
+    $stdout.sync = true
 
     Open3.popen2e(command) do |_stdin, stdout_and_stderr, thread|
       while (line = stdout_and_stderr.gets)
@@ -14,6 +16,7 @@ class ShellCommand
       success = thread.value.success?
     end
 
+    $stdout.sync = old_sync
     success
   end
 end


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/vets-api/pull/3320

See http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fgibct-data-service/detail/display_jenkins_console_error_output/1/pipeline/ for output failures

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs