### PR TITLE
Refactor CSV type to be Upload types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -166,6 +166,7 @@ RSpec/FilePath:
 RSpec/DescribeClass:
   Exclude:
     - "spec/config/initializers/csv_types_spec.rb"
+    - "spec/config/initializers/upload_types_spec.rb"
     - "spec/config/initializers/common_spec.rb"
     - "spec/models/archiver_spec.rb"
     - "spec/utilities/caution_flags/caution_flag_template_spec.rb"

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -102,7 +102,7 @@ class DashboardsController < ApplicationController
     model = CSV_TYPES_ALL_TABLES_CLASSES.select { |klass| klass.name == csv_type }.first
     return model if model.present?
 
-    raise(ArgumentError, "#{csv_type} is not a valid CSV type") if model.blank?
+    raise(ArgumentError, "#{csv_type} is not a valid exportable CSV type") if model.blank?
   end
 
   def fetch_api_data(api_upload)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -3,14 +3,14 @@
 module DashboardsHelper
   def latest_upload_class(upload)
     return '' if upload.ok?
-    return 'danger' if CSV_TYPES_REQUIRED_TABLE_NAMES.include?(upload.csv_type)
+    return 'danger' if UPLOAD_TYPES_REQUIRED_NAMES.include?(upload.csv_type)
 
     'warning'
   end
 
   def latest_upload_title(upload)
     return '' if upload.ok?
-    return 'Missing required upload' if CSV_TYPES_REQUIRED_TABLE_NAMES.include?(upload.csv_type)
+    return 'Missing required upload' if UPLOAD_TYPES_REQUIRED_NAMES.include?(upload.csv_type)
 
     'Missing upload'
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -8,7 +8,7 @@ class Storage < ApplicationRecord
   validates_associated :user
   validates :user_id, presence: true
 
-  validates :csv_type, uniqueness: true, inclusion: { in: CSV_TYPES_ALL_TABLES_NAMES }
+  validates :csv_type, uniqueness: true, inclusion: { in: UPLOAD_TYPES_ALL_NAMES }
   validates :data, :csv, presence: true
   validates :upload_file, presence: true, unless: :persisted?
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -23,7 +23,7 @@ class Upload < ApplicationRecord
   end
 
   def csv_type_check?
-    return true if [*CSV_TYPES_ALL_TABLES_NAMES, 'Institution'].include?(csv_type)
+    return true if [*UPLOAD_TYPES_ALL_NAMES, 'Institution'].include?(csv_type)
 
     if csv_type.present?
       errors.add(:csv_type, "#{csv_type} is not a valid CSV data source")
@@ -40,7 +40,7 @@ class Upload < ApplicationRecord
 
   def self.last_uploads
     Upload.select('DISTINCT ON("csv_type") *')
-          .where(ok: true, csv_type: CSV_TYPES_ALL_TABLES_NAMES)
+          .where(ok: true, csv_type: UPLOAD_TYPES_ALL_NAMES)
           .order(csv_type: :asc, updated_at: :desc)
   end
 
@@ -49,7 +49,7 @@ class Upload < ApplicationRecord
     upload_csv_types = uploads.map(&:csv_type)
 
     # add csv types that are missing from database to allow for uploads
-    CSV_TYPES_ALL_TABLES_NAMES.each do |klass_name|
+    UPLOAD_TYPES_ALL_NAMES.each do |klass_name|
       next if upload_csv_types.include?(klass_name)
 
       missing_upload = Upload.new

--- a/app/views/dashboards/_latest_upload.html.erb
+++ b/app/views/dashboards/_latest_upload.html.erb
@@ -1,4 +1,4 @@
-<% if production? && CSV_TYPES_NO_PROD_NAMES.include?(upload.csv_type) %>
+<% if production? && UPLOAD_TYPES_NO_PROD_NAMES.include?(upload.csv_type) %>
 <%else %>
   <tr id="row_<%=upload.csv_type%>"
       class="<%= latest_upload_class(upload) %>"

--- a/app/views/storages/_csv_type_select.html.erb
+++ b/app/views/storages/_csv_type_select.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= f.label(:csv_file_type) %>
-  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES_NAMES),
+  <%= f.select(:csv_type, options_for_select(UPLOAD_TYPES_ALL_NAMES),
     { include_blank: "Select Csv File Type" },
     { class: "form-control", required: true }) %>
 </div>

--- a/app/views/uploads/_csv_type_select.html.erb
+++ b/app/views/uploads/_csv_type_select.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= f.label(:csv_file_type) %>
-  <%= f.select(:csv_type, options_for_select(CSV_TYPES_ALL_TABLES_NAMES),
+  <%= f.select(:csv_type, options_for_select(UPLOAD_TYPES_ALL_NAMES),
     { include_blank: "Select Csv File Type" },
     { class: "form-control", required: true }) %>
 </div>

--- a/config/initializers/csv_types.rb
+++ b/config/initializers/csv_types.rb
@@ -32,8 +32,5 @@ CSV_TYPES_TABLES = [
   { klass: SchoolRating, required?: false },
 ].freeze
 
-CSV_TYPES_REQUIRED_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:required?] }.map { |table| table[:klass].name }.freeze
 CSV_TYPES_HAS_API_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:has_api?] }.map { |table| table[:klass].name }.freeze
 CSV_TYPES_ALL_TABLES_CLASSES = CSV_TYPES_TABLES.map { |table| table[:klass] }.freeze
-CSV_TYPES_ALL_TABLES_NAMES = CSV_TYPES_TABLES.map { |table| table[:klass].name }.freeze
-CSV_TYPES_NO_PROD_NAMES = CSV_TYPES_TABLES.select { |table| table[:not_prod_ready?] }.map { |table| table[:klass].name }.freeze

--- a/config/initializers/upload_types.rb
+++ b/config/initializers/upload_types.rb
@@ -1,0 +1,18 @@
+UPLOAD_TYPES = [
+    *CSV_TYPES_TABLES
+].freeze
+
+def klass_name(klass)
+  return klass if klass.is_a? String
+  klass.name
+end
+
+def klass_names(upload_types)
+  upload_types.map do |upload|
+    klass_name(upload[:klass])
+  end.freeze
+end
+
+UPLOAD_TYPES_REQUIRED_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:required?] })
+UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map { |upload| klass_name(upload[:klass]) }.freeze
+UPLOAD_TYPES_NO_PROD_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:not_prod_ready?] })

--- a/config/initializers/upload_types.rb
+++ b/config/initializers/upload_types.rb
@@ -2,18 +2,20 @@ UPLOAD_TYPES = [
     *CSV_TYPES_TABLES
 ].freeze
 
-def klass_name(upload)
+UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map do |upload|
   klass = upload[:klass]
   return klass if klass.is_a? String
   klass.name
-end
+end.freeze
 
-def klass_names(upload_types)
-  upload_types.map do |upload|
-    klass_name(upload)
-  end.freeze
-end
+UPLOAD_TYPES_REQUIRED_NAMES = UPLOAD_TYPES.select { |upload| upload[:required?] }.map do |upload|
+  klass = upload[:klass]
+  return klass if klass.is_a? String
+  klass.name
+end.freeze
 
-UPLOAD_TYPES_REQUIRED_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:required?] })
-UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map { |upload| klass_name(upload) }.freeze
-UPLOAD_TYPES_NO_PROD_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:not_prod_ready?] })
+UPLOAD_TYPES_NO_PROD_NAMES = UPLOAD_TYPES.select { |upload| upload[:not_prod_ready?] }.map do |upload|
+  klass = upload[:klass]
+  return klass if klass.is_a? String
+  klass.name
+end.freeze

--- a/config/initializers/upload_types.rb
+++ b/config/initializers/upload_types.rb
@@ -2,17 +2,18 @@ UPLOAD_TYPES = [
     *CSV_TYPES_TABLES
 ].freeze
 
-def klass_name(klass)
+def klass_name(upload)
+  klass = upload[:klass]
   return klass if klass.is_a? String
   klass.name
 end
 
 def klass_names(upload_types)
   upload_types.map do |upload|
-    klass_name(upload[:klass])
+    klass_name(upload)
   end.freeze
 end
 
 UPLOAD_TYPES_REQUIRED_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:required?] })
-UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map { |upload| klass_name(upload[:klass]) }.freeze
+UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map { |upload| klass_name(upload) }.freeze
 UPLOAD_TYPES_NO_PROD_NAMES = klass_names(UPLOAD_TYPES.select { |upload| upload[:not_prod_ready?] })

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-API_TABLES = [
-  Scorecard.name
-].freeze
-
 def klass_name(upload)
   klass = upload[:klass]
   return klass if klass.is_a? String
@@ -20,7 +16,13 @@ RSpec.describe 'CSV_TYPES' do
 
   describe 'has_api_table_names' do
     it 'contains tables' do
-      expect(CSV_TYPES_HAS_API_TABLE_NAMES).to eq(API_TABLES)
+      CSV_TYPES_TABLES.each do |upload_type|
+        if upload_type[:has_api?]
+          expect(CSV_TYPES_HAS_API_TABLE_NAMES).to include(klass_name(upload_type))
+        else
+          expect(CSV_TYPES_HAS_API_TABLE_NAMES).not_to include(klass_name(upload_type))
+        end
+      end
     end
   end
 

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -4,6 +4,13 @@ API_TABLES = [
   Scorecard.name
 ].freeze
 
+def klass_name(upload)
+  klass = upload[:klass]
+  return klass if klass.is_a? String
+
+  klass.name
+end
+
 RSpec.describe 'CSV_TYPES' do
   describe 'all_tables' do
     it 'lengths should be equal' do
@@ -20,9 +27,7 @@ RSpec.describe 'CSV_TYPES' do
   describe 'fields checks' do
     CSV_TYPES_TABLES.each do |upload|
       it "#{klass_name(upload)} csv type config has_api? is a boolean" do
-        if upload.respond_to?(:has_api?)
-          expect(upload[:has_api?]).to be_in([true, false])
-        end
+        expect(upload[:has_api?]).to be_in([true, false]) if upload.respond_to?(:has_api?)
       end
     end
   end

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -1,59 +1,19 @@
 # frozen_string_literal: true
 
-REQUIRED_TABLES = [
-  AccreditationAction.name,
-  AccreditationInstituteCampus.name,
-  AccreditationRecord.name,
-  ArfGiBill.name,
-  Complaint.name,
-  Crosswalk.name,
-  EightKey.name,
-  Hcm.name,
-  IpedsHd.name,
-  IpedsIcAy.name,
-  IpedsIcPy.name,
-  IpedsIc.name,
-  Mou.name,
-  Outcome.name,
-  Scorecard.name,
-  Sec702.name,
-  Sva.name,
-  Vsoc.name,
-  Weam.name,
-  IpedsCipCode.name,
-  StemCipCode.name,
-  YellowRibbonProgramSource.name,
-  Sec109ClosedSchool.name
-].freeze
-
 API_TABLES = [
   Scorecard.name
 ].freeze
 
-NO_PROD_TABLES = [].freeze
-
 RSpec.describe 'CSV_TYPES' do
   describe 'all_tables' do
     it 'lengths should be equal' do
-      expect(CSV_TYPES_ALL_TABLES_NAMES.length).to eq(CSV_TYPES_TABLES.length)
-    end
-  end
-
-  describe 'required_table_names' do
-    it 'contains tables' do
-      expect(CSV_TYPES_REQUIRED_TABLE_NAMES).to eq(REQUIRED_TABLES)
+      expect(CSV_TYPES_ALL_TABLES_CLASSES.length).to eq(CSV_TYPES_TABLES.length)
     end
   end
 
   describe 'has_api_table_names' do
     it 'contains tables' do
       expect(CSV_TYPES_HAS_API_TABLE_NAMES).to eq(API_TABLES)
-    end
-  end
-
-  describe 'no_prod_names' do
-    it 'contains tables' do
-      expect(CSV_TYPES_NO_PROD_NAMES).to eq(NO_PROD_TABLES)
     end
   end
 end

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -16,4 +16,14 @@ RSpec.describe 'CSV_TYPES' do
       expect(CSV_TYPES_HAS_API_TABLE_NAMES).to eq(API_TABLES)
     end
   end
+
+  describe 'fields checks' do
+    CSV_TYPES_TABLES.each do |upload|
+      it "#{klass_name(upload)} csv type config has_api? is a boolean" do
+        if upload.respond_to?(:has_api?)
+          expect(upload[:has_api?]).to be_in([true, false])
+        end
+      end
+    end
+  end
 end

--- a/spec/config/initializers/upload_types_spec.rb
+++ b/spec/config/initializers/upload_types_spec.rb
@@ -28,6 +28,13 @@ REQUIRED_TABLES = [
 
 NO_PROD_TABLES = [].freeze
 
+def klass_name(upload)
+  klass = upload[:klass]
+  return klass if klass.is_a? String
+
+  klass.name
+end
+
 RSpec.describe 'UPLOAD_TYPES' do
   describe 'all_tables' do
     it 'lengths should be equal' do
@@ -62,9 +69,7 @@ RSpec.describe 'UPLOAD_TYPES' do
 
     UPLOAD_TYPES.each do |upload|
       it "#{klass_name(upload)} upload type config not_prod_ready? is a boolean" do
-        if upload[:not_prod_ready?].present?
-          expect(upload[:not_prod_ready?]).to be_in([true, false])
-        end
+        expect(upload[:not_prod_ready?]).to be_in([true, false]) if upload[:not_prod_ready?].present?
       end
     end
   end

--- a/spec/config/initializers/upload_types_spec.rb
+++ b/spec/config/initializers/upload_types_spec.rb
@@ -28,7 +28,7 @@ REQUIRED_TABLES = [
 
 NO_PROD_TABLES = [].freeze
 
-RSpec.describe 'CSV_TYPES' do
+RSpec.describe 'UPLOAD_TYPES' do
   describe 'all_tables' do
     it 'lengths should be equal' do
       expect(UPLOAD_TYPES_ALL_NAMES.length).to eq(UPLOAD_TYPES.length)

--- a/spec/config/initializers/upload_types_spec.rb
+++ b/spec/config/initializers/upload_types_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+REQUIRED_TABLES = [
+  AccreditationAction.name,
+  AccreditationInstituteCampus.name,
+  AccreditationRecord.name,
+  ArfGiBill.name,
+  Complaint.name,
+  Crosswalk.name,
+  EightKey.name,
+  Hcm.name,
+  IpedsHd.name,
+  IpedsIcAy.name,
+  IpedsIcPy.name,
+  IpedsIc.name,
+  Mou.name,
+  Outcome.name,
+  Scorecard.name,
+  Sec702.name,
+  Sva.name,
+  Vsoc.name,
+  Weam.name,
+  IpedsCipCode.name,
+  StemCipCode.name,
+  YellowRibbonProgramSource.name,
+  Sec109ClosedSchool.name
+].freeze
+
+NO_PROD_TABLES = [].freeze
+
+RSpec.describe 'CSV_TYPES' do
+  describe 'all_tables' do
+    it 'lengths should be equal' do
+      expect(UPLOAD_TYPES_ALL_NAMES.length).to eq(UPLOAD_TYPES.length)
+    end
+  end
+
+  describe 'required_table_names' do
+    it 'contains tables' do
+      expect(UPLOAD_TYPES_REQUIRED_NAMES).to eq(REQUIRED_TABLES)
+    end
+  end
+
+  describe 'no_prod_names' do
+    it 'contains tables' do
+      expect(UPLOAD_TYPES_NO_PROD_NAMES).to eq(NO_PROD_TABLES)
+    end
+  end
+end

--- a/spec/config/initializers/upload_types_spec.rb
+++ b/spec/config/initializers/upload_types_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe 'UPLOAD_TYPES' do
       expect(UPLOAD_TYPES_NO_PROD_NAMES).to eq(NO_PROD_TABLES)
     end
   end
+
+  describe 'fields checks' do
+    UPLOAD_TYPES.each do |upload|
+      it "#{klass_name(upload)} upload type config has field klass" do
+        expect(upload[:klass]).to be_a(String).or be < ImportableRecord
+      end
+    end
+
+    UPLOAD_TYPES.each do |upload|
+      it "#{klass_name(upload)} upload type config has field required?" do
+        expect(upload[:required?]).to be_in([true, false])
+      end
+    end
+
+    UPLOAD_TYPES.each do |upload|
+      it "#{klass_name(upload)} upload type config not_prod_ready? is a boolean" do
+        if upload[:not_prod_ready?].present?
+          expect(upload[:not_prod_ready?]).to be_in([true, false])
+        end
+      end
+    end
+  end
 end

--- a/spec/config/initializers/upload_types_spec.rb
+++ b/spec/config/initializers/upload_types_spec.rb
@@ -1,33 +1,5 @@
 # frozen_string_literal: true
 
-REQUIRED_TABLES = [
-  AccreditationAction.name,
-  AccreditationInstituteCampus.name,
-  AccreditationRecord.name,
-  ArfGiBill.name,
-  Complaint.name,
-  Crosswalk.name,
-  EightKey.name,
-  Hcm.name,
-  IpedsHd.name,
-  IpedsIcAy.name,
-  IpedsIcPy.name,
-  IpedsIc.name,
-  Mou.name,
-  Outcome.name,
-  Scorecard.name,
-  Sec702.name,
-  Sva.name,
-  Vsoc.name,
-  Weam.name,
-  IpedsCipCode.name,
-  StemCipCode.name,
-  YellowRibbonProgramSource.name,
-  Sec109ClosedSchool.name
-].freeze
-
-NO_PROD_TABLES = [].freeze
-
 def klass_name(upload)
   klass = upload[:klass]
   return klass if klass.is_a? String
@@ -44,13 +16,25 @@ RSpec.describe 'UPLOAD_TYPES' do
 
   describe 'required_table_names' do
     it 'contains tables' do
-      expect(UPLOAD_TYPES_REQUIRED_NAMES).to eq(REQUIRED_TABLES)
+      UPLOAD_TYPES.each do |upload_type|
+        if upload_type[:required?]
+          expect(UPLOAD_TYPES_REQUIRED_NAMES).to include(klass_name(upload_type))
+        else
+          expect(UPLOAD_TYPES_REQUIRED_NAMES).not_to include(klass_name(upload_type))
+        end
+      end
     end
   end
 
   describe 'no_prod_names' do
     it 'contains tables' do
-      expect(UPLOAD_TYPES_NO_PROD_NAMES).to eq(NO_PROD_TABLES)
+      UPLOAD_TYPES.each do |upload_type|
+        if upload_type[:not_prod_ready?]
+          expect(UPLOAD_TYPES_NO_PROD_NAMES).to include(klass_name(upload_type))
+        else
+          expect(UPLOAD_TYPES_NO_PROD_NAMES).not_to include(klass_name(upload_type))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Defining groups csv/file types for upload from multi-tab excel spreadsheets is coming and this is refactor/setup work that can be broken out from https://github.com/department-of-veterans-affairs/gibct-data-service/pull/751

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs