### PR TITLE
Update Dockerfile to use Bundler 2.2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--", "./docker-entrypoint.sh"]
 ###
 FROM development AS builder
 
-ENV BUNDLER_VERSION='2.1.4'
+ENV BUNDLER_VERSION='2.2.11'
 
 ARG bundler_opts
 COPY --chown=gi-bill-data-service:gi-bill-data-service . .


### PR DESCRIPTION
## Description
Updates Bundler in Dockerfile to 2.2.11

## Original issue(s)
https://dsva.slack.com/archives/CBU0KDSB1/p1614287169312000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
