### PR TITLE
Update institution search API

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -28,7 +28,7 @@ class Institution < ApplicationRecord
   }.freeze
 
   NON_FUZZY_SEARCH_CLAUSE = [
-    'institution LIKE :starts_with_term',
+    'institution LIKE :upper_contains_term',
     'institution = :search_term',
     'city = :search_term',
     'ialias LIKE :upper_contains_term'
@@ -267,7 +267,6 @@ class Institution < ApplicationRecord
                                        upper_search_term: search_term.upcase,
                                        upper_contains_term: "%#{search_term.upcase}%",
                                        lower_contains_term: "%#{search_term.downcase}%",
-                                       starts_with_term: "#{search_term.upcase}%",
                                        search_term: search_term.to_s,
                                        name_threshold: Settings.institution_name_similarity_threshold,
                                        city_threshold: Settings.institution_city_similarity_threshold]))
@@ -315,7 +314,6 @@ class Institution < ApplicationRecord
 
     where(sanitize_sql_for_conditions([clause.join(' OR '),
                                        search_term: search_term.upcase,
-                                       starts_with_term: "#{search_term.upcase}%",
                                        upper_contains_term: "%#{search_term.upcase}%"]))
       .count
   }


### PR DESCRIPTION
## Description

Change from `%search_term` to `%search_term%` for `institutions.institution` field, if the count is higher than 0 pgtrm SIMILARITY is not used

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs