### PR TITLE
Removed support for gibctStateSearch feature flag

### DIFF
--- a/app/controllers/v0/institution_programs_controller.rb
+++ b/app/controllers/v0/institution_programs_controller.rb
@@ -49,11 +49,11 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      if @query[:state_search] && Institution.state_search_term?(@query[:name])
+      if Institution.state_search_term?(@query[:name])
         relation = InstitutionProgram.joins(institution: :version)
                                      .eager_load(:institution)
                                      .where(institutions: { version: @version, state: @query[:name].upcase })
-      elsif @query[:state_search] && Institution.city_state_search_term?(@query[:name])
+      elsif Institution.city_state_search_term?(@query[:name])
         terms = @query[:name].split(',').map(&:strip)
         relation = InstitutionProgram.joins(institution: :version)
                                      .eager_load(:institution)

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -35,7 +35,7 @@ module V0
       search_term = @query[:name]
 
       # Weighted sort is not needed when not using Institution scope search
-      if (Institution.state_search_term?(search_term) || Institution.city_state_search_term?(search_term))
+      if Institution.state_search_term?(search_term) || Institution.city_state_search_term?(search_term)
 
         render json: search_results.city_state_search_order(max_gibill)
                                    .page(params[:page]), meta: @meta

--- a/app/controllers/v0/institutions_controller.rb
+++ b/app/controllers/v0/institutions_controller.rb
@@ -35,8 +35,7 @@ module V0
       search_term = @query[:name]
 
       # Weighted sort is not needed when not using Institution scope search
-      if @query[:state_search] &&
-         (Institution.state_search_term?(search_term) || Institution.city_state_search_term?(search_term))
+      if (Institution.state_search_term?(search_term) || Institution.city_state_search_term?(search_term))
 
         render json: search_results.city_state_search_order(max_gibill)
                                    .page(params[:page]), meta: @meta
@@ -96,10 +95,10 @@ module V0
 
     def search_results
       @query ||= normalized_query_params
-      if @query[:state_search] && Institution.state_search_term?(@query[:name])
+      if Institution.state_search_term?(@query[:name])
         relation = Institution.non_vet_tec_institutions(@version)
                               .where(state: @query[:name].upcase)
-      elsif @query[:state_search] && Institution.city_state_search_term?(@query[:name])
+      elsif Institution.city_state_search_term?(@query[:name])
         terms = @query[:name].upcase.split(',').map(&:strip)
         relation = Institution.non_vet_tec_institutions(@version)
                               .where({ city: terms[0].upcase, state: terms[1].upcase })

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -359,9 +359,6 @@ class Institution < ImportableRecord
       'institution'
     ]
 
-    # not included in weighted_sort as weight value would have to be at least 4.0 to affect order
-    order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC')
-
     alias_modifier = Settings.search.weight_modifiers.alias
     gibill_modifier = Settings.search.weight_modifiers.gibill
     institution_search_term = "%#{processed_search_term}%"

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -278,7 +278,6 @@ class Institution < ImportableRecord
 
     search_term = query[:name]
     include_address = query[:include_address] || false
-    state_search = query[:state_search] || false
 
     clause = ['facility_code = :upper_search_term']
 
@@ -296,7 +295,7 @@ class Institution < ImportableRecord
     clause << 'UPPER(city) = :upper_search_term'
     clause << 'UPPER(ialias) LIKE :upper_contains_term'
     clause << 'zip = :search_term'
-    clause << 'country LIKE :upper_contains_term' if state_search
+    clause << 'country LIKE :upper_contains_term'
 
     if include_address
       3.times do |i|
@@ -336,7 +335,6 @@ class Institution < ImportableRecord
     return order('institution') if query.blank? || query[:name].blank?
 
     search_term = query[:name]
-    state_search = query[:state_search] || false
 
     weighted_sort = ['CASE WHEN UPPER(ialias) = :upper_search_term THEN 1 ELSE 0 END',
                      "CASE WHEN REGEXP_MATCH(ialias, :regexp_exists_as_word, 'i') IS NOT NULL " \
@@ -356,7 +354,7 @@ class Institution < ImportableRecord
     order_by = ["#{weighted_sort.join(' + ')} DESC NULLS LAST", 'institution']
 
     # not included in weighted_sort as weight value would have to be at least 4.0 to affect order
-    order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC') if state_search
+    order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC')
 
     alias_modifier = Settings.search.weight_modifiers.alias
     gibill_modifier = Settings.search.weight_modifiers.gibill

--- a/app/models/institution_program.rb
+++ b/app/models/institution_program.rb
@@ -68,7 +68,7 @@ class InstitutionProgram < ApplicationRecord
     if query.present?
       search_term = query[:name]
 
-      order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC') if state_search
+      order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC')
 
       conditions = [order_by.join(','), upper_contains_term: "%#{search_term.upcase}%"]
     end

--- a/app/models/institution_program.rb
+++ b/app/models/institution_program.rb
@@ -39,17 +39,15 @@ class InstitutionProgram < ApplicationRecord
     return if query.blank? || query[:name].blank?
 
     search_term = query[:name]
-    state_search = query[:state_search]
 
     clause = [
       'institution_programs.facility_code = (:upper_search_term)',
       'lower(description) LIKE (:lower_contains_term)',
       'institution % :contains_search_term',
       'UPPER(physical_city) = :upper_search_term',
-      'institutions.physical_zip = :search_term'
+      'institutions.physical_zip = :search_term',
+      'country LIKE :upper_contains_term'
     ]
-
-    clause << 'country LIKE :upper_contains_term' if state_search
 
     where(
       sanitize_sql_for_conditions(
@@ -68,14 +66,11 @@ class InstitutionProgram < ApplicationRecord
     conditions = [order_by.join(',')]
 
     if query.present?
-      state_search = query[:state_search]
       search_term = query[:name]
 
-      if search_term.present?
-        order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC') if state_search
+      order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC') if state_search
 
-        conditions = [order_by.join(','), upper_contains_term: "%#{search_term.upcase}%"]
-      end
+      conditions = [order_by.join(','), upper_contains_term: "%#{search_term.upcase}%"]
     end
 
     sanitized_order_by = sanitize_sql_for_conditions(conditions)

--- a/app/models/institution_program.rb
+++ b/app/models/institution_program.rb
@@ -65,7 +65,7 @@ class InstitutionProgram < ApplicationRecord
     order_by = ['institutions.preferred_provider DESC NULLS LAST', 'institutions.institution']
     conditions = [order_by.join(',')]
 
-    if query.present?
+    if query.present? && !query[:name].nil?
       search_term = query[:name]
 
       order_by.unshift('CASE WHEN UPPER(country) LIKE :upper_contains_term THEN 1 ELSE 0 END DESC')

--- a/spec/controllers/v0/institution_programs_controller_spec.rb
+++ b/spec/controllers/v0/institution_programs_controller_spec.rb
@@ -290,12 +290,5 @@ RSpec.describe V0::InstitutionProgramsController, type: :controller do
       get(:index, params: { name: 'testville, ak' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
-
-    it 'search returns results with flag enabled for institution names' do
-      create(:institution, physical_city: 'VERY LONG CITY NAME', version_id: Version.current_production.id)
-      create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'VERY LONG CITY NAME' })
-      expect(JSON.parse(response.body)['data'].count).to eq(1)
-    end
   end
 end

--- a/spec/controllers/v0/institution_programs_controller_spec.rb
+++ b/spec/controllers/v0/institution_programs_controller_spec.rb
@@ -266,35 +266,35 @@ RSpec.describe V0::InstitutionProgramsController, type: :controller do
     it 'search returns results with a valid state abbreviation uppercased search term' do
       create(:institution, state: 'AK', version_id: Version.current_production.id)
       create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'AK', state_search: true })
+      get(:index, params: { name: 'AK' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
 
     it 'search returns results with a valid state abbreviation lowercase search term' do
       create(:institution, state: 'AK', version_id: Version.current_production.id)
       create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'ak', state_search: true })
+      get(:index, params: { name: 'ak' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
 
     it 'search returns results with a valid city, state uppercased search term' do
       create(:institution, city: 'TESTVILLE', state: 'AK', version_id: Version.current_production.id)
       create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'TESTVILLE, AK', state_search: true })
+      get(:index, params: { name: 'TESTVILLE, AK' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
 
     it 'search returns results with a valid city, state lowercased search term' do
       create(:institution, city: 'TESTVILLE', state: 'AK', version_id: Version.current_production.id)
       create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'testville, ak', state_search: true })
+      get(:index, params: { name: 'testville, ak' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
 
     it 'search returns results with flag enabled for institution names' do
       create(:institution, physical_city: 'VERY LONG CITY NAME', version_id: Version.current_production.id)
       create(:institution_program, description: 'TEST', institution_id: Institution.last.id)
-      get(:index, params: { name: 'VERY LONG CITY NAME', state_search: true })
+      get(:index, params: { name: 'VERY LONG CITY NAME' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
     end
   end

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -490,7 +490,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'search returns results with a valid state abbreviation uppercased search term' do
       create(:institution,  state: 'AK', version_id: Version.current_production.id)
-      get(:index, params: { name: 'AK', state_search: true })
+      get(:index, params: { name: 'AK' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -498,7 +498,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'search returns results with a valid state abbreviation lowercased search term' do
       create(:institution,  state: 'AK', version_id: Version.current_production.id)
-      get(:index, params: { name: 'ak', state_search: true })
+      get(:index, params: { name: 'ak' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -506,7 +506,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'search returns results with a valid city, state abbreviation uppercased search term' do
       create(:institution, city: 'TESTVILLE', state: 'AK', version_id: Version.current_production.id)
-      get(:index, params: { name: 'TESTVILLE, AK', state_search: true })
+      get(:index, params: { name: 'TESTVILLE, AK' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -514,14 +514,14 @@ RSpec.describe V0::InstitutionsController, type: :controller do
 
     it 'search returns results with a valid city, state abbreviation lowercased search term' do
       create(:institution, city: 'TESTVILLE', state: 'AK', version_id: Version.current_production.id)
-      get(:index, params: { name: 'testville, ak', state_search: true })
+      get(:index, params: { name: 'testville, ak' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end
 
     it 'search returns results with flag enabled for institution names' do
-      get(:index, params: { name: 'chicago', state_search: true })
+      get(:index, params: { name: 'chicago' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -536,7 +536,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
 
     it 'filters by employer category' do
-      get(:index, params: { category: 'employer', name: 'in' })
+      get(:index, params: { category: 'employer', name: 'acme' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
@@ -550,7 +550,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
     end
 
     it 'filters by employer type' do
-      get(:index, params: { type: 'ojt', name: 'in' })
+      get(:index, params: { type: 'ojt', name: 'acme' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -519,13 +519,6 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institutions')
     end
-
-    it 'search returns results with flag enabled for institution names' do
-      get(:index, params: { name: 'chicago' })
-      expect(JSON.parse(response.body)['data'].count).to eq(1)
-      expect(response.content_type).to eq('application/json')
-      expect(response).to match_response_schema('institutions')
-    end
   end
 
   context 'with category and type search results' do


### PR DESCRIPTION
## Description
Removed `state_search` param so the new state search functionality is no longer behind a feature flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18214

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] state search functionality is not behind a feature flag

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
