### PR TITLE
Update default IHL institution section 103 message

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -5,6 +5,8 @@ class Institution < ApplicationRecord
 
   EMPLOYER = 'OJT'
 
+  DEFAULT_IHL_SECTION_103_MESSAGE = 'Contact the School Certifying Official (SCO) for requirements'
+
   LOCALE = {
     11 => 'city', 12 => 'city', 13 => 'city',
     21 => 'suburban', 22 => 'suburban', 23 => 'suburban',

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -642,7 +642,7 @@ module InstitutionBuilder
   def self.add_sec103(version_id)
     str = <<-SQL
       -- set default message for IHL institutions
-      UPDATE institutions SET section_103_message = 'No information available at this time'
+      UPDATE institutions SET section_103_message = '#{Institution::DEFAULT_IHL_SECTION_103_MESSAGE}'
       FROM weams
       WHERE weams.facility_code = institutions.facility_code
         AND SUBSTRING(weams.facility_code, 1, 2) IN('11', '12', '13', '21', '22', '23', '31', '32', '33')

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -956,7 +956,7 @@ RSpec.describe InstitutionBuilder, type: :model do
         described_class.run(user)
 
         expect(institutions.where("facility_code = '#{weam.facility_code}'").first['section_103_message'])
-          .to eq('No information available at this time')
+          .to eq(Institution::DEFAULT_IHL_SECTION_103_MESSAGE)
       end
 
       it 'does not set default message for nonIHL institutions' do


### PR DESCRIPTION
## Description
Updated default IHL institution section 103 message value

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8313)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Default section 103 message for IHL institutions is "Contact the School Certifying Official (SCO) for requirements"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs