### PR TITLE
add institutions ialias column to exact match checks for institution search API

### DIFF
--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -163,6 +163,7 @@ module V0
     def use_fuzzy_search
       exact_match_found = approved_institutions
                           .where(vet_tec_provider: false, institution: @query[:name]&.upcase)
+          .or(approved_institutions.where(vet_tec_provider: false, ialias: @query[:name]&.upcase))
                           .count.positive?
       @query.key?(:fuzzy_search) && !exact_match_found
     end

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -163,7 +163,7 @@ module V0
     def use_fuzzy_search
       exact_match_found = approved_institutions
                           .where(vet_tec_provider: false, institution: @query[:name]&.upcase)
-          .or(approved_institutions.where(vet_tec_provider: false, ialias: @query[:name]&.upcase))
+                          .or(approved_institutions.where(vet_tec_provider: false, ialias: @query[:name]&.upcase))
                           .count.positive?
       @query.key?(:fuzzy_search) && !exact_match_found
     end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -243,6 +243,7 @@ class Institution < ApplicationRecord
     else
       clause << 'institution LIKE :upper_search_term'
       clause << 'city LIKE :upper_search_term'
+      clause << 'ialias LIKE :upper_search_term'
     end
 
     if include_address

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -233,17 +233,15 @@ class Institution < ApplicationRecord
   scope :search, lambda { |search_term, include_address = false, fuzzy_search = false|
     return if search_term.blank?
 
-    clause = ['facility_code = :facility_code']
+    clause = ['facility_code = :facility_code', 'ialias LIKE :upper_search_term']
 
     if fuzzy_search
       clause << 'SIMILARITY(institution, :search_term) > :name_threshold'
       clause << 'SIMILARITY(city, :search_term) > :city_threshold'
       clause << 'zip = :search_term'
-      clause << 'ialias LIKE :upper_search_term'
     else
       clause << 'institution LIKE :upper_search_term'
       clause << 'city LIKE :upper_search_term'
-      clause << 'ialias LIKE :upper_search_term'
     end
 
     if include_address

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -233,7 +233,7 @@ class Institution < ApplicationRecord
   scope :search, lambda { |search_term, include_address = false, fuzzy_search = false|
     return if search_term.blank?
 
-    clause = ['facility_code = :facility_code', 'ialias LIKE :upper_search_term']
+    clause = ['facility_code = :facility_code']
 
     if fuzzy_search
       clause << 'SIMILARITY(institution, :search_term) > :name_threshold'
@@ -242,6 +242,7 @@ class Institution < ApplicationRecord
     else
       clause << 'institution LIKE :upper_search_term'
       clause << 'city LIKE :upper_search_term'
+      clause << 'ialias LIKE :upper_search_term'
     end
 
     if include_address

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1532,9 +1532,8 @@ ActiveRecord::Schema.define(version: 2020_07_18_131012) do
   end
 
   create_table "va_caution_flags", id: :serial, force: :cascade do |t|
-    t.string "institution_id"
+    t.string "facility_code", null: false
     t.string "institution_name"
-    t.integer "school_system_code"
     t.string "school_system_name"
     t.string "settlement_title"
     t.string "settlement_description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1532,8 +1532,9 @@ ActiveRecord::Schema.define(version: 2020_07_18_131012) do
   end
 
   create_table "va_caution_flags", id: :serial, force: :cascade do |t|
-    t.string "facility_code", null: false
+    t.string "institution_id"
     t.string "institution_name"
+    t.integer "school_system_code"
     t.string "school_system_name"
     t.string "settlement_title"
     t.string "settlement_description"

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -183,7 +183,8 @@ RSpec.describe Institution, type: :model do
           .to include(
             "WHERE ((facility_code = 'CHICAGO'",
             "OR institution LIKE '%CHICAGO%'",
-            "OR city LIKE '%CHICAGO%'))"
+            "OR city LIKE '%CHICAGO%'",
+            "OR ialias LIKE '%CHICAGO%'))"
           )
       end
     end


### PR DESCRIPTION
## Description

Add `institutions.ialias` to the check for exact match and query that is used

## Testing done
```
 SELECT ialias, institution
 	FROM "institutions" INNER JOIN "versions" ON "versions"."id" = "institutions"."version_id" 
	WHERE (campus_type != 'E' OR campus_type IS NULL) 
	AND "institutions"."approved" is true
	AND "institutions"."version_id" = <CURRENT_VERSION_NUMBER>
	AND "institutions"."vet_tec_provider" is false
	AND ialias is not null
	order by ialias
```

to find valid tests cases

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs