### PR TITLE
8319: Add new caution flag plain language mappings

### DIFF
--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -119,6 +119,18 @@ if ENV['CI'].blank?
                predicate: 'reason',
                object: 'There may be a potential lapse in program approval for Ashford University. VA may be forced to stop making benefit payments unless Ashford continues to show a good faith effort to seek approval in California. The State Attorney General filed a lawsuit against Ashford University for engaging in unlawful business practices, and litigation is pending.',
                priority: 2),
+      Rule.new(rule_name: CautionFlag.name,
+               matcher: Rule::MATCHERS[:has],
+               subject: nil,
+               predicate: 'reason',
+               object: 'Federal Trade Commission Filed Suit for Deceptive Action',
+               priority: 2),
+      Rule.new(rule_name: CautionFlag.name,
+               matcher: Rule::MATCHERS[:has],
+               subject: nil,
+               predicate: 'reason',
+               object: 'States Attorney General Filed Suit for Deceptive Action',
+               priority: 2),
   ]
 
   results = Rule.import(values, returning: [:id, :object])
@@ -225,7 +237,7 @@ if ENV['CI'].blank?
       },
       #settlement
       {rule_id: rule_id(rule_results, 'Settlement reached with States Attorney General'),
-       title: 'School has settled its case with the state Attorney General',
+       title: 'Settlement reached with state\'s Attorney General',
        description: 'The state\'s Attorney General has reached a settlement with this school. ',
        link_text: nil,
        link_url: nil,
@@ -251,6 +263,20 @@ if ENV['CI'].blank?
        link_text: nil,
        link_url: nil,
       },
+      #settlement
+      {rule_id: rule_id(rule_results, 'Federal Trade Commission Filed Suit for Deceptive Action'),
+        title: 'Federal Trade Commission (FTC) filed suit for deceptive action',
+        description: 'The FTC filed a suit against this school for deceptive action. VA may suspend benefits to this school.',
+        link_text: nil,
+        link_url: nil,
+       },
+       #settlement
+      {rule_id: rule_id(rule_results, 'States Attorney General Filed Suit for Deceptive Action'),
+        title: 'State\'s Attorney General filed suit for deceptive action',
+        description: 'The state\'s Attorney General filed suit against this school for deceptive action. VA may suspend benefits to this school.',
+        link_text: nil,
+        link_url: nil,
+       },
   ]
 
   CautionFlagRule.import(values, validate: false)


### PR DESCRIPTION
## Description
As a developer, I need to update the Caution Flag content for any issues found post launch so that the user has a good experience when using the Comparison Tool

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8319)

## Testing done
CI tests pass locally after making changes.

## Screenshots
<img width="994" alt="Screen Shot 2020-05-29 at 4 05 29 PM" src="https://user-images.githubusercontent.com/48804834/83419924-de4a1980-a3f3-11ea-84d1-b44b516fa101.png">
<img width="991" alt="Screen Shot 2020-05-29 at 4 05 04 PM" src="https://user-images.githubusercontent.com/48804834/83419927-dee2b000-a3f3-11ea-9db9-a67dd8687cc0.png">
<img width="1023" alt="Screen Shot 2020-05-29 at 4 03 49 PM" src="https://user-images.githubusercontent.com/48804834/83419928-df7b4680-a3f3-11ea-953a-ab9cb1875516.png">
<img width="714" alt="Screen Shot 2020-05-29 at 4 01 41 PM" src="https://user-images.githubusercontent.com/48804834/83419929-df7b4680-a3f3-11ea-9478-2ed1c7bd7182.png">


## Acceptance criteria
- [x] The Caution Flag "Federal Trade Commission Filed Suit for Deceptive Action" received in the settlement.csv file uploaded to GIDS is displayed in the following way on the Comparison Tool:
Title: Federal Trade Commission (FTC) filed suit for deceptive action
Description: The FTC filed a suit against this school for deceptive action. VA may suspend benefits to this school.
- [x] The Caution Flag "States Attorney General Filed Suit for Deceptive Action" received in the settlement.csv file uploaded to GIDS is displayed in the following way on the Comparison Tool:
Title: State’s Attorney General filed suit for deceptive action
Description: The state’s Attorney General filed suit against this school for deceptive action. VA may suspend benefits to this school.
- [x] The Caution Flag "Settlement reached with States Attorney General" received in the settlement.csv file uploaded to GIDS is displayed in the following way on the Comparison Tool:
Title: Settlement reached with state’s Attorney General
Description: The state's Attorney General has reached a settlement with this school.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs