### PR TITLE
GIDS: Research allowing GIDS to handle ES6 or adding a rubocop to keep ES6 out #6855

### DIFF
--- a/app/assets/javascripts/calculator_constants.js
+++ b/app/assets/javascripts/calculator_constants.js
@@ -1,6 +1,6 @@
 $(function() {
     formatInputFields = function (field) {
-        var field_id = $(field).attr("id");
+        let field_id = $(field).attr("id");
         if (field_id === "FISCALYEAR") {
             $(field).val(parseInt($(field).val()));
         } else {
@@ -8,14 +8,14 @@ $(function() {
         }
     };
 
-    var formatFloatInputToCurrency = function (field) {
+    const formatFloatInputToCurrency = function (field) {
         if (!$(field).val()) {
             $(field).val(0);
         }
         $(field).val(parseFloat($(field).val()).toFixed(2));
     };
 
-    var calculator_constant_fields  = $(':input[type="number"]');
+    const calculator_constant_fields  = $(':input[type="number"]');
 
     calculator_constant_fields.each( function () {
         formatInputFields(this);

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6855
https://github.com/lautis/uglifier#es6--es2015--harmony-mode

## Testing done


## Screenshots


## Acceptance criteria
- [ ] `bundle exec rake assets:precompile RAILS_ENV=production` doesn't fail
- [ ] Calculator Constants page works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs