### PR TITLE
Institution rating calculation improvements

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -800,11 +800,15 @@ module InstitutionBuilder
         SUM(CASE #{category} WHEN 4 THEN 1 ELSE 0 END),
         SUM(CASE #{category} WHEN 5 THEN 1 ELSE 0 END),
         SUM(CASE WHEN #{category} IS NULL THEN 1 ELSE 0 END),
+        CASE
+          WHEN COUNT(#{category}) = 0 THEN NULL
+        ELSE
         (SUM(CASE #{category} WHEN 1 THEN 1 ELSE 0 END)
          + SUM(CASE #{category} WHEN 2 THEN 2 ELSE 0 END)
          + SUM(CASE #{category} WHEN 3 THEN 3 ELSE 0 END)
          + SUM(CASE #{category} WHEN 4 THEN 4 ELSE 0 END)
-         + SUM(CASE #{category} WHEN 5 THEN 5 ELSE 0 END)) / COUNT(institutions.id)::float,
+         + SUM(CASE #{category} WHEN 5 THEN 5 ELSE 0 END)) / COUNT(#{category})::float
+        END,
         COUNT(#{category})
       FROM institutions
         INNER JOIN
@@ -817,7 +821,11 @@ module InstitutionBuilder
             (
               SELECT
                 facility_code,
-                #{category},
+                CASE
+                  WHEN #{category} <= 0 THEN null
+                  WHEN #{category} > 5 THEN 5
+                  ELSE #{category}
+                END,
                 ROW_NUMBER() OVER (PARTITION BY rater_id ORDER BY rated_at DESC ) AS row_num
               FROM school_ratings
             ) top_votes
@@ -841,10 +849,15 @@ module InstitutionBuilder
       FROM(
         SELECT
           institution_id,
+          CASE
+            WHEN SUM(rated5_count) + SUM(rated4_count) + SUM(rated3_count)
+              + SUM(rated2_count) + SUM(rated1_count) = 0 THEN NULL::float
+          ELSE
           (SUM(rated5_count) * 5 + SUM(rated4_count) * 4 + SUM(rated3_count) * 3
             + SUM(rated2_count) * 2 + SUM(rated1_count))
             / (SUM(rated5_count) + SUM(rated4_count) + SUM(rated3_count)
-            + SUM(rated2_count) + SUM(rated1_count))::float average,
+            + SUM(rated2_count) + SUM(rated1_count))::float
+          END average,
           COUNT(DISTINCT rater_id) count
         FROM institution_category_ratings
           INNER JOIN institutions ON institution_category_ratings.institution_id = institutions.id

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -36,8 +36,11 @@ module InstitutionBuilder
     build_zip_code_rates_from_weams(version.id)
     build_institution_programs(version.id)
     build_versioned_school_certifying_official(version.id)
-    build_institution_category_ratings(version.id)
     set_count_of_caution_flags(version.id)
+  end
+
+  def self.build_ratings(version)
+    build_institution_category_ratings(version.id)
   end
 
   def self.run(user)
@@ -47,6 +50,10 @@ module InstitutionBuilder
     begin
       Institution.transaction do
         run_insertions(version)
+      end
+
+      Institution.transaction do
+        build_ratings(version)
       end
 
       version.update(completed_at: Time.now.utc.to_s(:db))


### PR DESCRIPTION
## Description
"NA" votes are no longer included in vote counts. This change meant making sure that average ratings for institutions with only "NA" votes are defaulted to `null` to prevent the average calculation from dividing by zero.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13635)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Ratings are calculated correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs