### PR TITLE
9851: Update caution flag plain language mappings

### DIFF
--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -123,7 +123,7 @@ if ENV['CI'].blank?
                matcher: Rule::MATCHERS[:has],
                subject: nil,
                predicate: 'reason',
-               object: 'Federal Trade Commission Filed Suit for Deceptive Action',
+               object: 'Federal Trade Commission (FTC) filed suit for deceptive action',
                priority: 2),
       Rule.new(rule_name: CautionFlag.name,
                matcher: Rule::MATCHERS[:has],
@@ -264,7 +264,7 @@ if ENV['CI'].blank?
        link_url: nil,
       },
       #settlement
-      {rule_id: rule_id(rule_results, 'Federal Trade Commission Filed Suit for Deceptive Action'),
+      {rule_id: rule_id(rule_results, 'Federal Trade Commission (FTC) filed suit for deceptive action'),
         title: 'Federal Trade Commission (FTC) filed suit for deceptive action',
         description: 'The FTC filed a suit against this school for deceptive action. VA may suspend benefits to this school.',
         link_text: nil,


### PR DESCRIPTION
## Description
As a developer, I need to update the Caution Flag content for any issues found post launch so that the user has a good experience when using the Comparison Tool

[Originating issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9851)

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] The Caution Flag "Federal Trade Commission (FTC) filed suit for deceptive action" received in the settlement.csv file uploaded to GIDS is displayed in the following way on the Comparison Tool:
Title: Federal Trade Commission (FTC) filed suit for deceptive action
Description: The FTC filed a suit against this school for deceptive action. VA may suspend benefits to this school.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs