### PR TITLE
Remove Activerecord session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rails', '~> 6.0.3.5'
 gem 'active_model_serializers', '~> 0.10.4'
 
 # Switch from cookie based storage to AR storage in case of failure pushing to GIBCT
-gem 'activerecord-session_store', '~> 1.0'
+gem 'activerecord-session_store', github: 'rails-lts/activerecord-session_store', branch: 'secure-session-store'
 
 gem 'bcrypt', '~> 3.1.7'
 # Use cancancan for authorization

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'rails', '~> 6.0.3.5'
 # JSON API
 gem 'active_model_serializers', '~> 0.10.4'
 
-# Switch from cookie based storage to AR storage in case of failure pushing to GIBCT
-gem 'activerecord-session_store', github: 'rails-lts/activerecord-session_store', branch: 'secure-session-store'
-
 gem 'bcrypt', '~> 3.1.7'
 # Use cancancan for authorization
 gem 'cancancan', '~> 1.13', '>= 1.13.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,18 @@ GIT
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
+GIT
+  remote: https://github.com/rails-lts/activerecord-session_store.git
+  revision: d091c7ea819350bbb9433d4dd065379832d593a3
+  branch: secure-session-store
+  specs:
+    activerecord-session_store (1.1.3)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -61,12 +73,6 @@ GEM
       activesupport (= 6.0.3.5)
     activerecord-import (1.0.5)
       activerecord (>= 3.2)
-    activerecord-session_store (1.1.3)
-      actionpack (>= 4.0)
-      activerecord (>= 4.0)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0)
     activestorage (6.0.3.5)
       actionpack (= 6.0.3.5)
       activejob (= 6.0.3.5)
@@ -438,7 +444,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.4)
   activerecord-import
-  activerecord-session_store (~> 1.0)
+  activerecord-session_store!
   bcrypt (~> 3.1.7)
   brakeman
   bundler-audit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,18 +7,6 @@ GIT
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
-GIT
-  remote: https://github.com/rails-lts/activerecord-session_store.git
-  revision: d091c7ea819350bbb9433d4dd065379832d593a3
-  branch: secure-session-store
-  specs:
-    activerecord-session_store (1.1.3)
-      actionpack (>= 5.2.4.1)
-      activerecord (>= 5.2.4.1)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 2.0.8, < 3)
-      railties (>= 5.2.4.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -444,7 +432,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.4)
   activerecord-import
-  activerecord-session_store!
   bcrypt (~> 3.1.7)
   brakeman
   bundler-audit

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,4 @@ Rails.application.configure do
     auth_token: ENV['GOVDELIVERY_TOKEN'],
     api_root: "https://#{ENV['GOVDELIVERY_URL']}"
   }
-
-  config.hosts.clear
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
     auth_token: ENV['GOVDELIVERY_TOKEN'],
     api_root: "https://#{ENV['GOVDELIVERY_URL']}"
   }
+
+  config.hosts.clear
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-# Rails.application.config.session_store :active_record_store, key: '_gibct-data-service_session'
 Rails.application.config.session_store :cookie_store, key: '_gibct-data-service_session'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :active_record_store, key: '_gibct-data-service_session'
+# Rails.application.config.session_store :active_record_store, key: '_gibct-data-service_session'
+Rails.application.config.session_store :cookie_store, key: '_gibct-data-service_session'


### PR DESCRIPTION
## Description
https://github.com/advisories/GHSA-cvw2-xj8r-mjf7

Removing https://github.com/rails/activerecord-session_store as [potential fix](https://github.com/rails/activerecord-session_store/pull/151) in that repo is taking a while to go out
And this is blocking https://github.com/department-of-veterans-affairs/gibct-data-service/pull/796
## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
- uploaded Weams.csv
- generated and published preview
- Spun up vets-api and vets-website
- http://localhost:3001/gi-bill-comparison-tool/
- searched for a school
- went to school's profile

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
