### PR TITLE
Remove return from upload_types

### DIFF
--- a/config/initializers/upload_types.rb
+++ b/config/initializers/upload_types.rb
@@ -4,18 +4,27 @@ UPLOAD_TYPES = [
 
 UPLOAD_TYPES_ALL_NAMES = UPLOAD_TYPES.map do |upload|
   klass = upload[:klass]
-  return klass if klass.is_a? String
-  klass.name
+  if klass.is_a? String
+    klass
+  else
+    klass.name
+  end
 end.freeze
 
 UPLOAD_TYPES_REQUIRED_NAMES = UPLOAD_TYPES.select { |upload| upload[:required?] }.map do |upload|
   klass = upload[:klass]
-  return klass if klass.is_a? String
-  klass.name
+  if klass.is_a? String
+    klass
+  else
+    klass.name
+  end
 end.freeze
 
 UPLOAD_TYPES_NO_PROD_NAMES = UPLOAD_TYPES.select { |upload| upload[:not_prod_ready?] }.map do |upload|
   klass = upload[:klass]
-  return klass if klass.is_a? String
-  klass.name
+  if klass.is_a? String
+    klass
+  else
+    klass.name
+  end
 end.freeze


### PR DESCRIPTION
## Description

this will causes issues when `upload[:klass]` is a string

the return was causing the file to be exited early and the constants to not be setup

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs