### PR TITLE
CF: Exclude institutions with warnings filter not excluding cautionary warnings#7747

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -39,6 +39,7 @@ module InstitutionBuilder
     build_institution_programs(version.id)
     build_versioned_school_certifying_official(version.id)
     CautionFlag.map(version.id)
+    set_count_of_caution_flags(version.id)
   end
 
   def self.run(user)
@@ -769,5 +770,18 @@ module InstitutionBuilder
     SQL
     sql = CautionFlag.send(:sanitize_sql, [str])
     CautionFlag.connection.execute(sql)
+  end
+
+  def self.set_count_of_caution_flags(version_id)
+    str = <<-SQL
+      UPDATE institutions SET count_of_caution_flags = (
+        SELECT count(1)
+        FROM caution_flags
+        WHERE caution_flags.institution_id = institutions.id
+        AND institutions.version_id = #{version_id}
+    )
+    SQL
+
+    Institution.connection.update(str)
   end
 end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -938,5 +938,16 @@ RSpec.describe InstitutionBuilder, type: :model do
         end
       end
     end
+
+    describe 'when setting count_of_caution_flags' do
+      it 'has count greater than zero' do
+        create :accreditation_institute_campus
+        create :accreditation_action_probationary
+
+        described_class.run(user)
+
+        expect(institutions.where('count_of_caution_flags > 0').count).to be > 0
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7747

## Testing done
- generate preview and publish to production
- go to local vets-website and search for DODGE CITY COMMUNITY COLLEGE 
- toggle Exclude institutions with warnings  filter

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs