### PR TITLE
CT: Nulls on caution flag for search results #7114

### DIFF
--- a/app/models/institution_program.rb
+++ b/app/models/institution_program.rb
@@ -38,7 +38,7 @@ class InstitutionProgram < ApplicationRecord
 
   delegate :school_closing, to: :institution
 
-  delegate :caution_flag, to: :institution
+  delegate :caution_flags, to: :institution
 
   # Finds exact-matching facility_code or partial-matching school and city names
   #

--- a/app/serializers/institution_program_serializer.rb
+++ b/app/serializers/institution_program_serializer.rb
@@ -15,5 +15,5 @@ class InstitutionProgramSerializer < ActiveModel::Serializer
              :va_bah,
              :dod_bah,
              :school_closing,
-             :caution_flag
+             :caution_flags
 end

--- a/spec/serializers/institution_program_serializer_spec.rb
+++ b/spec/serializers/institution_program_serializer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe InstitutionProgramSerializer, type: :serializer do
     expect(attributes['school_closing']).to eq(institution_program.school_closing)
   end
 
-  it 'includes caution_flag' do
-    expect(attributes['caution_flag']).to eq(institution_program.caution_flag)
+  it 'includes caution_flags' do
+    expect(attributes['caution_flags']).to eq(institution_program.caution_flags)
   end
 end


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7114

## Testing done
- create row in `caution_flags` for a vet tec institution and then GET http://localhost:4000/v0/institution_programs/

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs