### PR TITLE
Only generate Versioned SCOs for allowed priority values

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -767,7 +767,7 @@ module InstitutionBuilder
         i.id
       FROM school_certifying_officials s
       INNER JOIN institutions i ON i.facility_code = s.facility_code
-      WHERE i.version_id = #{version_id}
+      WHERE i.version_id = #{version_id} AND LOWER(s.priority) IN('primary', 'secondary')
     SQL
 
     sql = SchoolCertifyingOfficial.send(:sanitize_sql, [str])

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -740,6 +740,7 @@ module InstitutionBuilder
   end
 
   def self.build_versioned_school_certifying_official(version_id)
+    valid_priorities = VersionedSchoolCertifyingOfficial::VALID_PRIORITY_VALUES.map { |value| "'#{value}'" }.join(', ')
     str = <<-SQL
       INSERT INTO versioned_school_certifying_officials(
         facility_code,
@@ -767,7 +768,7 @@ module InstitutionBuilder
         i.id
       FROM school_certifying_officials s
       INNER JOIN institutions i ON i.facility_code = s.facility_code
-      WHERE i.version_id = #{version_id} AND LOWER(s.priority) IN('primary', 'secondary')
+      WHERE i.version_id = #{version_id} AND UPPER(s.priority) IN(#{valid_priorities})
     SQL
 
     sql = SchoolCertifyingOfficial.send(:sanitize_sql, [str])

--- a/app/models/versioned_school_certifying_official.rb
+++ b/app/models/versioned_school_certifying_official.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 class VersionedSchoolCertifyingOfficial < ApplicationRecord
+  VALID_PRIORITY_VALUES = %w[
+    PRIMARY
+    SECONDARY
+  ].freeze
+
   belongs_to :institution
 end

--- a/spec/factories/school_certifying_official.rb
+++ b/spec/factories/school_certifying_official.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     phone_number { '1337852' }
     phone_extension { '1234' }
     email { 'dsample@cfu.edu' }
+
+    trait :invalid_priority do
+      priority { 'OTHER' }
+    end
   end
 end

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -939,6 +939,13 @@ RSpec.describe InstitutionBuilder, type: :model do
         expect(VersionedSchoolCertifyingOfficial.last.institution_id).to be_present
       end
 
+      it 'ignores priority casing' do
+        weam = create(:weam)
+        create :school_certifying_official, facility_code: weam.facility_code, priority: 'primarY'
+        expect { described_class.run(user) }.to change(VersionedSchoolCertifyingOfficial, :count).from(0).to(1)
+        expect(VersionedSchoolCertifyingOfficial.last.institution_id).to be_present
+      end
+
       it 'does not create VSCO for SCO with invalid priority value' do
         weam = create(:weam)
         create :school_certifying_official, :invalid_priority, facility_code: weam.facility_code

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -929,13 +929,21 @@ RSpec.describe InstitutionBuilder, type: :model do
       it 'sets correctly for VET TEC institution' do
         expect(institutions.find_by(facility_code: '1VZZZZZZ').approved).to be_truthy
       end
+    end
 
-      describe 'when generating school certifying official table' do
-        it 'properly generates school certifying official with instituion_id' do
-          create :school_certifying_official, facility_code: '1ZZZZZZZ'
-          expect { described_class.run(user) }.to change(VersionedSchoolCertifyingOfficial, :count).from(0).to(1)
-          expect(VersionedSchoolCertifyingOfficial.last.institution_id).to be_present
-        end
+    describe 'when creating versioned_school_certifying_officials' do
+      it 'properly generates school certifying official with instituion_id' do
+        weam = create(:weam)
+        create :school_certifying_official, facility_code: weam.facility_code
+        expect { described_class.run(user) }.to change(VersionedSchoolCertifyingOfficial, :count).from(0).to(1)
+        expect(VersionedSchoolCertifyingOfficial.last.institution_id).to be_present
+      end
+
+      it 'does not create VSCO for SCO with invalid priority value' do
+        weam = create(:weam)
+        create :school_certifying_official, :invalid_priority, facility_code: weam.facility_code
+        described_class.run(user)
+        expect(VersionedSchoolCertifyingOfficial.count).to be_zero
       end
     end
 


### PR DESCRIPTION
## Description
Update to institution_builder to only ignore `school_certifying_officials` records with a priority other than Primary and Secondary when creating `versioned_school_certifying_officials`.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8948)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] SCO data with a priority other than "Primary" OR "Secondary", non case-sensitive, is not included in new GIDS version creation.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs