### PR TITLE
Change date columns to be strings in va_caution_flags table

### DIFF
--- a/db/migrate/20200727113800_change_va_caution_flag_date_type.rb
+++ b/db/migrate/20200727113800_change_va_caution_flag_date_type.rb
@@ -1,0 +1,16 @@
+class ChangeVaCautionFlagDateType < ActiveRecord::Migration[4.2]
+    def change
+        drop_table :va_caution_flags
+          create_table :va_caution_flags do |t|
+            t.string :facility_code, null: false
+            t.string :institution_name
+            t.string :school_system_name
+            t.string :settlement_title
+            t.string :settlement_description
+            t.string :settlement_date
+            t.string :settlement_link
+            t.string :school_closing_date
+            t.boolean :sec_702
+          end
+    end
+end

--- a/db/migrate/20200727113800_change_va_caution_flag_date_type.rb
+++ b/db/migrate/20200727113800_change_va_caution_flag_date_type.rb
@@ -1,16 +1,16 @@
 class ChangeVaCautionFlagDateType < ActiveRecord::Migration[4.2]
     def change
-        drop_table :va_caution_flags
-          create_table :va_caution_flags do |t|
-            t.string :facility_code, null: false
-            t.string :institution_name
-            t.string :school_system_name
-            t.string :settlement_title
-            t.string :settlement_description
-            t.string :settlement_date
-            t.string :settlement_link
-            t.string :school_closing_date
-            t.boolean :sec_702
-          end
+      drop_table :va_caution_flags
+      create_table :va_caution_flags do |t|
+        t.string :facility_code, null: false
+        t.string :institution_name
+        t.string :school_system_name
+        t.string :settlement_title
+        t.string :settlement_description
+        t.string :settlement_date
+        t.string :settlement_link
+        t.string :school_closing_date
+        t.boolean :sec_702
+      end
     end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_18_131012) do
+ActiveRecord::Schema.define(version: 2020_07_27_113800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1532,15 +1532,14 @@ ActiveRecord::Schema.define(version: 2020_07_18_131012) do
   end
 
   create_table "va_caution_flags", id: :serial, force: :cascade do |t|
-    t.string "institution_id"
+    t.string "facility_code", null: false
     t.string "institution_name"
-    t.integer "school_system_code"
     t.string "school_system_name"
     t.string "settlement_title"
     t.string "settlement_description"
-    t.date "settlement_date"
+    t.string "settlement_date"
     t.string "settlement_link"
-    t.date "school_closing_date"
+    t.string "school_closing_date"
     t.boolean "sec_702"
   end
 


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10883

The csv has dates as "mm/dd/yy" format. Upon upload as a date, the data is formated as "00yy-mm-dd". Because of this, we need the columns to be strings. 

## Testing done
Dev tested

## Screenshots


## Acceptance criteria
- [x] creates va_caution_flags table with date columns as strings.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs