### PR TITLE
CT Institution Search

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -270,7 +270,7 @@ class Institution < ApplicationRecord
                      'CASE WHEN UPPER(institution) = :upper_search_term THEN 1 ELSE 0 END',
                      '(COALESCE(SIMILARITY(institution, :search_term), 0))']
 
-    weighted_sort << '(COALESCE(gibill, 0)/CAST(:max_gibill as FLOAT))' if max_gibill.nonzero?
+    weighted_sort << '((COALESCE(gibill, 0)/CAST(:max_gibill as FLOAT))/3)' if max_gibill.nonzero?
 
     order_by = "#{weighted_sort.join(' + ')} DESC NULLS LAST, institution"
     sanitized_order_by = Institution.sanitize_sql_for_conditions([order_by,

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -267,7 +267,8 @@ class Institution < ApplicationRecord
     weighted_sort = ['(COALESCE(SIMILARITY(ialias, :search_term), 0)/2)',
                      'CASE WHEN UPPER(ialias) = :upper_search_term THEN 1 ELSE 0 END',
                      'CASE WHEN UPPER(city) = :upper_search_term THEN 1 ELSE 0 END',
-                     '(COALESCE(SIMILARITY(institution, :search_term), 0)/2)']
+                     'CASE WHEN UPPER(institution) = :upper_search_term THEN 1 ELSE 0 END',
+                     '(COALESCE(SIMILARITY(institution, :search_term), 0))']
 
     weighted_sort << '(COALESCE(gibill, 0)/CAST(:max_gibill as FLOAT))' if max_gibill.nonzero?
 


### PR DESCRIPTION
## Description

Increase weight in sort of exact matches on `institutions.institution`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs