### PR TITLE
AccreditationAction import update

### DIFF
--- a/app/models/accreditation_action.rb
+++ b/app/models/accreditation_action.rb
@@ -12,10 +12,10 @@ class AccreditationAction < ImportableRecord
     'programname' => { column: :program_name, converter: BaseConverter },
     'sequentialid' => { column: :sequential_id, converter: NumberConverter },
     'actiondescription' => { column: :action_description, converter: BaseConverter },
-    'actiondate' => { column: :action_date, converter: DateConverter },
+    'actiondate' => { column: :action_date, converter: BaseConverter },
     'justificationdescription' => { column: :justification_description, converter: BaseConverter },
     'justificationother' => { column: :justification_other, converter: BaseConverter },
-    'enddate' => { column: :end_date, converter: DateConverter }
+    'enddate' => { column: :end_date, converter: BaseConverter }
   }.freeze
 
   PROBATIONARY_STATUSES = [


### PR DESCRIPTION
## Description
Update the converter for a `accreditation_import` column because the DateConverter expects M/D/Y and the accreditation data is exported from a system as Y/M/D.  Importing it as a string is fine, because the datatype of the column is `Date`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24378

## Testing done
Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] `action_date` column is imported correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
