### PR TITLE
Group uploads: add hidden field for param when checkbox is not displayed

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -17,11 +17,16 @@
   </div>
 
   <% if flash[:danger].present? %>
-    <div class="form-group danger">
+    <div class="form-group alert-danger">
       <%= f.check_box(:parse_as_xml) %>
       <%= f.label(:parse_as_xml) %>
-      <p class="help-block">If there is an error below change this and upload again</p>
+      <p class="help-block">This upload process was designed for the Excel data file downloaded from
+        <a href="https://ope.ed.gov/dapip/#/download-data-files">DAPIP</a>.<br/>
+        If there is an error below uncheck this and upload again.
+      </p>
     </div>
+  <% else %>
+    <%= f.hidden_field(:parse_as_xml) %>
   <% end %>
 
   <h4>Sheet options</h4>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15604

The checkbox is a “well they tried a valid excel file and the custom process for the downloaded file didn’t work” fail safe

Without the hidden field the param wasn't being passed down correctly and Accreditation Excel file from https://ope.ed.gov/dapip/#/download-data-files wasn't uploading on first try correctly

The failsafe should be more prominent when it occurs.

## Testing done
- download Excel file from https://ope.ed.gov/dapip/#/download-data-files
- upload

## Screenshots
![image](https://user-images.githubusercontent.com/1094999/97618998-129f2180-19f6-11eb-9494-5256990f9096.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs