### PR TITLE
GIBCT Inaccessible in local builds

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,8 @@ Rails.application.configure do
     auth_token: ENV['GOVDELIVERY_TOKEN'],
     api_root: "https://#{ENV['GOVDELIVERY_URL']}"
   }
+
+  # Specify environment specific hostname and protocol
+  config.hosts = Settings.virtual_hosts
+
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,5 +58,7 @@ search:
     - "&"
     - "-"
 
+virtual_hosts: ["127.0.0.1", "localhost", "10.0.2.2", "192.168.2.2", "host.docker.internal"] # Safe host names
+
 
 


### PR DESCRIPTION
## Description
> Add ActionDispatch::HostAuthorization middleware that guards against DNS rebinding attacks. [Pull Request](https://github.com/rails/rails/pull/33145)

from https://guides.rubyonrails.org/6_0_release_notes.html#notable-changes is what shows we needed to make this fix

## Original issue(s)
department-of-veterans-affairs/va.gov-team#21150

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
