### PR TITLE
Add section_103_message column to institutions

### DIFF
--- a/db/migrate/20200414145010_add_section103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section103_message_column_to_institutions.rb
@@ -1,0 +1,5 @@
+class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions, :section103_message, :string
+  end
+end

--- a/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
@@ -1,5 +1,5 @@
 class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
   def change
-    add_column :institutions, :section103_message, :string
+    add_column :institutions, :section_103_message, :string
   end
 end

--- a/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
@@ -1,5 +1,5 @@
 class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
   def change
-    add_column :institutions, :section_103_message, :string
+    add_column :institutions, :section_103_message, :string, default: 'No information available at this time'
   end
 end

--- a/db/migrate/20200415150200_add_section_103_message_column_to_institutions_archives.rb
+++ b/db/migrate/20200415150200_add_section_103_message_column_to_institutions_archives.rb
@@ -1,0 +1,5 @@
+class AddSection103MessageColumnToInstitutionsArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions_archives, :section_103_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_145010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
-    t.string "section103_message"
+    t.string "section_103_message"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_145010) do
+ActiveRecord::Schema.define(version: 2020_04_15_150200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -568,6 +568,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_145010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
+    t.string "section_103_message"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_150200) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
-    t.string "section_103_message"
+    t.string "section_103_message", default: "No information available at this time"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_101010) do
+ActiveRecord::Schema.define(version: 2020_04_14_145010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -420,6 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_101010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
+    t.string "section103_message"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin


### PR DESCRIPTION
## Description
Add `section_103_message` column to `institutions`

DB migration PR for https://github.com/department-of-veterans-affairs/gibct-data-service/pull/643

[ZenHub issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7843)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Column  `section_103_message` column added to `institutions` table

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs