### PR TITLE
CF: Remove "VA may suspend benefits to this school." from caution flags #11116

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 /.generators
 /.rakeTasks
+*.iml

--- a/db/seeds/03_rules.rb
+++ b/db/seeds/03_rules.rb
@@ -278,14 +278,14 @@ if ENV['CI'].blank?
       #settlement
       {rule_id: rule_id(rule_results, 'Federal Trade Commission (FTC) filed suit for deceptive action'),
         title: 'Federal Trade Commission (FTC) filed suit for deceptive action',
-        description: 'The FTC filed a suit against this school for deceptive action. VA may suspend benefits to this school.',
+        description: 'The FTC filed a suit against this school for deceptive action.',
         link_text: nil,
         link_url: nil,
        },
        #settlement
       {rule_id: rule_id(rule_results, 'States Attorney General Filed Suit for Deceptive Action'),
         title: 'State\'s Attorney General filed suit for deceptive action',
-        description: 'The state\'s Attorney General filed suit against this school for deceptive action. VA may suspend benefits to this school.',
+        description: 'The state\'s Attorney General filed suit against this school for deceptive action.',
         link_text: nil,
         link_url: nil,
        },


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/11116

The description for caution flag "Federal Trade Commission (FTC) filed suit for deceptive action" is: "The FTC filed a suit against this school for deceptive action."

The description for caution flag "States Attorney General Filed Suit for Deceptive Action" is: "The state's Attorney General filed suit against this school for deceptive action."


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs