### PR TITLE
CT Search for "Texas" doesn't return sufficient relevant results #16558

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -258,11 +258,12 @@ class Institution < ImportableRecord
     processed_search_term = processed[:search_term]
     excluded_only = processed[:excluded_only]
 
-    clause << if excluded_only
-                'institution % :institution_search_term'
-              else
-                'institution_search % :institution_search_term'
-              end
+    if excluded_only
+      clause <<  'institution % :institution_search_term'
+    else
+      clause <<  'institution_search % :institution_search_term'
+      clause <<  'institution_search LIKE UPPER(:institution_search_term)'
+    end
 
     clause << 'UPPER(city) = :upper_search_term'
     clause << 'UPPER(ialias) LIKE :upper_contains_term'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,7 @@ pg_trgm:
 
 search:
   weight_modifiers:
-    alias: 1.4
+    alias: 1.5
     gibill: .33
   common_word_list: 
     - "of"


### PR DESCRIPTION
## Description
When using `institution_search` includes a `institution_search LIKE UPPER(:institution_search_term)` and increased alias regexp weight for ordering

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16558

## Testing done
In CT search using the following terms:

- "college of charlesotn" for misspelling
- "college of charleston" for exact match
- "university of maryland" for starts with/contains
- "mit" for alias
- "bbc" for alias
- "texas" for a free text issue

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
