### PR TITLE
GIDS: Archive Tab is inaccessible in production #6786

### DIFF
--- a/app/views/archives/_version.html.erb
+++ b/app/views/archives/_version.html.erb
@@ -1,8 +1,8 @@
 <tr class="<%= cycle('even', 'odd') -%>">
   <td><%= version.number %></td>
   <td><%= version.uuid %></td>
-  <td><%= version.user.email %></td>
-  <td><%= version.created_at.to_formatted_s(:long_ordinal) %></td>
+  <td><%= version.user&.email %></td>
+  <td><%= version.created_at&.to_formatted_s(:long_ordinal) %></td>
   <td>
       <%= link_to 'Download Institution CSV', archives_export_path(InstitutionsArchive.name, version.number),
                   class: "btn dashboard-btn-warning btn-xs", role: "button" %>

--- a/app/views/dashboards/_version.html.erb
+++ b/app/views/dashboards/_version.html.erb
@@ -1,8 +1,8 @@
 <tr class="<%= 'success' if version.production? %>">
   <td><%= version.number %></td>
   <td><%= version.uuid %></td>
-  <td><%= version.user.email %></td>
-  <td><%= version.created_at.to_formatted_s(:long_ordinal) %></td>
+  <td><%= version.user&.email %></td>
+  <td><%= version.created_at&.to_formatted_s(:long_ordinal) %></td>
   <td>
     <% if version.generating? %>
         <i class="fa fa-gear fa-spin" style="font-size:24px"></i>


### PR DESCRIPTION
## Description
http://sentry.vfs.va.gov/vets-gov/gi-bill-data-service-production/issues/99217/?query=is%3Aunresolved

https://github.com/department-of-veterans-affairs/va.gov-team/issues/6786

## Testing done
- Locally run the query `update versions set user_id = 999 where id = 1` then go to Archives tab

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs