### PR TITLE
Standardize caution flag institution URLS

### DIFF
--- a/app/models/caution_flag.rb
+++ b/app/models/caution_flag.rb
@@ -53,8 +53,7 @@ class CautionFlag < ApplicationRecord
       str = <<-SQL
             UPDATE #{table_name} SET #{cols_to_update(cols_map_update)}
             FROM #{CautionFlagRule.table_name}
-            WHERE #{CautionFlagRule.table_name}.id = #{rule.id}
-            AND #{table_name}.id in (#{ids.join(',')})
+            WHERE #{CautionFlagRule.table_name}.id = #{rule.id} AND #{table_name}.id in (#{ids.join(',')})
       SQL
     end
 

--- a/app/models/caution_flag.rb
+++ b/app/models/caution_flag.rb
@@ -37,7 +37,13 @@ class CautionFlag < ApplicationRecord
     if rule.link_url == CautionFlagRule::SCHOOL_URL
       cols_map_update.pop
       str = <<-SQL
-          UPDATE #{table_name} SET #{cols_to_update(cols_map_update)}, link_url = #{Institution.table_name}.insturl
+            UPDATE #{table_name} SET #{cols_to_update(cols_map_update)},
+            link_url = CASE
+              WHEN LEFT(LOWER(#{Institution.table_name}.insturl), 4) != 'http' THEN
+                'http://' || #{Institution.table_name}.insturl
+              ELSE
+                #{Institution.table_name}.insturl
+              END
           FROM #{CautionFlagRule.table_name}, #{Institution.table_name}
           WHERE #{CautionFlagRule.table_name}.id = #{rule.id}
           AND #{table_name}.id in (#{ids.join(',')})

--- a/spec/factories/caution_flag_rules.rb
+++ b/spec/factories/caution_flag_rules.rb
@@ -17,5 +17,13 @@ FactoryBot.define do
       link_text { "Learn more about this school's accreditation" }
       link_url { 'http://ope.ed.gov/accreditation' }
     end
+
+    trait :closing_settlement_rule do
+      rule { create(:rule, :closing_settlement_reason) }
+      title { 'Campus will be closing soon' }
+      description { 'This campus will be closing soon.' }
+      link_text { "Visit the school's website to learn more" }
+      link_url { 'SCHOOL_URL' }
+    end
   end
 end

--- a/spec/factories/caution_flags.rb
+++ b/spec/factories/caution_flags.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
 
     trait :closing_settlement_pre_map do
       source { Settlement.name }
-      reason { 'TEST' }
+      reason { 'closing reason' }
     end
 
     trait :institution_url_with_protocol do

--- a/spec/factories/caution_flags.rb
+++ b/spec/factories/caution_flags.rb
@@ -18,5 +18,18 @@ FactoryBot.define do
       source { Settlement.name }
       reason { 'Settlement with U.S. Government' }
     end
+
+    trait :closing_settlement_pre_map do
+      source { Settlement.name }
+      reason { 'TEST' }
+    end
+
+    trait :institution_url_with_protocol do
+      institution { create(:institution, insturl: 'http://www.school-good.edu') }
+    end
+
+    trait :institution_url_without_protocol do
+      institution { create(:institution) }
+    end
   end
 end

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -18,5 +18,10 @@ FactoryBot.define do
       object { 'Settlement with U.S. Government' }
       predicate { 'reason' }
     end
+
+    trait :closing_settlement_reason do
+      object { 'TEST' }
+      predicate { 'reason' }
+    end
   end
 end

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :closing_settlement_reason do
-      object { 'TEST' }
+      object { 'closing reason' }
       predicate { 'reason' }
     end
   end

--- a/spec/models/caution_flag_spec.rb
+++ b/spec/models/caution_flag_spec.rb
@@ -27,5 +27,29 @@ RSpec.describe CautionFlag, type: :model do
       expect(described_class.select(:title)
                  .where(version_id: version.id).pluck(:title)).to all(be)
     end
+
+    it 'uses institution url' do
+      flag = create :caution_flag,
+                    :closing_settlement_pre_map,
+                    :institution_url_with_protocol,
+                    version_id: version.id
+      create :caution_flag_rule, :closing_settlement_rule
+
+      described_class.map(version.id)
+
+      expect(flag.reload['link_url']).to eq(flag.institution.insturl)
+    end
+
+    it 'adds protocol to school url' do
+      flag = create :caution_flag,
+                    :closing_settlement_pre_map,
+                    :institution_url_without_protocol,
+                    version_id: version.id
+      create :caution_flag_rule, :closing_settlement_rule
+
+      described_class.map(version.id)
+
+      expect(flag.reload['link_url']).to eq('http://' + flag.institution.insturl)
+    end
   end
 end


### PR DESCRIPTION
## Description
Caution flags for "school closing" settlements are using the `institutions.insturl` as a `link_url` which is causing issues in vets-website when values without a protocol are being treated as relative URLs.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7993

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Link URLs should be absolute

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs