### PR TITLE
Refactor code related to File Uploads

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -97,7 +97,7 @@ class UploadsController < ApplicationController
 
     CrosswalkIssue.delete_all if [Crosswalk, IpedsHd, Weam].include?(klass)
 
-    data = klass.load(file, @upload.options)
+    data = klass.load_from_csv(file, @upload.options)
     CrosswalkIssue.rebuild if [Crosswalk, IpedsHd, Weam].include?(klass)
 
     @upload.update(ok: data.present? && data.ids.present?, completed_at: Time.now.utc.to_s(:db))

--- a/app/models/accreditation_action.rb
+++ b/app/models/accreditation_action.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccreditationAction < ApplicationRecord
+class AccreditationAction < ImportableRecord
   belongs_to(:accreditation_institute_campus, foreign_key: 'dapip_id', primary_key: :dapip_id,
                                               inverse_of: :accreditation_actions)
 

--- a/app/models/accreditation_action.rb
+++ b/app/models/accreditation_action.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class AccreditationAction < ApplicationRecord
-  include CsvHelper
-
   belongs_to(:accreditation_institute_campus, foreign_key: 'dapip_id', primary_key: :dapip_id,
                                               inverse_of: :accreditation_actions)
 

--- a/app/models/accreditation_institute_campus.rb
+++ b/app/models/accreditation_institute_campus.rb
@@ -3,6 +3,8 @@
 class AccreditationInstituteCampus < ApplicationRecord
   self.table_name = 'accreditation_institute_campuses'
 
+  include CsvHelper
+
   has_many(:accreditation_records, primary_key: :dapip_id, foreign_key: 'dapip_id',
                                    inverse_of: :accreditation_institute_campus,
                                    dependent: :nullify)

--- a/app/models/accreditation_institute_campus.rb
+++ b/app/models/accreditation_institute_campus.rb
@@ -3,8 +3,6 @@
 class AccreditationInstituteCampus < ApplicationRecord
   self.table_name = 'accreditation_institute_campuses'
 
-  include CsvHelper
-
   has_many(:accreditation_records, primary_key: :dapip_id, foreign_key: 'dapip_id',
                                    inverse_of: :accreditation_institute_campus,
                                    dependent: :nullify)

--- a/app/models/accreditation_record.rb
+++ b/app/models/accreditation_record.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class AccreditationRecord < ApplicationRecord
-  include CsvHelper
-
   belongs_to(:accreditation_institute_campus, foreign_key: 'dapip_id', primary_key: :dapip_id,
                                               inverse_of: :accreditation_records)
 

--- a/app/models/accreditation_record.rb
+++ b/app/models/accreditation_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccreditationRecord < ApplicationRecord
+class AccreditationRecord < ImportableRecord
   belongs_to(:accreditation_institute_campus, foreign_key: 'dapip_id', primary_key: :dapip_id,
                                               inverse_of: :accreditation_records)
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include ExcelHelper
+  include CsvHelper
+
   self.abstract_class = true
+
+  def display_errors_with_row
+    return '' if errors.messages.empty?
+
+    row = errors[:row].first.to_s
+    keys = errors.keys - [:row]
+
+    "Row #{row.presence || 'N/A'} : " + keys.map do |key|
+      message = key.to_s == 'base' ? '' : "#{key} : "
+      message + errors[key].join(', ')
+    end.join(', ')
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
-  include ExcelHelper
   include CsvHelper
 
   self.abstract_class = true

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
-  include CsvHelper
-
   self.abstract_class = true
-
-  def display_errors_with_row
-    return '' if errors.messages.empty?
-
-    row = errors[:row].first.to_s
-    keys = errors.keys - [:row]
-
-    "Row #{row.presence || 'N/A'} : " + keys.map do |key|
-      message = key.to_s == 'base' ? '' : "#{key} : "
-      message + errors[key].join(', ')
-    end.join(', ')
-  end
 end

--- a/app/models/arf_gi_bill.rb
+++ b/app/models/arf_gi_bill.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ArfGiBill < ApplicationRecord
+class ArfGiBill < ImportableRecord
   CSV_CONVERTER_INFO = {
     'facility no.' => { column: :facility_code, converter: FacilityCodeConverter },
     'school name' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/arf_gi_bill.rb
+++ b/app/models/arf_gi_bill.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ArfGiBill < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'facility no.' => { column: :facility_code, converter: FacilityCodeConverter },
     'school name' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/calculator_constant.rb
+++ b/app/models/calculator_constant.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CalculatorConstant < ApplicationRecord
+class CalculatorConstant < ImportableRecord
   CSV_CONVERTER_INFO = {
     'name' => { column: :name, converter: UpcaseConverter },
     'value' => { column: :float_value, converter: NumberConverter },

--- a/app/models/calculator_constant.rb
+++ b/app/models/calculator_constant.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CalculatorConstant < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'name' => { column: :name, converter: UpcaseConverter },
     'value' => { column: :float_value, converter: NumberConverter },

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -16,8 +16,6 @@
 # frozen_string_literal: true
 
 class Complaint < ApplicationRecord
-  include CsvHelper
-
   STATUSES = %w[active closed pending reserved].freeze
   CLOSED_REASONS = ['resolved', 'invalid', 'information only', 'no response', 'unresolved'].freeze
 

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -15,7 +15,7 @@
 
 # frozen_string_literal: true
 
-class Complaint < ApplicationRecord
+class Complaint < ImportableRecord
   STATUSES = %w[active closed pending reserved].freeze
   CLOSED_REASONS = ['resolved', 'invalid', 'information only', 'no response', 'unresolved'].freeze
 

--- a/app/models/crosswalk.rb
+++ b/app/models/crosswalk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Crosswalk < ApplicationRecord
+class Crosswalk < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[ope cross ope6].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/crosswalk.rb
+++ b/app/models/crosswalk.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Crosswalk < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[ope cross ope6].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/edu_program.rb
+++ b/app/models/edu_program.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class EduProgram < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution name' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/edu_program.rb
+++ b/app/models/edu_program.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EduProgram < ApplicationRecord
+class EduProgram < ImportableRecord
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution name' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/eight_key.rb
+++ b/app/models/eight_key.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class EightKey < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'institution of higher education' => { column: :institution, converter: InstitutionConverter },
     'city' => { column: :city, converter: BaseConverter },

--- a/app/models/eight_key.rb
+++ b/app/models/eight_key.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EightKey < ApplicationRecord
+class EightKey < ImportableRecord
   CSV_CONVERTER_INFO = {
     'institution of higher education' => { column: :institution, converter: InstitutionConverter },
     'city' => { column: :city, converter: BaseConverter },

--- a/app/models/hcm.rb
+++ b/app/models/hcm.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Hcm < ApplicationRecord
+class Hcm < ImportableRecord
   CSV_CONVERTER_INFO = {
     'ope id' => { column: :ope, converter: OpeConverter },
     'institution name' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/hcm.rb
+++ b/app/models/hcm.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Hcm < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'ope id' => { column: :ope, converter: OpeConverter },
     'institution name' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/importable_record.rb
+++ b/app/models/importable_record.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ImportableRecord < ApplicationRecord
+  include CsvHelper
+
+  self.abstract_class = true
+
+  def display_errors_with_row
+    return '' if errors.messages.empty?
+
+    row = errors[:row].first.to_s
+    keys = errors.keys - [:row]
+
+    "Row #{row.presence || 'N/A'} : " + keys.map do |key|
+      message = key.to_s == 'base' ? '' : "#{key} : "
+      message + errors[key].join(', ')
+    end.join(', ')
+  end
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Institution < ApplicationRecord
-  include CsvHelper
-
   EMPLOYER = 'OJT'
 
   DEFAULT_IHL_SECTION_103_MESSAGE = 'Contact the School Certifying Official (SCO) for requirements'

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Institution < ApplicationRecord
+class Institution < ImportableRecord
   EMPLOYER = 'OJT'
 
   DEFAULT_IHL_SECTION_103_MESSAGE = 'Contact the School Certifying Official (SCO) for requirements'

--- a/app/models/ipeds_cip_code.rb
+++ b/app/models/ipeds_cip_code.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IpedsCipCode < ApplicationRecord
+class IpedsCipCode < ImportableRecord
   CSV_CONVERTER_INFO = {
     'unitid' => { column: :cross, converter: CrossConverter },
     'cipcode' => { column: :cipcode, converter: BaseConverter },

--- a/app/models/ipeds_cip_code.rb
+++ b/app/models/ipeds_cip_code.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IpedsCipCode < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'unitid' => { column: :cross, converter: CrossConverter },
     'cipcode' => { column: :cipcode, converter: BaseConverter },

--- a/app/models/ipeds_hd.rb
+++ b/app/models/ipeds_hd.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IpedsHd < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[vet_tuition_policy_url f1sysnam f1syscod].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/ipeds_hd.rb
+++ b/app/models/ipeds_hd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IpedsHd < ApplicationRecord
+class IpedsHd < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[vet_tuition_policy_url f1sysnam f1syscod].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/ipeds_ic.rb
+++ b/app/models/ipeds_ic.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IpedsIc < ApplicationRecord
+class IpedsIc < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[
     credit_for_mil_training vet_poc student_vet_grp_ipeds
     soc_member calendar online_all

--- a/app/models/ipeds_ic.rb
+++ b/app/models/ipeds_ic.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IpedsIc < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[
     credit_for_mil_training vet_poc student_vet_grp_ipeds
     soc_member calendar online_all

--- a/app/models/ipeds_ic_ay.rb
+++ b/app/models/ipeds_ic_ay.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IpedsIcAy < ApplicationRecord
+class IpedsIcAy < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[tuition_in_state tuition_out_of_state books].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/ipeds_ic_ay.rb
+++ b/app/models/ipeds_ic_ay.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IpedsIcAy < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[tuition_in_state tuition_out_of_state books].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/ipeds_ic_py.rb
+++ b/app/models/ipeds_ic_py.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IpedsIcPy < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[tuition_in_state tuition_out_of_state books].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/ipeds_ic_py.rb
+++ b/app/models/ipeds_ic_py.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IpedsIcPy < ApplicationRecord
+class IpedsIcPy < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[tuition_in_state tuition_out_of_state books].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/mou.rb
+++ b/app/models/mou.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Mou < ApplicationRecord
-  include CsvHelper
-
   STATUSES = /\A(probation - dod|title iv non-compliant)\z/i.freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/mou.rb
+++ b/app/models/mou.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Mou < ApplicationRecord
+class Mou < ImportableRecord
   STATUSES = /\A(probation - dod|title iv non-compliant)\z/i.freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Outcome < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[
     retention_rate_veteran_ba retention_rate_veteran_otb
     persistance_rate_veteran_ba persistance_rate_veteran_otb

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Outcome < ApplicationRecord
+class Outcome < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[
     retention_rate_veteran_ba retention_rate_veteran_otb
     persistance_rate_veteran_ba persistance_rate_veteran_otb

--- a/app/models/post911_stat.rb
+++ b/app/models/post911_stat.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Post911Stat < ApplicationRecord
+class Post911Stat < ImportableRecord
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'distinct count of tuition and fee' => { column: :tuition_and_fee_count, converter: NumberConverter },

--- a/app/models/post911_stat.rb
+++ b/app/models/post911_stat.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Post911Stat < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'distinct count of tuition and fee' => { column: :tuition_and_fee_count, converter: NumberConverter },

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Program < ApplicationRecord
+class Program < ImportableRecord
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution name' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Program < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },
     'institution name' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/school_certifying_official.rb
+++ b/app/models/school_certifying_official.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SchoolCertifyingOfficial < ApplicationRecord
+class SchoolCertifyingOfficial < ImportableRecord
   VALID_PRIORITY_VALUES = %w[
     PRIMARY
     SECONDARY

--- a/app/models/school_certifying_official.rb
+++ b/app/models/school_certifying_official.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SchoolCertifyingOfficial < ApplicationRecord
-  include CsvHelper
-
   VALID_PRIORITY_VALUES = %w[
     PRIMARY
     SECONDARY

--- a/app/models/school_rating.rb
+++ b/app/models/school_rating.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SchoolRating < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'rater id' => { column: :rater_id, converter: BaseConverter },
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },

--- a/app/models/school_rating.rb
+++ b/app/models/school_rating.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SchoolRating < ApplicationRecord
+class SchoolRating < ImportableRecord
   CSV_CONVERTER_INFO = {
     'rater id' => { column: :rater_id, converter: BaseConverter },
     'facility code' => { column: :facility_code, converter: FacilityCodeConverter },

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -155,7 +155,7 @@ class Scorecard < ApplicationRecord
 
   def self.populate
     results = ScorecardApi::Service.populate
-    load_from_api(results) if results.any?
+    load(results) if results.any?
     results.any?
   end
 

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Scorecard < ApplicationRecord
-  include CsvHelper
-
   validates :cross, presence: true
   validates :pred_degree_awarded, inclusion: { in: (0..4) }
   validates :locale, inclusion: { in: [-3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43] }, allow_blank: true

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Scorecard < ApplicationRecord
+class Scorecard < ImportableRecord
   validates :cross, presence: true
   validates :pred_degree_awarded, inclusion: { in: (0..4) }
   validates :locale, inclusion: { in: [-3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43] }, allow_blank: true

--- a/app/models/sec103.rb
+++ b/app/models/sec103.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Sec103 < ApplicationRecord
-  include CsvHelper
   COLS_USED_IN_INSTITUTION = %i[complies_with_sec_103 solely_requires_coe requires_coe_and_criteria].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/sec103.rb
+++ b/app/models/sec103.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Sec103 < ApplicationRecord
+class Sec103 < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[complies_with_sec_103 solely_requires_coe requires_coe_and_criteria].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/sec109_closed_school.rb
+++ b/app/models/sec109_closed_school.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Sec109ClosedSchool < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[closure109].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/sec109_closed_school.rb
+++ b/app/models/sec109_closed_school.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Sec109ClosedSchool < ApplicationRecord
+class Sec109ClosedSchool < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[closure109].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/sec702.rb
+++ b/app/models/sec702.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Sec702 < ApplicationRecord
+class Sec702 < ImportableRecord
   CSV_CONVERTER_INFO = {
     'state' => { column: :state, converter: StateConverter },
     'state full name' => { column: :state_full_name, converter: BaseConverter },

--- a/app/models/sec702.rb
+++ b/app/models/sec702.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Sec702 < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'state' => { column: :state, converter: StateConverter },
     'state full name' => { column: :state_full_name, converter: BaseConverter },

--- a/app/models/stem_cip_code.rb
+++ b/app/models/stem_cip_code.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class StemCipCode < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'two-digit series' => { column: :two_digit_series, converter: NumberConverter },
     '2010 cip code' => { column: :twentyten_cip_code, converter: BaseConverter },

--- a/app/models/stem_cip_code.rb
+++ b/app/models/stem_cip_code.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StemCipCode < ApplicationRecord
+class StemCipCode < ImportableRecord
   CSV_CONVERTER_INFO = {
     'two-digit series' => { column: :two_digit_series, converter: NumberConverter },
     '2010 cip code' => { column: :twentyten_cip_code, converter: BaseConverter },

--- a/app/models/sva.rb
+++ b/app/models/sva.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Sva < ApplicationRecord
+class Sva < ImportableRecord
   CSV_CONVERTER_INFO = {
     'id' => { column: :csv_id, converter: NumberConverter },
     'school' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/sva.rb
+++ b/app/models/sva.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Sva < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'id' => { column: :csv_id, converter: NumberConverter },
     'school' => { column: :institution, converter: InstitutionConverter },

--- a/app/models/va_caution_flag.rb
+++ b/app/models/va_caution_flag.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class VaCautionFlag < ApplicationRecord
-  include CsvHelper
   CSV_CONVERTER_INFO = {
     'id' => { column: :facility_code, converter: FacilityCodeConverter },
     'instnm' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/va_caution_flag.rb
+++ b/app/models/va_caution_flag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VaCautionFlag < ApplicationRecord
+class VaCautionFlag < ImportableRecord
   CSV_CONVERTER_INFO = {
     'id' => { column: :facility_code, converter: FacilityCodeConverter },
     'instnm' => { column: :institution_name, converter: InstitutionConverter },

--- a/app/models/vsoc.rb
+++ b/app/models/vsoc.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Vsoc < ApplicationRecord
-  include CsvHelper
-
   COLS_USED_IN_INSTITUTION = %i[vetsuccess_name vetsuccess_email].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/vsoc.rb
+++ b/app/models/vsoc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Vsoc < ApplicationRecord
+class Vsoc < ImportableRecord
   COLS_USED_IN_INSTITUTION = %i[vetsuccess_name vetsuccess_email].freeze
 
   CSV_CONVERTER_INFO = {

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -7,7 +7,7 @@
 # Col Separator: normally ',' but can be '|'
 # Quirks: protectorates are listed as states
 # rubocop:disable Metrics/ClassLength
-class Weam < ApplicationRecord
+class Weam < ImportableRecord
   REQUIRED_VET_TEC_LAW_CODE = 'educational institution is approved for vet tec only'
 
   LAW_CODES_BLOCKING_APPROVED_STATUS = [

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -8,8 +8,6 @@
 # Quirks: protectorates are listed as states
 # rubocop:disable Metrics/ClassLength
 class Weam < ApplicationRecord
-  include CsvHelper
-
   REQUIRED_VET_TEC_LAW_CODE = 'educational institution is approved for vet tec only'
 
   LAW_CODES_BLOCKING_APPROVED_STATUS = [

--- a/app/models/yellow_ribbon_program_source.rb
+++ b/app/models/yellow_ribbon_program_source.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class YellowRibbonProgramSource < ApplicationRecord
-  include CsvHelper
-
   CSV_CONVERTER_INFO = {
     'city' => { column: :city },
     'contribution amount' => { column: :contribution_amount, converter: NumberConverter },

--- a/app/models/yellow_ribbon_program_source.rb
+++ b/app/models/yellow_ribbon_program_source.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class YellowRibbonProgramSource < ApplicationRecord
+class YellowRibbonProgramSource < ImportableRecord
   CSV_CONVERTER_INFO = {
     'city' => { column: :city },
     'contribution amount' => { column: :contribution_amount, converter: NumberConverter },

--- a/lib/csv_helper/loader.rb
+++ b/lib/csv_helper/loader.rb
@@ -9,14 +9,14 @@ module CsvHelper
       remove_empty_values: true, convert_values_to_numeric: false, remove_unmapped_keys: true
     }.freeze
 
-    def load(file, options = {})
+    def load_from_csv(file, options = {})
       klass.transaction do
         delete_all
         load_csv_file(file, options)
       end
     end
 
-    def load_from_api(results, options = {})
+    def load(results, options = {})
       klass.transaction do
         delete_all
         load_records(results, options)

--- a/lib/csv_helper/shared.rb
+++ b/lib/csv_helper/shared.rb
@@ -6,7 +6,7 @@ module CsvHelper
     base.extend Loader
     base.extend Exporter
   end
-  
+
   module Shared
     def klass
       name.constantize

--- a/lib/csv_helper/shared.rb
+++ b/lib/csv_helper/shared.rb
@@ -6,19 +6,7 @@ module CsvHelper
     base.extend Loader
     base.extend Exporter
   end
-
-  def display_errors_with_row
-    return '' if errors.messages.empty?
-
-    row = errors[:row].first.to_s
-    keys = errors.keys - [:row]
-
-    "Row #{row.presence || 'N/A'} : " + keys.map do |key|
-      message = key.to_s == 'base' ? '' : "#{key} : "
-      message + errors[key].join(', ')
-    end.join(', ')
-  end
-
+  
   module Shared
     def klass
       name.constantize

--- a/lib/seed_utils.rb
+++ b/lib/seed_utils.rb
@@ -36,6 +36,6 @@ module SeedUtils
   end
 
   def seed_table(klass, path, options = {})
-    klass.load(path, options)
+    klass.load_from_csv(path, options)
   end
 end

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DashboardsController, type: :controller do
     csv_path = 'spec/fixtures'
 
     upload = create :upload, csv_type: csv_type, csv_name: csv_name, user: User.first
-    klass.load("#{csv_path}/#{csv_name}", options)
+    klass.load_from_csv("#{csv_path}/#{csv_name}", options)
     upload.update(ok: true)
   end
 

--- a/spec/models/scorecard_spec.rb
+++ b/spec/models/scorecard_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe Scorecard, type: :model do
 
     it 'causes populate to be called for a CSV' do
       allow(ScorecardApi::Service).to receive(:populate).and_return([scorecard])
-      allow(described_class).to receive(:load_from_api)
+      allow(described_class).to receive(:load)
       message = described_class.populate
 
       expect(message).to be_truthy
       expect(ScorecardApi::Service).to have_received(:populate)
-      expect(described_class).to have_received(:load_from_api)
+      expect(described_class).to have_received(:load)
     end
   end
 end

--- a/spec/models/shared_examples/shared_examples_for_exportable.rb
+++ b/spec/models/shared_examples/shared_examples_for_exportable.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples 'an exportable model' do |options|
     load_options = default_options.transform_keys(&:to_sym).merge(options)
 
     before do
-      described_class.load(csv_file, load_options)
+      described_class.load_from_csv(csv_file, load_options)
     end
 
     def check_attributes_from_records(rows, header_row)

--- a/spec/models/shared_examples/shared_examples_for_loadable.rb
+++ b/spec/models/shared_examples/shared_examples_for_loadable.rb
@@ -23,11 +23,11 @@ RSpec.shared_examples 'a loadable model' do |options|
 
     context 'with an error-free csv file' do
       it 'deletes the old table content' do
-        expect { described_class.load(csv_file, load_options) }.to change(described_class, :count).from(5).to(2)
+        expect { described_class.load_from_csv(csv_file, load_options) }.to change(described_class, :count).from(5).to(2)
       end
 
       it 'loads the table' do
-        results = described_class.load(csv_file, load_options)
+        results = described_class.load_from_csv(csv_file, load_options)
 
         expect(results.num_inserts).to eq(1)
         expect(results.ids.length).to eq(2)
@@ -38,7 +38,7 @@ RSpec.shared_examples 'a loadable model' do |options|
       let(:csv_rows) { 2 }
 
       it 'does not load invalid records into the table' do
-        results = described_class.load(csv_file_invalid, load_options)
+        results = described_class.load_from_csv(csv_file_invalid, load_options)
 
         expect(results.num_inserts).to eq(1)
         expect(results.ids.length).to eq(1)
@@ -47,14 +47,14 @@ RSpec.shared_examples 'a loadable model' do |options|
       it 'does roll back to the old table content if the upload is invalid' do
         allow(described_class).to receive(:load_csv_file).and_raise(StandardError)
         before_count = described_class.count
-        expect { described_class.load(csv_file_invalid, load_options) }.to raise_error(StandardError)
+        expect { described_class.load_from_csv(csv_file_invalid, load_options) }.to raise_error(StandardError)
         expect(before_count).to eq(described_class.count)
       end
 
       it 'does roll back to the old table content if the upload loaded records are invalid' do
         allow(described_class).to receive(:load_records).and_raise(StandardError)
         before_count = described_class.count
-        expect { described_class.load_from_api([], load_options) }.to raise_error(StandardError)
+        expect { described_class.load([], load_options) }.to raise_error(StandardError)
         expect(before_count).to eq(described_class.count)
       end
     end

--- a/spec/models/shared_examples/shared_examples_for_loadable.rb
+++ b/spec/models/shared_examples/shared_examples_for_loadable.rb
@@ -23,7 +23,8 @@ RSpec.shared_examples 'a loadable model' do |options|
 
     context 'with an error-free csv file' do
       it 'deletes the old table content' do
-        expect { described_class.load_from_csv(csv_file, load_options) }.to change(described_class, :count).from(5).to(2)
+        expect { described_class.load_from_csv(csv_file, load_options) }
+          .to change(described_class, :count).from(5).to(2)
       end
 
       it 'loads the table' do


### PR DESCRIPTION
## Description

A refactor being done as part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/14735

- Create ImportableRecord which includes CsvHelper, creating a separate abstract model as ApplicationRecord is used by models that do not need what CsvHelper provides
- Remove including CsvHelper in individual models that inherit from ApplicationRecord and have them inherit from ImportableRecord
- Rename `load` to `load_from_csv` as this is specific to CSV loading
- Rename `load_from_api` to `load` as this is the generic method that wraps the loading of an array of hashes in a transaction

## Testing done
- Upload valid and invalid CSVs
- Export files

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs