### PR TITLE
6265: Correct Duplication of institutions where Non-Unique facility codes exist

### DIFF
--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe InstitutionBuilder, type: :model do
         create :weam, facility_code: '18181818', institution: 'REAL SCHOOL'
         create :weam, facility_code: '18181818', institution: 'FAKE SCHOOL'
         described_class.run(user)
-        expect(institutions.last.institution).to eq('REAL SCHOOL')
-        expect(institutions.last.institution).not_to eq('FAKE SCHOOL')
+        expect(institutions.where(facility_code: '18181818').count).to eq(1)
       end
     end
 

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe InstitutionBuilder, type: :model do
       end
     end
 
+    describe 'when preventing duplicates' do
+      it 'duplicates in WEAMs are not present in institutions' do
+        create :weam, facility_code: '18181818', institution: 'REAL SCHOOL'
+        create :weam, facility_code: '18181818', institution: 'FAKE SCHOOL'
+        described_class.run(user)
+        expect(institutions.last.institution).to eq('REAL SCHOOL')
+        expect(institutions.last.institution).not_to eq('FAKE SCHOOL')
+      end
+    end
+
     describe 'when adding Crosswalk data' do
       let(:institution) { institutions.find_by(facility_code: crosswalk.facility_code) }
       let(:crosswalk) { Crosswalk.first }


### PR DESCRIPTION
## Description
As a developer, I need to prevent duplicates from being added to the institutions table when duplicate facility codes are present in weam.csv

[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/6265)

## Testing done
Manual and CI testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] The SQL Query used in institution_builder is corrected to resolve the duplication issue based off of version_id

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs