### PR TITLE
Add columns to caution_flags

### DIFF
--- a/db/migrate/20200323092001_add_columns_to_caution_flags.rb
+++ b/db/migrate/20200323092001_add_columns_to_caution_flags.rb
@@ -1,0 +1,8 @@
+class AddColumnsToCautionFlags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :caution_flags, :title, :string
+    add_column :caution_flags, :description, :string
+    add_column :caution_flags, :link_text, :string
+    add_column :caution_flags, :link_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_16_133022) do
+ActiveRecord::Schema.define(version: 2020_03_23_092001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -104,6 +104,10 @@ ActiveRecord::Schema.define(version: 2020_03_16_133022) do
     t.string "reason"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "description"
+    t.string "link_text"
+    t.string "link_url"
   end
 
   create_table "complaints", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description
Add new fields to the `caution_flags` table.

Database migration PR for https://github.com/department-of-veterans-affairs/gibct-data-service/pull/628

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6805

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] `caution_flags` has fields for:
  - Title
  - Description
  - Link text
  - Link URL

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs