### PR TITLE
Change when fuzzy search with pgtrm is used

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,7 +113,6 @@ Metrics/ModuleLength:
     - "app/models/institution_builder.rb"
 
 Metrics/BlockLength:
-  Max: 40
   Exclude:
     - "spec/**/*"
     - "rakelib/**/*.rake"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,7 @@ Metrics/ModuleLength:
     - "app/models/institution_builder.rb"
 
 Metrics/BlockLength:
+  Max: 40
   Exclude:
     - "spec/**/*"
     - "rakelib/**/*.rake"

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -29,7 +29,7 @@ module V0
         facets: facets
       }
 
-      if use_fuzzy_search
+      if @query.key?(:fuzzy_search) && !exact_match_found?
         order_by = 'SIMILARITY(institution, :search_term) * COALESCE(gibill, 0) DESC, institution'
         sanitized_order_by = Institution.sanitize_sql_for_conditions([order_by, search_term: (@query[:name]).to_s])
         render json: search_results.order(sanitized_order_by).page(params[:page]), meta: @meta
@@ -88,7 +88,8 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      relation = non_vet_tec_institutions.search(@query[:name], @query[:include_address], use_fuzzy_search)
+      relation = non_vet_tec_institutions.search(@query[:name], @query[:include_address], @query.key?(:fuzzy_search),
+                                                 exact_match_found?)
       filter_results(relation)
     end
 
@@ -162,9 +163,8 @@ module V0
       approved_institutions.where(vet_tec_provider: false)
     end
 
-    def use_fuzzy_search
-      exact_match_found = non_vet_tec_institutions.search_count(@query[:name]).positive?
-      @query.key?(:fuzzy_search) && !exact_match_found
+    def exact_match_found?
+      non_vet_tec_institutions.search_count(@query[:name]).positive?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -29,7 +29,7 @@ module V0
         facets: facets
       }
 
-      if @query.key?(:fuzzy_search) && !exact_match_found?
+      if use_fuzzy_search
         order_by = 'SIMILARITY(institution, :search_term) * COALESCE(gibill, 0) DESC, institution'
         sanitized_order_by = Institution.sanitize_sql_for_conditions([order_by, search_term: (@query[:name]).to_s])
         render json: search_results.order(sanitized_order_by).page(params[:page]), meta: @meta
@@ -90,7 +90,7 @@ module V0
       @query ||= normalized_query_params
       relation = approved_institutions
                  .where(vet_tec_provider: false)
-                 .search(@query[:name], @query[:include_address], @query.key?(:fuzzy_search), exact_match_found?)
+                 .search(@query[:name], @query[:include_address], use_fuzzy_search)
       filter_results(relation)
     end
 
@@ -160,11 +160,14 @@ module V0
       Institution.joins(:version).no_extentions.where(approved: true, version: @version)
     end
 
-    def exact_match_found?
-      approved_institutions
-        .where(vet_tec_provider: false, institution: @query[:name]&.upcase)
-        .or(approved_institutions.where(vet_tec_provider: false, ialias: @query[:name]&.upcase))
-        .count.positive?
+    # if institution starts with or is
+    # if ialias contains
+    def use_fuzzy_search
+      exact_match_found = approved_institutions
+                          .where(vet_tec_provider: false, institution: @query[:name]&.upcase)
+                          .or(approved_institutions.where(vet_tec_provider: false, ialias: @query[:name]&.upcase))
+                          .count.positive?
+      @query.key?(:fuzzy_search) && !exact_match_found
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -267,7 +267,7 @@ class Institution < ApplicationRecord
                                        upper_search_term: search_term.upcase,
                                        upper_contains_term: "%#{search_term.upcase}%",
                                        lower_contains_term: "%#{search_term.downcase}%",
-                                       starts_with_term: "%#{search_term.upcase}",
+                                       starts_with_term: "#{search_term.upcase}%",
                                        search_term: search_term.to_s,
                                        name_threshold: Settings.institution_name_similarity_threshold,
                                        city_threshold: Settings.institution_city_similarity_threshold]))
@@ -315,7 +315,7 @@ class Institution < ApplicationRecord
 
     where(sanitize_sql_for_conditions([clause.join(' OR '),
                                        search_term: search_term.upcase,
-                                       starts_with_term: "%#{search_term.upcase}",
+                                       starts_with_term: "#{search_term.upcase}%",
                                        upper_contains_term: "%#{search_term.upcase}%"]))
       .count
   }

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -31,8 +31,8 @@ class Institution < ApplicationRecord
       'institution LIKE :starts_with_term',
       'institution = :search_term',
       'city = :search_term',
-      'ialias LIKE :contains_term'
-  ]
+      'ialias LIKE :upper_contains_term'
+  ].freeze
 
   CSV_CONVERTER_INFO = {
     'facility_code' => { column: :facility_code, converter: FacilityCodeConverter },
@@ -250,7 +250,7 @@ class Institution < ApplicationRecord
         clause << 'SIMILARITY(city, :search_term) > :city_threshold'
         clause << 'zip = :search_term'
       else
-        clause + NON_FUZZY_SEARCH_CLAUSE
+        clause.push(*NON_FUZZY_SEARCH_CLAUSE)
       end
     else
       clause << 'institution LIKE :upper_contains_term'
@@ -311,12 +311,12 @@ class Institution < ApplicationRecord
     return 0 if search_term.blank?
 
     clause = ['facility_code = :search_term']
-    clause + NON_FUZZY_SEARCH_CLAUSE
+    clause.push(*NON_FUZZY_SEARCH_CLAUSE)
 
     where(sanitize_sql_for_conditions([clause.join(' OR ') ,
                                        search_term: search_term.upcase,
                                        starts_with_term: "%#{search_term.upcase}",
-                                       contains_term: "%#{search_term.upcase}%"]))
+                                       upper_contains_term: "%#{search_term.upcase}%"]))
       .count
   }
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -28,10 +28,10 @@ class Institution < ApplicationRecord
   }.freeze
 
   NON_FUZZY_SEARCH_CLAUSE = [
-      'institution LIKE :starts_with_term',
-      'institution = :search_term',
-      'city = :search_term',
-      'ialias LIKE :upper_contains_term'
+    'institution LIKE :starts_with_term',
+    'institution = :search_term',
+    'city = :search_term',
+    'ialias LIKE :upper_contains_term'
   ].freeze
 
   CSV_CONVERTER_INFO = {
@@ -263,7 +263,7 @@ class Institution < ApplicationRecord
       end
     end
 
-    where(sanitize_sql_for_conditions(['(' + clause.join(' OR ') + ')',
+    where(sanitize_sql_for_conditions([clause.join(' OR '),
                                        upper_search_term: search_term.upcase,
                                        upper_contains_term: "%#{search_term.upcase}%",
                                        lower_contains_term: "%#{search_term.downcase}%",
@@ -313,7 +313,7 @@ class Institution < ApplicationRecord
     clause = ['facility_code = :search_term']
     clause.push(*NON_FUZZY_SEARCH_CLAUSE)
 
-    where(sanitize_sql_for_conditions([clause.join(' OR ') ,
+    where(sanitize_sql_for_conditions([clause.join(' OR '),
                                        search_term: search_term.upcase,
                                        starts_with_term: "%#{search_term.upcase}",
                                        upper_contains_term: "%#{search_term.upcase}%"]))

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -287,5 +287,30 @@ class Institution < ApplicationRecord
     group(field).where.not(field => nil).order(field).count
   }
 
+  # Returns count of institutions that have:
+  # a facility_code that equals search_term
+  # an institution that starts with search_term
+  # an institution that equals search_term
+  # a city that equals search_term
+  # an ialias that contains search_term
+  #
+  scope :search_count, lambda { |search_term|
+    return 0 if search_term.blank?
+
+    clause = [
+      'facility_code = :search_term',
+      'institution LIKE :starts_with_term',
+      'institution = :search_term',
+      'city = :search_term',
+      'ialias LIKE :contains_term'
+    ]
+
+    where(sanitize_sql_for_conditions([clause.join(' OR ') ,
+                                       search_term: search_term.upcase,
+                                       starts_with_term: "%#{search_term.upcase}",
+                                       contains_term: "%#{search_term.upcase}%"]))
+      .count
+  }
+
   scope :no_extentions, -> { where("campus_type != 'E' OR campus_type IS NULL") }
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -230,26 +230,19 @@ class Institution < ApplicationRecord
 
   # Finds exact-matching facility_code or partial-matching school and city names
   #
-  scope :search, lambda { |search_term, include_address = false, fuzzy_search = false,
-      exact_match = false
-  |
+  scope :search, lambda { |search_term, include_address = false, fuzzy_search = false|
     return if search_term.blank?
 
     clause = ['facility_code = :facility_code']
 
     if fuzzy_search
-      if exact_match
-        clause << 'institution = :exact_match_term'
-        clause << 'city = :exact_match_term'
-        clause << 'ialias = :exact_match_term'
-      else
-        clause << 'SIMILARITY(institution, :search_term) > :name_threshold'
-        clause << 'SIMILARITY(city, :search_term) > :city_threshold'
-        clause << 'zip = :search_term'
-      end
+      clause << 'SIMILARITY(institution, :search_term) > :name_threshold'
+      clause << 'SIMILARITY(city, :search_term) > :city_threshold'
+      clause << 'zip = :search_term'
     else
       clause << 'institution LIKE :upper_search_term'
       clause << 'city LIKE :upper_search_term'
+      clause << 'ialias LIKE :upper_search_term'
     end
 
     if include_address
@@ -263,7 +256,6 @@ class Institution < ApplicationRecord
                                        upper_search_term: "%#{search_term.upcase}%",
                                        lower_search_term: "%#{search_term.downcase}%",
                                        search_term: search_term.to_s,
-                                       exact_match_term: search_term.upcase.to_s,
                                        name_threshold: Settings.institution_name_similarity_threshold,
                                        city_threshold: Settings.institution_city_similarity_threshold]))
   }

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -181,10 +181,9 @@ RSpec.describe Institution, type: :model do
       it 'searches when attribute is provided' do
         expect(described_class.search('chicago').to_sql)
           .to include(
-            "WHERE ((facility_code = 'CHICAGO'",
+            "WHERE (facility_code = 'CHICAGO'",
             "OR institution LIKE '%CHICAGO%'",
-            "OR city LIKE '%CHICAGO%'",
-            "OR ialias LIKE '%CHICAGO%'))"
+            "OR city LIKE '%CHICAGO%')"
           )
       end
     end


### PR DESCRIPTION
## Description
Initial implementation wasn't correctly behind feature flag and didn't account for several cases.  

This only allows usage of fuzzy search if the combined count of conditions below is 0: 
-  a facility_code that equals search_term
- an institution name that starts with search_term
- an institution name that equals search_term
- a city that equals search_term
- an ialias that contains search_term

This also updates the non-fuzzy search search to use same where statements as the count

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs