### PR TITLE
Update postgres version for strong migrations and docker composes

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,3 +1,3 @@
 # Only evaluate migrations with strong_migrations that were created after this gem was installed
 StrongMigrations.start_after = 20190626110700
-StrongMigrations.target_postgresql_version = 9.4
+StrongMigrations.target_postgresql_version = 11.5

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@
 version: '2.1'
 services:
   postgres:
-    image: "postgres:9.4"
+    image: "postgres:11.5"
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2.1'
 services:
   postgres:
-    image: "postgres:9.4"
+    image: "postgres:11.5"
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"


### PR DESCRIPTION
## Description
Dev, Staging, and Production now use Postgresql 11.5

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs