### PR TITLE
remove es6 syntax to fix styling issue in staging

### DIFF
--- a/app/assets/javascripts/calculator_constants.js
+++ b/app/assets/javascripts/calculator_constants.js
@@ -1,6 +1,6 @@
 $(function() {
     formatInputFields = function (field) {
-        let field_id = $(field).attr("id");
+        var field_id = $(field).attr("id");
         if (field_id === "FISCALYEAR") {
             $(field).val(parseInt($(field).val()));
         } else {
@@ -8,14 +8,14 @@ $(function() {
         }
     };
 
-    const formatFloatInputToCurrency = function (field) {
+    var formatFloatInputToCurrency = function (field) {
         if (!$(field).val()) {
             $(field).val(0);
         }
         $(field).val(parseFloat($(field).val()).toFixed(2));
     };
 
-    const calculator_constant_fields  = $(':input[type="number"]');
+    var calculator_constant_fields  = $(':input[type="number"]');
 
     calculator_constant_fields.each( function () {
         formatInputFields(this);


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6849

es6 syntax breaks the GIDS UI in staging and prod. Need to change es6 syntax to es5. 
## Testing done
Ran `bundle exec rake assets:precompile RAILS_ENV=production` locally to determine if assets will break prod build. 

## Screenshots

## Acceptance criteria
- [x] Remove ES6

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs