### PR TITLE
Add "fuzzy search" of institutions by name and city

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -34,7 +34,7 @@ module V0
           (SIMILARITY(institution, :search_term) + SIMILARITY(city, :search_term)) / 2 DESC,
           institution ASC
         SQL
-        sanitized_order_by = Institution::sanitize_sql_for_conditions([order_by, search_term: "#{@query[:name]}"])
+        sanitized_order_by = Institution.sanitize_sql_for_conditions([order_by, search_term: (@query[:name]).to_s])
         render json: search_results.order(sanitized_order_by).page(params[:page]), meta: @meta
       else
         render json: search_results.order(:institution).page(params[:page]), meta: @meta
@@ -92,8 +92,8 @@ module V0
     def search_results
       @query ||= normalized_query_params
       relation = approved_institutions
-                     .where(vet_tec_provider: false)
-                     .search(@query[:name], @query[:include_address], @query.key?(:fuzzy_search))
+                 .where(vet_tec_provider: false)
+                 .search(@query[:name], @query[:include_address], @query.key?(:fuzzy_search))
       filter_results(relation)
     end
 

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -29,7 +29,16 @@ module V0
         facets: facets
       }
 
-      render json: search_results.order(:institution).page(params[:page]), meta: @meta
+      if @query.key?(:fuzzy_search)
+        order_by = <<-SQL
+          (SIMILARITY(institution, :search_term) + SIMILARITY(city, :search_term)) / 2 DESC,
+          institution ASC
+        SQL
+        sanitized_order_by = Institution::sanitize_sql_for_conditions([order_by, search_term: "#{@query[:name]}"])
+        render json: search_results.order(sanitized_order_by).page(params[:page]), meta: @meta
+      else
+        render json: search_results.order(:institution).page(params[:page]), meta: @meta
+      end
     end
 
     # GET /v0/institutions/20005123
@@ -82,7 +91,9 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      relation = approved_institutions.where(vet_tec_provider: false).search(@query[:name], @query[:include_address])
+      relation = approved_institutions
+                     .where(vet_tec_provider: false)
+                     .search(@query[:name], @query[:include_address], @query.key?(:fuzzy_search))
       filter_results(relation)
     end
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -255,7 +255,7 @@ class Institution < ApplicationRecord
                                    facility_code: search_term.upcase,
                                    upper_search_term: "%#{search_term.upcase}%",
                                    lower_search_term: "%#{search_term.downcase}%",
-                                   search_term: "#{search_term}",
+                                   search_term: search_term.to_s,
                                    name_threshold: Settings.institution_name_similarity_threshold,
                                    city_threshold: Settings.institution_city_similarity_threshold])
     )

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -234,15 +234,14 @@ class Institution < ApplicationRecord
     return if search_term.blank?
 
     clause = [
-      'facility_code = (:facility_code)'
+      'facility_code = (:facility_code)',
+      'institution LIKE (:upper_search_term)',
+      'city LIKE (:upper_search_term)'
     ]
 
     if fuzzy_search
       clause << "SIMILARITY(institution, :search_term) > #{Settings.institution_name_similarity_threshold}"
       clause << "SIMILARITY(city, :search_term) > #{Settings.institution_city_similarity_threshold}"
-    else
-      clause << 'institution LIKE (:upper_search_term)'
-      clause << 'city LIKE (:upper_search_term)'
     end
 
     if include_address

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -237,8 +237,8 @@ class Institution < ApplicationRecord
     ]
 
     if fuzzy_search
-      clause << 'SIMILARITY(institution, :search_term) > :name_threshold'
-      clause << 'SIMILARITY(city, :search_term) > :city_threshold'
+      clause << "SIMILARITY(institution, :search_term) > #{Settings.institution_name_similarity_threshold}"
+      clause << "SIMILARITY(city, :search_term) > #{Settings.institution_city_similarity_threshold}"
     else
       clause << 'institution LIKE (:upper_search_term)'
       clause << 'city LIKE (:upper_search_term)'
@@ -255,9 +255,7 @@ class Institution < ApplicationRecord
                                    facility_code: search_term.upcase,
                                    upper_search_term: "%#{search_term.upcase}%",
                                    lower_search_term: "%#{search_term.downcase}%",
-                                   search_term: search_term.to_s,
-                                   name_threshold: Settings.institution_name_similarity_threshold,
-                                   city_threshold: Settings.institution_city_similarity_threshold])
+                                   search_term: search_term.to_s])
     )
   }
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,7 @@ scorecard:
   api_key: <%= ENV['SCORECARD_API_KEY'] %>
 
 environment: <%= ENV['DEPLOYMENT_ENV'] %>
+
+institution_name_similarity_threshold: .7
+
+institution_city_similarity_threshold: .7

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,1 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
-institution_name_similarity_threshold: .8
-institution_city_similarity_threshold: .8

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,3 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
+institution_name_similarity_threshold: .8
+institution_city_similarity_threshold: .8

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,1 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
-institution_name_similarity_threshold: .8
-institution_city_similarity_threshold: .8

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,1 +1,3 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
+institution_name_similarity_threshold: .8
+institution_city_similarity_threshold: .8

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,1 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
-institution_name_similarity_threshold: .8
-institution_city_similarity_threshold: .8

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,3 @@
 college_navigator_url: 'https://nces.ed.gov/collegenavigator'
+institution_name_similarity_threshold: .8
+institution_city_similarity_threshold: .8

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end
-    
+
     it 'search returns results fuzzy-matching name' do
       create(:institution, :independent_study, version_id: Version.current_production.id)
       get(:index, params: { name: 'UNIVERSITY OF NDEPENDENT STUDY', fuzzy_search: true })

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -321,6 +321,14 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end
+    
+    it 'search returns results fuzzy-matching name' do
+      create(:institution, :independent_study, version_id: Version.current_production.id)
+      get(:index, params: { name: 'UNIVERSITY OF NDEPENDENT STUDY', fuzzy_search: true })
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
 
     it 'search returns case-insensitive results' do
       get(:index, params: { name: 'CHICAGO' })

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -330,6 +330,22 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response).to match_response_schema('institutions')
     end
 
+    it 'search returns results fuzzy-matching city' do
+      create(:institution, :independent_study, city: 'VERY LONG CITY NAME', version_id: Version.current_production.id)
+      get(:index, params: { name: 'VERY LONG CITY AME', fuzzy_search: true })
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
+    it 'search uses fuzzy_search flag' do
+      create(:institution, :independent_study, version_id: Version.current_production.id)
+      get(:index, params: { name: 'UNIVERSITY OF NDEPENDENT STUDY' })
+      expect(JSON.parse(response.body)['data'].count).to eq(0)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
     it 'search returns case-insensitive results' do
       get(:index, params: { name: 'CHICAGO' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)


### PR DESCRIPTION
## Description
Added `fuzzy_search` param.  This will enable it to be accessible behind the `gibctSearchEnhancements` feature flag in vets-website.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10613)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Institution search results return partial matches based on the defined threshold on any of the following search criteria:
  - a. City
  - b. Institution Name
- [x] The institution search results are sorted in the following order:
  - a. % Match
  - b. Institution Name

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs