### PR TITLE
caution flag filter migration

### DIFF
--- a/db/migrate/20200401125410_add_count_of_caution_flags_column_to_institutions.rb
+++ b/db/migrate/20200401125410_add_count_of_caution_flags_column_to_institutions.rb
@@ -1,0 +1,7 @@
+class AddCountOfCautionFlagsColumnToInstitutions < ActiveRecord::Migration[5.2]
+  # run on rails console to update counter cache
+  #Institution.find_each {|institutions| Institution.reset_counters(institutions.id, :caution_flags)}
+  def change
+      add_column :institutions, :count_of_caution_flags, :integer, :default => 0
+    end
+end

--- a/db/migrate/20200402101010_add_count_of_caution_flags_column_to_institutions_archives.rb
+++ b/db/migrate/20200402101010_add_count_of_caution_flags_column_to_institutions_archives.rb
@@ -1,0 +1,5 @@
+class AddCountOfCautionFlagsColumnToInstitutionsArchives < ActiveRecord::Migration[5.2]
+    def change
+        add_column :institutions_archives, :count_of_caution_flags, :integer, :default => 0
+      end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_23_092001) do
+ActiveRecord::Schema.define(version: 2020_04_02_101010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -408,6 +408,7 @@ ActiveRecord::Schema.define(version: 2020_03_23_092001) do
     t.boolean "complies_with_sec_103"
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
+    t.integer "count_of_caution_flags", default: 0
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin
@@ -554,6 +555,7 @@ ActiveRecord::Schema.define(version: 2020_03_23_092001) do
     t.boolean "complies_with_sec_103"
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
+    t.integer "count_of_caution_flags", default: 0
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description
Added count_of_caution_flags to institutions and institutions archive

story:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7185

related PR
https://github.com/department-of-veterans-affairs/gibct-data-service/pull/635

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] count_of_caution_flags is added to institutions and institutions archive

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs