### PR TITLE
For uploads reorder warnings messages and populate warnings even if error occurs

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -56,7 +56,7 @@ class UploadsController < ApplicationController
                                      .map(&:display_errors_with_row)
     header_warnings = @upload.all_warnings
 
-    if valid_rows >= 0
+    if valid_rows > 0
       flash[:csv_success] = {
         total_rows_count: total_rows_count.to_s,
         valid_rows: valid_rows.to_s,

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -56,7 +56,7 @@ class UploadsController < ApplicationController
                                      .map(&:display_errors_with_row)
     header_warnings = @upload.all_warnings
 
-    if valid_rows > 0
+    if valid_rows.positive?
       flash[:csv_success] = {
         total_rows_count: total_rows_count.to_s,
         valid_rows: valid_rows.to_s,

--- a/app/views/uploads/_upload_messages.html.erb
+++ b/app/views/uploads/_upload_messages.html.erb
@@ -1,3 +1,15 @@
+<% if flash[:danger].present? %>
+  <aside class="alert alert-danger">
+    <% if flash[:danger].is_a? Hash %>
+      <% flash[:danger].each_pair do |label, dangers| %>
+        <%= pretty_error(dangers, label) %>
+      <% end %>
+    <% else %>
+      <%= flash[:danger].html_safe %>
+    <% end %>
+  </aside>
+<% end %>
+
 <% if flash[:csv_success].present? %>
   <aside class="alert alert-success">
     <div class="errors">
@@ -29,14 +41,3 @@
   </aside>
 <% end %>
 
-<% if flash[:danger].present? %>
-  <aside class="alert alert-danger">
-    <% if flash[:danger].is_a? Hash %>
-      <% flash[:danger].each_pair do |label, dangers| %>
-        <%= pretty_error(dangers, label) %>
-      <% end %>
-    <% else %>
-      <%= flash[:danger].html_safe %>
-    <% end %>
-  </aside>
-<% end %>


### PR DESCRIPTION
## Description

- Move error messages to be displayed at top if they occur
- Populate success message only if valid rows is greater than 0
- Populate warning messages even when an error occurs

## Testing done


## Screenshots

![image](https://user-images.githubusercontent.com/1094999/96611477-b5ef8880-12ca-11eb-8782-d7cef4525edd.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs