### PR TITLE
add physical zip and ialias criteria to free text institution search 

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -237,7 +237,7 @@ class Institution < ApplicationRecord
       'facility_code = (:facility_code)',
       'institution LIKE (:upper_search_term)',
       'city LIKE (:upper_search_term)'
-     ]
+    ]
 
     if fuzzy_search
       clause << "SIMILARITY(institution, :search_term) > #{Settings.institution_name_similarity_threshold}"

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -236,12 +236,17 @@ class Institution < ApplicationRecord
     clause = [
       'facility_code = (:facility_code)',
       'institution LIKE (:upper_search_term)',
-      'city LIKE (:upper_search_term)'
-    ]
+      'city LIKE (:upper_search_term)',
+      'ialias = (:search_term)',
+      'ialias = (:facility_code)'
+     ]
 
     if fuzzy_search
       clause << "SIMILARITY(institution, :search_term) > #{Settings.institution_name_similarity_threshold}"
       clause << "SIMILARITY(city, :search_term) > #{Settings.institution_city_similarity_threshold}"
+      clause << 'zip = (:search_term)'
+      clause << 'ialias LIKE (:search_term)'
+      clause << 'ialias LIKE upper(:search_term)'
     end
 
     if include_address

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -236,9 +236,7 @@ class Institution < ApplicationRecord
     clause = [
       'facility_code = (:facility_code)',
       'institution LIKE (:upper_search_term)',
-      'city LIKE (:upper_search_term)',
-      'ialias = (:search_term)',
-      'ialias = (:facility_code)'
+      'city LIKE (:upper_search_term)'
      ]
 
     if fuzzy_search

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -243,8 +243,7 @@ class Institution < ApplicationRecord
       clause << "SIMILARITY(institution, :search_term) > #{Settings.institution_name_similarity_threshold}"
       clause << "SIMILARITY(city, :search_term) > #{Settings.institution_city_similarity_threshold}"
       clause << 'zip = (:search_term)'
-      clause << 'ialias LIKE (:search_term)'
-      clause << 'ialias LIKE upper(:search_term)'
+      clause << 'ialias LIKE (:upper_search_term)'
     end
 
     if include_address

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -39,6 +39,7 @@ module InstitutionBuilder
     build_versioned_school_certifying_official(version.id)
     CautionFlag.map(version.id)
     set_count_of_caution_flags(version.id)
+    update_ialias_to_upper(version.id)
   end
 
   def self.run(user)
@@ -803,6 +804,13 @@ module InstitutionBuilder
       WHERE institutions.version_id = #{version_id}
     SQL
 
+    Institution.connection.update(str)
+  end
+
+  def self.update_ialias_to_upper(version_id)
+    str = <<-SQL
+        UPDATE institutions SET ialias = upper(ialias)
+    SQL
     Institution.connection.update(str)
   end
 end

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -39,7 +39,6 @@ module InstitutionBuilder
     build_versioned_school_certifying_official(version.id)
     CautionFlag.map(version.id)
     set_count_of_caution_flags(version.id)
-    update_ialias_to_upper(version.id)
   end
 
   def self.run(user)
@@ -804,13 +803,6 @@ module InstitutionBuilder
       WHERE institutions.version_id = #{version_id}
     SQL
 
-    Institution.connection.update(str)
-  end
-
-  def self.update_ialias_to_upper(version_id)
-    str = <<-SQL
-        UPDATE institutions SET ialias = upper(ialias)
-    SQL
     Institution.connection.update(str)
   end
 end

--- a/app/models/ipeds_hd.rb
+++ b/app/models/ipeds_hd.rb
@@ -50,7 +50,7 @@ class IpedsHd < ApplicationRecord
     'pseflag' => { column: :pseflag, converter: NumberConverter },
     'pset4flg' => { column: :pset4flg, converter: NumberConverter },
     'rptmth' => { column: :rptmth, converter: NumberConverter },
-    'ialias' => { column: :ialias, converter: BaseConverter },
+    'ialias' => { column: :ialias, converter: UpcaseConverter },
     'instcat' => { column: :instcat, converter: NumberConverter },
     'ccbasic' => { column: :ccbasic, converter: NumberConverter },
     'ccipug' => { column: :ccipug, converter: NumberConverter },

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -346,6 +346,23 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response).to match_response_schema('institutions')
     end
 
+    it 'search returns results zip' do
+     create(:institution, :independent_study, zip: '29461', version_id: Version.current_production.id)
+     get(:index, params: { name: '29461', fuzzy_search: true })
+     expect(JSON.parse(response.body)['data'].count).to eq(1)
+     expect(response.content_type).to eq('application/json')
+     expect(response).to match_response_schema('institutions')
+    end
+
+    it 'search returns results alias' do
+     create(:institution, :independent_study, ialias: 'UIS', version_id: Version.current_production.id)
+     get(:index, params: { name: 'uis', fuzzy_search: true })
+     expect(JSON.parse(response.body)['data'].count).to eq(1)
+     expect(response.content_type).to eq('application/json')
+     expect(response).to match_response_schema('institutions')
+    end
+
+
     it 'search returns case-insensitive results' do
       get(:index, params: { name: 'CHICAGO' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -347,21 +347,20 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
 
     it 'search returns results zip' do
-     create(:institution, :independent_study, zip: '29461', version_id: Version.current_production.id)
-     get(:index, params: { name: '29461', fuzzy_search: true })
-     expect(JSON.parse(response.body)['data'].count).to eq(1)
-     expect(response.content_type).to eq('application/json')
-     expect(response).to match_response_schema('institutions')
+      create(:institution, :independent_study, zip: '29461', version_id: Version.current_production.id)
+      get(:index, params: { name: '29461', fuzzy_search: true })
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
     end
 
     it 'search returns results alias' do
-     create(:institution, :independent_study, ialias: 'UIS', version_id: Version.current_production.id)
-     get(:index, params: { name: 'uis', fuzzy_search: true })
-     expect(JSON.parse(response.body)['data'].count).to eq(1)
-     expect(response.content_type).to eq('application/json')
-     expect(response).to match_response_schema('institutions')
+      create(:institution, :independent_study, ialias: 'UIS', version_id: Version.current_production.id)
+      get(:index, params: { name: 'uis', fuzzy_search: true })
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
     end
-
 
     it 'search returns case-insensitive results' do
       get(:index, params: { name: 'CHICAGO' })


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10617


## Testing done
Dev tested.

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/86368913-c4e2fa00-bc4b-11ea-93ce-81260b378a18.png)

![image](https://user-images.githubusercontent.com/48804654/86368925-c7ddea80-bc4b-11ea-8845-1d22eb68359a.png)


## Acceptance criteria
- [ ] The 'ialias' from the IPEDSHD is searchable within the Comparison Tool.
- [ ] The 'physical institution zip code' from the WEAMS data is searchable within the Comparison Tool.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs