### PR TITLE
CF: Update Caution Flag value for Ashford University Online #8882

### DIFF
--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -246,10 +246,10 @@ if ENV['CI'].blank?
       },
       #settlement
       {rule_id: rule_id(rule_results, 'The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending'),
-       title: 'School is facing a potential loss of program approval',
-       description: 'There may be a loss of program approval for this school.',
-       link_text: 'More information on Ashford University',
-       link_url: 'https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA',
+       title: 'State\'s Attorney General filed suit',
+       description: 'The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending',
+       link_text: nil,
+       link_url: nil,
       },
   ]
 

--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -248,8 +248,8 @@ if ENV['CI'].blank?
       {rule_id: rule_id(rule_results, 'The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending'),
        title: 'School is facing a potential loss of program approval',
        description: 'There may be a loss of program approval for this school.',
-       link_text: nil,
-       link_url: nil,
+       link_text: 'More information on Ashford University',
+       link_url: 'https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA',
       },
   ]
 

--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -117,7 +117,7 @@ if ENV['CI'].blank?
                matcher: Rule::MATCHERS[:has],
                subject: nil,
                predicate: 'reason',
-               object: 'There may be a potential lapse in program approval for Ashford University. VA may be forced to stop making benefit payments unless Ashford continues to show a good faith effort to seek approval in California. The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending.',
+               object: 'The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending',
                priority: 2),
   ]
 
@@ -245,7 +245,7 @@ if ENV['CI'].blank?
        link_url: nil,
       },
       #settlement
-      {rule_id: rule_id(rule_results, 'There may be a potential lapse in program approval for Ashford University. VA may be forced to stop making benefit payments unless Ashford continues to show a good faith effort to seek approval in California. The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending.'),
+      {rule_id: rule_id(rule_results, 'The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending'),
        title: 'School is facing a potential loss of program approval',
        description: 'There may be a loss of program approval for this school.',
        link_text: nil,


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8882

`settlement_description` in  Settlement CSV for ASHFORD UNIVERSITY-ONLINE does not match Caution Flag mapping rule, need to update the rule to match what is in the Settlement CSV column `settlement_description`

## Testing done
- `bundle exec rake db:seed_rules`

## Screenshots


## Acceptance criteria
- [ ] Displayed caution flag for ASHFORD UNIVERSITY-ONLINE should be

```
title: 'School is facing a potential loss of program approval',
description: 'There may be a loss of program approval for this school.',
link_text: 'More information on Ashford University',
link_url: 'https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA',
```

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs