### PR TITLE
Update/Add rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,17 @@ Style/ClassAndModuleChildren:
 Style/GuardClause:
   Enabled: false
 
-Metrics/LineLength:
+# https://rubocop.readthedocs.io/en/latest/cops_style/#stylehasheachmethods
+Style/HashEachMethods:
+  Enabled: true
+# https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformkeys
+Style/HashTransformKeys:
+  Enabled: true
+# https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformvalues
+Style/HashTransformValues:
+  Enabled: true
+
+Layout/LineLength:
   Max: 120
   Exclude:
     - "app/controllers/v0/institutions_controller.rb"


### PR DESCRIPTION
## Description
Running `rake ci` outputted below 
```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
```
and
```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods
 - Style/HashTransformKeys
 - Style/HashTransformValues
```

For new cops
https://rubocop.readthedocs.io/en/latest/cops_style/#stylehasheachmethods
https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformkeys
https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformvalues

For cops rename
https://github.com/rubocop-hq/rubocop/releases/tag/v0.78.0
```
#7542: (Breaking) Move LineLength cop from Metrics department to Layout department. (@koic)
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs