### PR TITLE
add `per_page` functionality to `yellow_ribbon_programs_controller`

### DIFF
--- a/app/controllers/v0/yellow_ribbon_programs_controller.rb
+++ b/app/controllers/v0/yellow_ribbon_programs_controller.rb
@@ -20,8 +20,8 @@ module V0
         version: @version,
         count: search_results.count
       }
-      search_results.per_page = params[:per_page] if params[:per_page]
-      render json: search_results.page(params[:page]), meta: @meta
+      per_page = params[:per_page] || search_results.per_page
+      render json: search_results.page(params[:page]).per_page(per_page.to_i), meta: @meta
     end
 
     private

--- a/app/controllers/v0/yellow_ribbon_programs_controller.rb
+++ b/app/controllers/v0/yellow_ribbon_programs_controller.rb
@@ -20,6 +20,7 @@ module V0
         version: @version,
         count: search_results.count
       }
+      search_results.per_page = params[:per_page] if params[:per_page]
       render json: search_results.page(params[:page]), meta: @meta
     end
 

--- a/spec/controllers/v0/yellow_ribbon_programs_controller_spec.rb
+++ b/spec/controllers/v0/yellow_ribbon_programs_controller_spec.rb
@@ -96,5 +96,11 @@ RSpec.describe V0::YellowRibbonProgramsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('yellow_ribbon_program')
     end
+
+    it 'respects `per_page`' do
+      get(:index, params: { per_page: 2 })
+      data = JSON.parse(response.body)['data']
+      expect(data.count).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
## Description
add `per_page` functionality to `yellow_ribbon_programs_controller`
This is accomplished by specifying the `per_page` value on the collection, which ActiveModelSerializer respects.

## Testing done
specs

## Acceptance criteria
- [x] add `per_page` functionality to `yellow_ribbon_programs_controller`

## Definition of done
- [ ] ~~Events are logged appropriately~~
- [ ] ~~Documentation has been updated, if applicable~~
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs