### PR TITLE
CT: Duplicate caution flags on search results #7111

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -157,7 +157,7 @@ module InstitutionBuilder
   end
 
   # Set the `accreditation_type`, `accreditation_status`, and create `caution_flags` rows
-  # by joining on `ope` for a specific match because not all institutions
+  # by joining on `ope` for a specific match
   # Set the accreditation_type according to the hierarchy hybrid < national < regional
   # We include only those accreditation that are institutional and currently active.
   def self.add_accreditation(version_id)

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -157,9 +157,7 @@ module InstitutionBuilder
   end
 
   # Set the `accreditation_type`, `accreditation_status`, and create `caution_flags` rows
-  # by joining on
-  # `ope6` for more broad match, then `ope` for a more specific match because not all institutions
-  # have a unique `ope` provided.
+  # by joining on `ope` for a specific match because not all institutions
   # Set the accreditation_type according to the hierarchy hybrid < national < regional
   # We include only those accreditation that are institutional and currently active.
   def self.add_accreditation(version_id)
@@ -465,7 +463,7 @@ module InstitutionBuilder
     build_caution_flags(version_id, CautionFlag::SOURCES[:settlement], reason, caution_flag_clause)
   end
 
-  # Sets caution flags and caution flag reasons if the corresponding approved school (by ope6)
+  # Sets caution flags and caution flag reasons if the corresponding approved school by ope
   # has an entry in the hcms table.
   def self.add_hcm(version_id)
     # Leaving old way of setting caution_flag and caution_flag_reason


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7111

With the switch from `ope6` to `ope` caution flags may appear to disappear this is because `ope` is more restrictive as opposed to `ope6` because [`ope6` is a shorter version of `ope`](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/master/app/models/converters/ope6_converter.rb#L4)

## Testing done
- Preview generation then publish 
- http://localhost:3001/gi-bill-comparison-tool/search?category=school&name=STEVENS-HENAGER+COLLEGE-MURRAY vs staging version
- http://localhost:3001/gi-bill-comparison-tool/search?category=school&name=ABILENE+CHRISTIAN+UNIVERSITY vs staging version

## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs