### PR TITLE
Exclude removed CSV types from displaying in Latest Uploads

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -99,7 +99,7 @@ class DashboardsController < ApplicationController
   private
 
   def csv_model(csv_type)
-    model = CSV_TYPES_ALL_TABLES_NAMES.select { |klass_name| klass_name == csv_type }.first
+    model = CSV_TYPES_ALL_TABLES_CLASSES.select { |klass| klass.name == csv_type }.first
     return model if model.present?
 
     raise(ArgumentError, "#{csv_type} is not a valid CSV type") if model.blank?

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -99,7 +99,7 @@ class DashboardsController < ApplicationController
   private
 
   def csv_model(csv_type)
-    model = CSV_TYPES_ALL_TABLES.select { |klass| klass.name == csv_type }.first
+    model = CSV_TYPES_ALL_TABLES_NAMES.select { |klass_name| klass_name == csv_type }.first
     return model if model.present?
 
     raise(ArgumentError, "#{csv_type} is not a valid CSV type") if model.blank?

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -8,7 +8,7 @@ class Storage < ApplicationRecord
   validates_associated :user
   validates :user_id, presence: true
 
-  validates :csv_type, uniqueness: true, inclusion: { in: CSV_TYPES_ALL_TABLES.map(&:name) }
+  validates :csv_type, uniqueness: true, inclusion: { in: CSV_TYPES_ALL_TABLES_NAMES }
   validates :data, :csv, presence: true
   validates :upload_file, presence: true, unless: :persisted?
 

--- a/app/views/storages/_csv_type_select.html.erb
+++ b/app/views/storages/_csv_type_select.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= f.label(:csv_file_type) %>
-  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES.map(&:name)),
+  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES_NAMES),
     { include_blank: "Select Csv File Type" },
     { class: "form-control", required: true }) %>
 </div>

--- a/app/views/uploads/_csv_type_select.html.erb
+++ b/app/views/uploads/_csv_type_select.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= f.label(:csv_file_type) %>
-  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES.map(&:name)),
+  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES_NAMES),
     { include_blank: "Select Csv File Type" },
     { class: "form-control", required: true }) %>
 </div>

--- a/config/initializers/csv_types.rb
+++ b/config/initializers/csv_types.rb
@@ -35,7 +35,7 @@ CSV_TYPES_TABLES = [
   {klass: VaCautionFlag, required?: false}
 ].freeze
 
-CSV_TYPES_REQUIRED_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:required?] }.map { |table| table[:klass].name }
-CSV_TYPES_HAS_API_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:has_api?] }.map { |table| table[:klass].name }
-CSV_TYPES_ALL_TABLES = CSV_TYPES_TABLES.map { |table| table[:klass] }
-CSV_TYPES_NO_PROD_NAMES = CSV_TYPES_TABLES.select { |table| table[:not_prod_ready?] }.map { |table| table[:klass].name }
+CSV_TYPES_REQUIRED_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:required?] }.map { |table| table[:klass].name }.freeze
+CSV_TYPES_HAS_API_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:has_api?] }.map { |table| table[:klass].name }.freeze
+CSV_TYPES_ALL_TABLES_NAMES = CSV_TYPES_TABLES.map { |table| table[:klass].name }.freeze
+CSV_TYPES_NO_PROD_NAMES = CSV_TYPES_TABLES.select { |table| table[:not_prod_ready?] }.map { |table| table[:klass].name }.freeze

--- a/config/initializers/csv_types.rb
+++ b/config/initializers/csv_types.rb
@@ -37,5 +37,6 @@ CSV_TYPES_TABLES = [
 
 CSV_TYPES_REQUIRED_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:required?] }.map { |table| table[:klass].name }.freeze
 CSV_TYPES_HAS_API_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:has_api?] }.map { |table| table[:klass].name }.freeze
+CSV_TYPES_ALL_TABLES_CLASSES = CSV_TYPES_TABLES.map { |table| table[:klass] }.freeze
 CSV_TYPES_ALL_TABLES_NAMES = CSV_TYPES_TABLES.map { |table| table[:klass].name }.freeze
 CSV_TYPES_NO_PROD_NAMES = CSV_TYPES_TABLES.select { |table| table[:not_prod_ready?] }.map { |table| table[:klass].name }.freeze

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -35,10 +35,12 @@ API_TABLES = [
   Scorecard.name
 ].freeze
 
+NO_PROD_TABLES = [].freeze
+
 RSpec.describe 'CSV_TYPES' do
   describe 'all_tables' do
     it 'lengths should be equal' do
-      expect(CSV_TYPES_ALL_TABLES.length).to eq(CSV_TYPES_TABLES.length)
+      expect(CSV_TYPES_ALL_TABLES_NAMES.length).to eq(CSV_TYPES_TABLES.length)
     end
   end
 
@@ -51,6 +53,12 @@ RSpec.describe 'CSV_TYPES' do
   describe 'has_api_table_names' do
     it 'contains tables' do
       expect(CSV_TYPES_HAS_API_TABLE_NAMES).to eq(API_TABLES)
+    end
+  end
+
+  describe 'no_prod_names' do
+    it 'contains tables' do
+      expect(CSV_TYPES_NO_PROD_NAMES).to eq(NO_PROD_TABLES)
     end
   end
 end

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DashboardsController, type: :controller do
     end
 
     it 'populates an array of uploads' do
-      expect(assigns(:uploads).length).to eq(CSV_TYPES_ALL_TABLES_NAMES.length)
+      expect(assigns(:uploads).length).to eq(CSV_TYPES_ALL_TABLES_CLASSES.length)
     end
 
     it 'returns http success' do
@@ -47,10 +47,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
-                          force_simple_split: defaults[klass_name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_CLASSES.each do |klass|
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
     end
 
@@ -76,10 +76,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
-                          force_simple_split: defaults[klass_name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_CLASSES.each do |klass|
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
 
       post(:build)
@@ -108,10 +108,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
-                          force_simple_split: defaults[klass_name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_CLASSES.each do |klass|
+        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
+                          force_simple_split: defaults[klass.name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
       end
 
       post(:build)

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
                           force_simple_split: defaults[klass_name]['force_simple_split'],
                           strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end
@@ -77,7 +77,7 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
                           force_simple_split: defaults[klass_name]['force_simple_split'],
                           strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end
@@ -109,7 +109,7 @@ RSpec.describe DashboardsController, type: :controller do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
       CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
-        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+        load_table(klass_name, skip_lines: defaults[klass_name]['skip_lines'],
                           force_simple_split: defaults[klass_name]['force_simple_split'],
                           strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DashboardsController, type: :controller do
     end
 
     it 'populates an array of uploads' do
-      expect(assigns(:uploads).length).to eq(CSV_TYPES_ALL_TABLES.length)
+      expect(assigns(:uploads).length).to eq(CSV_TYPES_ALL_TABLES_NAMES.length)
     end
 
     it 'returns http success' do
@@ -47,10 +47,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
-                          force_simple_split: defaults[klass.name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
+        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+                          force_simple_split: defaults[klass_name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end
     end
 
@@ -76,10 +76,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
-                          force_simple_split: defaults[klass.name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
+        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+                          force_simple_split: defaults[klass_name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end
 
       post(:build)
@@ -108,10 +108,10 @@ RSpec.describe DashboardsController, type: :controller do
     before do
       defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
 
-      CSV_TYPES_ALL_TABLES.each do |klass|
-        load_table(klass, skip_lines: defaults[klass.name]['skip_lines'],
-                          force_simple_split: defaults[klass.name]['force_simple_split'],
-                          strip_chars_from_headers: defaults[klass.name]['strip_chars_from_headers'])
+      CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
+        load_table(klass, skip_lines: defaults[klass_name]['skip_lines'],
+                          force_simple_split: defaults[klass_name]['force_simple_split'],
+                          strip_chars_from_headers: defaults[klass_name]['strip_chars_from_headers'])
       end
 
       post(:build)


### PR DESCRIPTION
## Description

When retrieving Latest Uploads where statement only looks for CSV Types that are listed in `CSV_TYPES_ALL_TABLES_NAMES`, this removes old uploads for CSVs that are no longer being used.

This is in preparation of replacement of several CSV types with consolidated CSVs.

Usage of `CSV_TYPES_ALL_TABLES` was always using `map` to get names, freezing so modifications can't occur to the array.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs