### PR TITLE
Create spec to test that bundle versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -171,6 +171,7 @@ RSpec/DescribeClass:
     - "spec/config/initializers/group_types_spec.rb"
     - "spec/config/initializers/upload_types_spec.rb"
     - "spec/config/initializers/common_spec.rb"
+    - "spec/config/docker_spec.rb"
     - "spec/models/archiver_spec.rb"
     - "spec/utilities/caution_flags/caution_flag_template_spec.rb"
 

--- a/spec/config/docker_spec.rb
+++ b/spec/config/docker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+describe 'Docker' do
+  describe 'correct bundle version' do
+    let(:locked_bundle_version) do
+      Bundler::Definition.build('Gemfile', nil, {}).locked_bundler_version
+    end
+
+    it 'in Dockerfile' do
+      search_string = 'ENV BUNDLER_VERSION='
+      docker_bundler_lines = File.foreach(Rails.root.join('Dockerfile')).grep /^#{search_string}/
+
+      raise "#{search_string} not found in Dockerfile" unless docker_bundler_lines.any?
+
+      docker_bundler_version = docker_bundler_lines[0].scan(/\d+.\d*.\d*/)[0]
+      expect(docker_bundler_version).to eq(locked_bundle_version)
+    end
+
+    it 'installed' do
+      installed_bundle_version = Gem.loaded_specs["bundler"].version.version
+      expect(installed_bundle_version).to eq(locked_bundle_version)
+    end
+  end
+end

--- a/spec/config/docker_spec.rb
+++ b/spec/config/docker_spec.rb
@@ -10,7 +10,7 @@ describe 'Docker' do
 
     it 'in Dockerfile' do
       search_string = 'ENV BUNDLER_VERSION='
-      docker_bundler_lines = File.foreach(Rails.root.join('Dockerfile')).grep /^#{search_string}/
+      docker_bundler_lines = File.foreach(Rails.root.join('Dockerfile')).grep(/^#{search_string}/)
 
       raise "#{search_string} not found in Dockerfile" unless docker_bundler_lines.any?
 
@@ -19,7 +19,7 @@ describe 'Docker' do
     end
 
     it 'installed' do
-      installed_bundle_version = Gem.loaded_specs["bundler"].version.version
+      installed_bundle_version = Gem.loaded_specs['bundler'].version.version
       expect(installed_bundle_version).to eq(locked_bundle_version)
     end
   end


### PR DESCRIPTION
## Description
Creates a spec that tests that the installed version of bundler and the version in Dockerfile match the bundled with version in the Gemfile.lock

From https://dsva.slack.com/archives/CBU0KDSB1/p1614287169312000 creating a test to catch this issue

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
