### PR TITLE
update puma to ~> 3.12.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 # Application server: Puma
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
-gem 'puma', '~> 3.12'
+gem 'puma', '~> 3.12.4'
 
 gem 'rails', '5.2.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.1)
-    puma (3.12.3)
+    puma (3.12.4)
     rack (2.0.8)
     rack-cors (1.0.5)
       rack (>= 1.6.0)
@@ -423,7 +423,7 @@ DEPENDENCIES
   oj
   pg (~> 0.15)
   pry-nav
-  puma (~> 3.12)
+  puma (~> 3.12.4)
   rack-cors
   rails (= 5.2.3)
   rails-controller-testing


### PR DESCRIPTION
## Description
From http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fgibct-data-service/detail/rubocop-78-updates/3/pipeline
```
running bundle-audit to check for insecure dependencies...
Updating ruby-advisory-db ...
Cloning into '/root/.local/share/ruby-advisory-db'...
Updated ruby-advisory-db
ruby-advisory-db: 429 advisories
Name: puma
Version: 3.12.3
Advisory: CVE-2020-5247
Criticality: Unknown
URL: https://github.com/puma/puma/security/advisories/GHSA-84j7-475p-hp8v
Title: HTTP Response Splitting vulnerability in puma
Solution: upgrade to ~> 3.12.4, >= 4.3.3
Vulnerabilities found!
```
## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs