### PR TITLE
CF: Exclude institutions with warnings filter not excluding cautionary warnings #7747

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -779,7 +779,8 @@ module InstitutionBuilder
         FROM caution_flags
         WHERE caution_flags.institution_id = institutions.id
         AND institutions.version_id = #{version_id}
-    )
+      )
+      WHERE institutions.version_id = #{version_id}
     SQL
 
     Institution.connection.update(str)


### PR DESCRIPTION
## Description
the sql that was setting `count_of_caution_flags` was zeroing out the current production version's institutions during preview generation

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs