### PR TITLE
Settlements matching

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -451,6 +451,7 @@ module InstitutionBuilder
     SQL
     caution_flag_clause = <<-SQL
 	    FROM institutions JOIN settlements on institutions.cross = settlements.cross
+        OR institutions.facility_code = settlements.cross
       WHERE settlements.cross IS NOT NULL
       AND institutions.version_id = #{version_id}
     SQL

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -439,7 +439,7 @@ module InstitutionBuilder
         WHERE "cross" IS NOT NULL
         GROUP BY "cross"
       ) settlement_list
-      WHERE institutions.cross = settlement_list.cross
+      WHERE institutions.cross = settlement_list.cross OR institutions.facility_code = settlement_list.cross
       AND institutions.version_id = #{version_id}
     SQL
 

--- a/spec/factories/settlements.rb
+++ b/spec/factories/settlements.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       cross { '999999' }
     end
 
+    trait :matches_by_facility_code do
+      cross { '1ZZZZZZZ' }
+    end
+
     initialize_with do
       new(cross: cross, settlement_description: settlement_description)
     end


### PR DESCRIPTION
## Description
Update institution builder to create caution flags for settlement records that match settlement unitid to institutions by facility code as well as IPEDS

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9857)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] The settlement file data is included in the GIDS version data when ONE OF the following conditions are met:
  - The settlement unitid column matches the weams iped column
  - The settlement unitid column matches the weams facility code column

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs