### PR TITLE
Update Institution fuzzy-search order by

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -30,10 +30,7 @@ module V0
       }
 
       if @query.key?(:fuzzy_search)
-        order_by = <<-SQL
-          (SIMILARITY(institution, :search_term) + SIMILARITY(city, :search_term)) / 2 DESC,
-          institution ASC
-        SQL
+        order_by = 'SIMILARITY(institution, :search_term) * COALESCE(gibill, 0) DESC, institution'
         sanitized_order_by = Institution.sanitize_sql_for_conditions([order_by, search_term: (@query[:name]).to_s])
         render json: search_results.order(sanitized_order_by).page(params[:page]), meta: @meta
       else

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -338,6 +338,15 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response).to match_response_schema('institutions')
     end
 
+    it 'search returns results correctly ordered results' do
+      create(:institution, institution: 'HARVARD', gibill: 1, version_id: Version.current_production.id)
+      first = create(:institution, institution: 'HARVARDY', gibill: 100, version_id: Version.current_production.id)
+      get(:index, params: { name: 'HARVARD', fuzzy_search: true })
+      expect(JSON.parse(response.body)['data'][0]['attributes']['name']).to eq(first.institution)
+      expect(response.content_type).to eq('application/json')
+      expect(response).to match_response_schema('institutions')
+    end
+
     it 'search uses fuzzy_search flag' do
       create(:institution, :independent_study, version_id: Version.current_production.id)
       get(:index, params: { name: 'UNIVERSITY OF NDEPENDENT STUDY' })


### PR DESCRIPTION
## Description
Update Institution "fuzzy search" order to increase relevance of top results by weighting institutions by the number of GI Bill students.

[ZenHub Issue #11197](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11197#event-3548567034)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Institution search results return results sorted by number of GI Bill students descending then similarity on institution name.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs