### PR TITLE
16357: Add database specific changes.

### DIFF
--- a/db/migrate/20201120180434_add_coordinates_to_institutions.rb
+++ b/db/migrate/20201120180434_add_coordinates_to_institutions.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToInstitutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions, :latitude, :float
+    add_column :institutions, :longitude, :float
+  end
+end

--- a/db/migrate/20201120180453_add_coordinates_to_institutions_archives.rb
+++ b/db/migrate/20201120180453_add_coordinates_to_institutions_archives.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToInstitutionsArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions_archives, :latitude, :float
+    add_column :institutions_archives, :longitude, :float
+  end
+end

--- a/db/migrate/20201123162846_add_coordinates_to_scorecard.rb
+++ b/db/migrate/20201123162846_add_coordinates_to_scorecard.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToScorecard < ActiveRecord::Migration[5.2]
+  def change
+    add_column :scorecards, :latitude, :float
+    add_column :scorecards, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_30_081100) do
+ActiveRecord::Schema.define(version: 2020_11_23_162846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -448,6 +448,8 @@ ActiveRecord::Schema.define(version: 2020_09_30_081100) do
     t.string "institution_search"
     t.integer "rating_count", default: 0
     t.float "rating_average"
+    t.float "latitude"
+    t.float "longitude"
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin
@@ -606,6 +608,8 @@ ActiveRecord::Schema.define(version: 2020_09_30_081100) do
     t.string "institution_search"
     t.integer "rating_count"
     t.float "rating_average"
+    t.float "latitude"
+    t.float "longitude"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|
@@ -1399,6 +1403,8 @@ ActiveRecord::Schema.define(version: 2020_09_30_081100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "alias"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["cross"], name: "index_scorecards_on_cross"
     t.index ["ope"], name: "index_scorecards_on_ope"
   end


### PR DESCRIPTION
## Description
As a developer, I need to include the latitude and longitude in version generation so that it can be used for any forthcoming mapping / near me functionality.

#### AC1 Analysis:
When testing with the local set of sample CSVs, only 9599 of the 69343 institutions have latitude values and 9600 of the same 69343 have longitude values.

Note: Longitude is supplied as `longitud` from the `ipeds_hd` csv file.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/16357)

## Testing done
CI tests pass locally.

## Screenshots
N/A

## Acceptance criteria
- [x] Analysis of data coverage of institutions with/without latitude and/or longitude is documented on this story.
- [x] Institution Latitude is:
a. included in version generation.
b. included in the institution export.
c. available to be used by the front end of the Comparison Tool
- [x] Institution Longitude is:
a. included in version generation.
b. included in the institution export.
c. available to be used by the front end of the Comparison Tool

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs