### PR TITLE
Force utf-8 encoding when uploading CSVs with Roo

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -33,6 +33,7 @@ class UploadsController < ApplicationController
      redirect_to @upload
     rescue StandardError => e
       @upload = Upload.from_csv_type(merged_params[:csv_type])
+      @extensions = Settings.roo_upload.extensions.single.join(', ')
       csv_requirements if @upload.csv_type_check?
       alert_and_log("Failed to upload #{original_filename}: #{e.message}\n#{e.backtrace[0]}", e)
       render :new

--- a/lib/roo_helper/loader.rb
+++ b/lib/roo_helper/loader.rb
@@ -175,7 +175,7 @@ module RooHelper
     def csv_options(file, file_options)
       csv_options = {
         col_sep: csv_col_sep(file, file_options),
-        encoding: 'ISO-8859-1',
+        encoding: 'ISO-8859-1'
       }
       csv_options[:liberal_parsing] = file_options[:liberal_parsing]
       csv_options

--- a/lib/roo_helper/loader.rb
+++ b/lib/roo_helper/loader.rb
@@ -171,9 +171,11 @@ module RooHelper
 
     # Set CSV options
     # See https://apidock.com/ruby/v2_5_5/CSV/new/class for more options
+    # Forces encoding to be utf-8
     def csv_options(file, file_options)
       csv_options = {
-        col_sep: csv_col_sep(file, file_options)
+        col_sep: csv_col_sep(file, file_options),
+        encoding: 'ISO-8859-1',
       }
       csv_options[:liberal_parsing] = file_options[:liberal_parsing]
       csv_options


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15973

When switching from SmarterCSV to Roo the option [`force_utf8`](https://github.com/tilo/smarter_csv/tree/1.2-stable#options) was not translated over.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs