### PR TITLE
Fix common word removal from processed institution search term

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -236,8 +236,8 @@ class Institution < ApplicationRecord
 
     processed_search_term = search_term.dup
     Settings.search.common_word_list.each do |word|
-      #  word.match(/[a-z]/i) is for characters like "&" and "-",
-      # the word boundary regex does not work with these characters
+      # word.match(/[a-z]/i) check is because of characters like "&" and "-",
+      # the word boundary regex "\b" does not replace these characters
       if word.match(/[a-z]/i)
         processed_search_term.gsub!(/\b#{Regexp.escape(word)}\b/i, '')
       else

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -237,7 +237,7 @@ class Institution < ApplicationRecord
     processed_search_term = search_term.dup
     Settings.search.common_word_list.each do |word|
       # word.match(/[a-z]/i) check is because of characters like "&" and "-",
-      # the word boundary regex "\b" does not replace these characters
+      # the word boundary regex "\b" does not work with these characters
       if word.match(/[a-z]/i)
         processed_search_term.gsub!(/\b#{Regexp.escape(word)}\b/i, '')
       else

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -27,6 +27,14 @@ class Institution < ApplicationRecord
     '4-year' => 4
   }.freeze
 
+  COMMON_REMOVAL_REGEXP = Regexp.new(
+    (
+    Settings.search.common_character_list.map { |char| Regexp.escape(char) } +
+        Settings.search.common_word_list.map { |word| "\\b#{Regexp.escape(word)}\\b" }
+  ).join('|'),
+    'i'
+  )
+
   CSV_CONVERTER_INFO = {
     'facility_code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution' => { column: :institution, converter: InstitutionConverter },
@@ -234,16 +242,7 @@ class Institution < ApplicationRecord
   def self.institution_search_term(search_term)
     return if search_term.blank?
 
-    processed_search_term = search_term.dup
-    Settings.search.common_word_list.each do |word|
-      # word.match(/[a-z]/i) check is because of characters like "&" and "-",
-      # the word boundary regex "\b" does not work with these characters
-      if word.match(/[a-z]/i)
-        processed_search_term.gsub!(/\b#{Regexp.escape(word)}\b/i, '')
-      else
-        processed_search_term.gsub!(/#{Regexp.escape(word)}/i, '')
-      end
-    end
+    processed_search_term = search_term.gsub(COMMON_REMOVAL_REGEXP, '')
 
     return search_term.dup if processed_search_term.blank?
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -236,8 +236,13 @@ class Institution < ApplicationRecord
 
     processed_search_term = search_term.dup
     Settings.search.common_word_list.each do |word|
-      processed_search_term.gsub!(/\b#{Regexp.escape(word)}\b/i, '') if word.match(/[a-z]/i)
-      processed_search_term.gsub!(/#{Regexp.escape(word)}/i, '')
+      #  word.match(/[a-z]/i) is for characters like "&" and "-",
+      # the word boundary regex does not work with these characters
+      if word.match(/[a-z]/i)
+        processed_search_term.gsub!(/\b#{Regexp.escape(word)}\b/i, '')
+      else
+        processed_search_term.gsub!(/#{Regexp.escape(word)}/i, '')
+      end
     end
 
     return search_term.dup if processed_search_term.blank?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,13 +37,15 @@ search:
     - "high"
     - "county"
     - "institute"
-    - "&"
-    - "-"
     - "academy"
     - "community"
     - "training"
     - "state"
     - "campus"
     - "city"
+  common_character_list:
+    - "&"
+    - "-"
+
 
 

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -254,20 +254,28 @@ RSpec.describe Institution, type: :model do
       expect(results.count).to eq(1)
     end
 
-    describe '#similarity_search_term' do
-      it 'removes common words' do
-        common_words = Settings.search.common_word_list.join(' ')
-        search_term = "search term #{common_words}"
+    describe '#institution_search_term' do
+      it 'removes common words and characters' do
+        common_words_characters = (Settings.search.common_word_list + Settings.search.common_character_list).join(' ')
+        search_term = "search term #{common_words_characters}"
         processed_search_term = described_class.institution_search_term(search_term)
         expect(processed_search_term).to eq('search term')
-        expect(processed_search_term).not_to include(common_words)
+        expect(processed_search_term).not_to include(common_words_characters)
       end
 
       it 'returns string if only contains common words' do
-        search_term = Settings.search.common_word_list.join(' ')
+        search_term = (Settings.search.common_word_list + Settings.search.common_character_list).join(' ')
         processed_search_term = described_class.institution_search_term(search_term)
         expect(processed_search_term).to eq(search_term)
         expect(processed_search_term).to be_present
+      end
+
+      it 'does not remove common words within words' do
+        common_words_characters = (Settings.search.common_word_list + Settings.search.common_character_list).join(' ')
+        search_term = 'university of maryland & and land'
+        processed_search_term = described_class.institution_search_term(search_term)
+        expect(processed_search_term).not_to include(common_words_characters)
+        expect(processed_search_term).to eq('maryland   land')
       end
     end
   end


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13408

Fix the removal of common words, the fix ensures that for "maryland" "and" is not replaced out of the word

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs