### PR TITLE
Section 103 institution updates

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -642,20 +642,17 @@ module InstitutionBuilder
   def self.add_sec103(version_id)
     str = <<-SQL
       -- default message
-      UPDATE Institutions
-      SET section_103_message = 'No information available at this time'
+      UPDATE Institutions SET section_103_message = 'No information available at this time'
       WHERE version_id = #{version_id};
 
       -- set message based on sec103s
       UPDATE institutions SET
         #{columns_for_update(Sec103)},
         section_103_message = CASE
-          WHEN sec103s.complies_with_sec_103 = true
-            AND sec103s.solely_requires_coe = false
+          WHEN sec103s.complies_with_sec_103 = true AND sec103s.solely_requires_coe = false
             AND (sec103s.requires_coe_and_criteria = true OR sec103s.requires_coe_and_criteria IS NULL) THEN
             'Requires Certificate of Eligibility (COE) and additional criteria'
-          WHEN sec103s.complies_with_sec_103 = true
-            AND sec103s.solely_requires_coe = true THEN
+          WHEN sec103s.complies_with_sec_103 = true AND sec103s.solely_requires_coe = true THEN
             'Requires Certificate of Eligibility (COE)'
           ELSE
             'No information available at this time'

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -651,14 +651,14 @@ module InstitutionBuilder
         #{columns_for_update(Sec103)},
         section_103_message = CASE
           WHEN sec103s.complies_with_sec_103 = true
-            AND sec103s.solely_requires_coe = false 
+            AND sec103s.solely_requires_coe = false
             AND (sec103s.requires_coe_and_criteria = true OR sec103s.requires_coe_and_criteria IS NULL) THEN
             'Requires Certificate of Eligibility (COE) and additional criteria'
           WHEN sec103s.complies_with_sec_103 = true
             AND sec103s.solely_requires_coe = true THEN
             'Requires Certificate of Eligibility (COE)'
           ELSE
-            'No information available at this time'  
+            'No information available at this time'
           END
       FROM  sec103s
       WHERE institutions.facility_code = sec103s.facility_code
@@ -670,7 +670,9 @@ module InstitutionBuilder
       AND institutions.version_id = #{version_id};
     SQL
 
-    Institution.connection.execute(str)
+    sql = InstitutionProgram.send(:sanitize_sql, [str])
+
+    Institution.connection.execute(sql)
   end
 
   # edu_programs.length_in_weeks is being used twice because

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -641,10 +641,6 @@ module InstitutionBuilder
 
   def self.add_sec103(version_id)
     str = <<-SQL
-      -- default message
-      UPDATE Institutions SET section_103_message = 'No information available at this time'
-      WHERE version_id = #{version_id};
-
       -- set message based on sec103s
       UPDATE institutions SET
         #{columns_for_update(Sec103)},

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -94,9 +94,6 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :facility_map
   attribute :programs
   attribute :versioned_school_certifying_officials
-  attribute :complies_with_sec_103
-  attribute :solely_requires_coe
-  attribute :requires_coe_and_criteria
   attribute :count_of_caution_flags
   attribute :section_103_message
 

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -98,6 +98,7 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :solely_requires_coe
   attribute :requires_coe_and_criteria
   attribute :count_of_caution_flags
+  attribute :section_103_message
 
   link(:website) { object.website_link }
   link(:scorecard) { object.scorecard_link }

--- a/db/migrate/20200414145010_add_section103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section103_message_column_to_institutions.rb
@@ -1,0 +1,5 @@
+class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions, :section103_message, :string
+  end
+end

--- a/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
@@ -1,5 +1,5 @@
 class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
   def change
-    add_column :institutions, :section103_message, :string
+    add_column :institutions, :section_103_message, :string
   end
 end

--- a/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
+++ b/db/migrate/20200414145010_add_section_103_message_column_to_institutions.rb
@@ -1,5 +1,5 @@
 class AddSection103MessageColumnToInstitutions < ActiveRecord::Migration[5.2]
   def change
-    add_column :institutions, :section_103_message, :string
+    add_column :institutions, :section_103_message, :string, default: 'No information available at this time'
   end
 end

--- a/db/migrate/20200415150200_add_section_103_message_column_to_institutions_archives.rb
+++ b/db/migrate/20200415150200_add_section_103_message_column_to_institutions_archives.rb
@@ -1,0 +1,5 @@
+class AddSection103MessageColumnToInstitutionsArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions_archives, :section_103_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_145010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
-    t.string "section103_message"
+    t.string "section_103_message"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_145010) do
+ActiveRecord::Schema.define(version: 2020_04_15_150200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -568,6 +568,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_145010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
+    t.string "section_103_message"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_150200) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
-    t.string "section_103_message"
+    t.string "section_103_message", default: "No information available at this time"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_101010) do
+ActiveRecord::Schema.define(version: 2020_04_14_145010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -420,6 +420,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_101010) do
     t.boolean "solely_requires_coe"
     t.boolean "requires_coe_and_criteria"
     t.integer "count_of_caution_flags", default: 0
+    t.string "section103_message"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin

--- a/spec/factories/sec103s.rb
+++ b/spec/factories/sec103s.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     complies_with_sec_103 { true }
     solely_requires_coe { true }
     requires_coe_and_criteria { true }
+
+    trait :requires_additional do
+      solely_requires_coe { false }
+    end
+
+    trait :does_not_comply do
+      complies_with_sec_103 { false }
+    end
   end
 end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -949,5 +949,44 @@ RSpec.describe InstitutionBuilder, type: :model do
         expect(institutions.where('count_of_caution_flags > 0').count).to be > 0
       end
     end
+
+    describe 'when setting section 103 data' do
+      it 'sets default message' do
+        create :weam
+        described_class.run(user)
+
+        expect(institutions.all)
+            .to all(have_attributes('section_103_message' => 'No information available at this time'))
+      end
+
+      it 'sets certificate required message' do
+        weam = create :weam
+        create :sec103, facility_code: weam.facility_code
+
+        described_class.run(user)
+
+        expect(institutions.where("facility_code = '#{weam.facility_code}'").first['section_103_message'])
+            .to eq('Requires Certificate of Eligibility (COE)')
+      end
+
+      it 'sets certificate required plus additional message' do
+        weam = create :weam
+        create :sec103, :requires_additional, facility_code: weam.facility_code
+
+        described_class.run(user)
+
+        expect(institutions.where("facility_code = '#{weam.facility_code}'").first['section_103_message'])
+            .to eq('Requires Certificate of Eligibility (COE) and additional criteria')
+      end
+
+      it 'institutions that explicitly do not comply with section 103 are not approved ' do
+        weam = create :weam
+        create :sec103, :does_not_comply, facility_code: weam.facility_code
+
+        described_class.run(user)
+
+        expect(institutions.where("facility_code = '#{weam.facility_code}'").first['approved']).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -956,7 +956,7 @@ RSpec.describe InstitutionBuilder, type: :model do
         described_class.run(user)
 
         expect(institutions.all)
-            .to all(have_attributes('section_103_message' => 'No information available at this time'))
+          .to all(have_attributes('section_103_message' => 'No information available at this time'))
       end
 
       it 'sets certificate required message' do
@@ -966,7 +966,7 @@ RSpec.describe InstitutionBuilder, type: :model do
         described_class.run(user)
 
         expect(institutions.where("facility_code = '#{weam.facility_code}'").first['section_103_message'])
-            .to eq('Requires Certificate of Eligibility (COE)')
+          .to eq('Requires Certificate of Eligibility (COE)')
       end
 
       it 'sets certificate required plus additional message' do
@@ -976,7 +976,7 @@ RSpec.describe InstitutionBuilder, type: :model do
         described_class.run(user)
 
         expect(institutions.where("facility_code = '#{weam.facility_code}'").first['section_103_message'])
-            .to eq('Requires Certificate of Eligibility (COE) and additional criteria')
+          .to eq('Requires Certificate of Eligibility (COE) and additional criteria')
       end
 
       it 'institutions that explicitly do not comply with section 103 are not approved ' do

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -462,7 +462,7 @@
                   "type": "array",
                   "items": {
                     "type": "object"
-                  }x
+                  }
                 }
               }
             },

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -478,14 +478,8 @@
                 "type": "object"
               }
             },
-            "complies_with_sec_103": {
-              "type": ["null", "boolean"]
-            },
-            "solely_requires_coe": {
-              "type": ["null", "boolean"]
-            },
-            "requires_coe_and_criteria": {
-              "type": ["null", "boolean"]
+            "section_103_message": {
+              "type": ["null", "string"]
             },
             "count_of_caution_flags": {
               "type": ["null", "number"]

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -462,7 +462,7 @@
                   "type": "array",
                   "items": {
                     "type": "object"
-                  }
+                  }x
                 }
               }
             },


### PR DESCRIPTION
## Description

A section 103 related messaged will be displayed on the comparison tool institution profile page.  This PR sets the value of that message as well as the the `approved field based on sec103s data.

[ZenHub issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7843)

DB migration PR: https://github.com/department-of-veterans-affairs/gibct-data-service/pull/641

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] If there is no 103 data for a facility, the institution profile displays 'No information available at this time' text.
- [x] If the 103 data value for “Complies with Section 103” is N, the facility is not displayed in the CT.
 - [x] If the 103 data value for “Complies with Section 103” is blank OR the data for “Soley Requirs COE” is blank, the institution profile displays 'No information available at this time' text.
 - [x] If the 103 data value meets the following criteria, the institution profile display the 103 text “Requires Certificate of Eligibility (COE) and additional criteria”:
    - Complies with Section 103 = Y
    - Soley Requires COE = N
    - Requires COE & Additional Criteria = Y OR Blank
- [x] If the 103 data value meets the following criteria, the institution profile display 'No information available at this time' text:
    - Complies with Section 103 = Y
    - Soley Requires COE = N
    - Requires COE & Additional Criteria = N
- [x] If the 103 data value meets the following criteria, the institution profile display the 103 text “Requires Certificate of Eligibility (COE)”:
    - Complies with Section 103 = Y
    - Soley Requires COE = Y

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs