### PR TITLE
Remove requires of roo_helper in several files

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-#
-# This should not have to be here but ruby is not loading this in config/initializers/roo_helper.rb
-Dir["#{Rails.application.config.root}/lib/roo_helper/**/*.rb"].sort.each { |f| require(f) }
-
 class GroupsController < ApplicationController
   def new
     return if setup(params[:group_type])

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-#
-# This should not have to be here but ruby is not loading this in config/initializers/roo_helper.rb
-Dir["#{Rails.application.config.root}/lib/roo_helper/**/*.rb"].sort.each { |f| require(f) }
-
 class UploadsController < ApplicationController
   def index
     @uploads = Upload.paginate(page: params[:page]).order(created_at: :desc)

--- a/app/models/importable_record.rb
+++ b/app/models/importable_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'roo_helper/shared'
+
 class ImportableRecord < ApplicationRecord
   include RooHelper
 

--- a/app/models/importable_record.rb
+++ b/app/models/importable_record.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# This should not have to be here but ruby is not loading this in config/initializers/roo_helper.rb
-Dir["#{Rails.application.config.root}/lib/roo_helper/**/*.rb"].sort.each { |f| require(f) }
-
 class ImportableRecord < ApplicationRecord
   include RooHelper
 

--- a/config/initializers/common.rb
+++ b/config/initializers/common.rb
@@ -1,4 +1,7 @@
 require 'common/exceptions'
+require 'common/exporter'
+require 'common/loader'
+require 'common/shared'
 
 Rails.application.config.after_initialize do
   deployment_env = ENV.fetch('DEPLOYMENT_ENV')

--- a/config/initializers/common.rb
+++ b/config/initializers/common.rb
@@ -1,7 +1,4 @@
 require 'common/exceptions'
-require 'common/exporter'
-require 'common/loader'
-require 'common/shared'
 
 Rails.application.config.after_initialize do
   deployment_env = ENV.fetch('DEPLOYMENT_ENV')

--- a/config/initializers/roo_helper.rb
+++ b/config/initializers/roo_helper.rb
@@ -1,2 +1,1 @@
 Dir["#{Rails.application.config.root}/lib/roo_helper/**/*.rb"].each { |f| require(f) }
-Dir["#{Rails.application.config.root}/lib/csv_helper/**/*.rb"].each { |f| require(f) }


### PR DESCRIPTION
## Description

These lines were added to work around an issue with files not recognizing the `roo_helper` classes.  Removing them appears to now work

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs