### PR TITLE
Exclude bad lat/long values from going into Institutions table

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -38,10 +38,10 @@ module InstitutionBuilder
       add_post_911_stats(version.id)
       add_mou(version.id)
       ScorecardBuilder.build(version.id)
-      add_ipeds_ic(version.id)
-      add_ipeds_hd(version.id)
-      add_ipeds_ic_ay(version.id)
-      add_ipeds_ic_py(version.id)
+      IpedsBuilder.build_ic(version.id)
+      IpedsBuilder.build_hd(version.id)
+      IpedsBuilder.build_ic_ay(version.id)
+      IpedsBuilder.build_ic_py(version.id)
       add_sec_702(version.id)
       add_settlement(version.id)
       add_hcm(version.id)
@@ -307,48 +307,6 @@ module InstitutionBuilder
       SQL
 
       CautionFlag.build(version_id, MouCautionFlag, caution_flag_clause)
-    end
-
-    def self.add_ipeds_ic(version_id)
-      str = <<-SQL
-        institutions.cross = ipeds_ics.cross
-      SQL
-
-      add_columns_for_update(version_id, IpedsIc, str)
-    end
-
-    def self.add_ipeds_hd(version_id)
-      str = <<-SQL
-        UPDATE institutions SET #{columns_for_update(IpedsHd)}, longitude = ipeds_hds.longitud
-        FROM ipeds_hds
-        WHERE institutions.cross = ipeds_hds.cross
-        AND institutions.version_id = #{version_id}
-      SQL
-
-      Institution.connection.update(str)
-    end
-
-    def self.add_ipeds_ic_ay(version_id)
-      str = <<-SQL
-        institutions.cross = ipeds_ic_ays.cross
-      SQL
-
-      add_columns_for_update(version_id, IpedsIcAy, str)
-    end
-
-    def self.add_ipeds_ic_py(version_id)
-      columns = IpedsIcPy::COLS_USED_IN_INSTITUTION.map(&:to_s).map do |col|
-        %("#{col}" = CASE WHEN institutions.#{col} IS NULL THEN ipeds_ic_pies.#{col} ELSE institutions.#{col} END)
-      end.join(', ')
-
-      str = <<-SQL
-        UPDATE institutions SET #{columns}
-        FROM ipeds_ic_pies
-        WHERE institutions.cross = ipeds_ic_pies.cross
-        AND institutions.version_id = #{version_id}
-      SQL
-
-      Institution.connection.update(str)
     end
 
     # Updates institution table as well as creates caution_flags

--- a/app/utilities/institution_builder/ipeds_builder.rb
+++ b/app/utilities/institution_builder/ipeds_builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module InstitutionBuilder
+  class IpedsBuilder
+    extend Common
+
+    def self.build_ic(version_id)
+      str = <<-SQL
+        institutions.cross = ipeds_ics.cross
+      SQL
+
+      add_columns_for_update(version_id, IpedsIc, str)
+    end
+
+    def self.build_hd(version_id)
+      str = <<-SQL
+        UPDATE institutions SET #{columns_for_update(IpedsHd)}, longitude = ipeds_hds.longitud
+        FROM ipeds_hds
+        WHERE institutions.cross = ipeds_hds.cross
+        AND ipeds_hds.latitude BETWEEN -90 AND 90
+        AND ipeds_hds.longitud BETWEEN -180 AND 180
+        AND institutions.version_id = #{version_id}
+      SQL
+
+      Institution.connection.update(str)
+    end
+
+    def self.build_ic_ay(version_id)
+      str = <<-SQL
+        institutions.cross = ipeds_ic_ays.cross
+      SQL
+
+      add_columns_for_update(version_id, IpedsIcAy, str)
+    end
+
+    def self.build_ic_py(version_id)
+      columns = IpedsIcPy::COLS_USED_IN_INSTITUTION.map(&:to_s).map do |col|
+        %("#{col}" = CASE WHEN institutions.#{col} IS NULL THEN ipeds_ic_pies.#{col} ELSE institutions.#{col} END)
+      end.join(', ')
+
+      str = <<-SQL
+        UPDATE institutions SET #{columns}
+        FROM ipeds_ic_pies
+        WHERE institutions.cross = ipeds_ic_pies.cross
+        AND institutions.version_id = #{version_id}
+      SQL
+
+      Institution.connection.update(str)
+    end
+  end
+end

--- a/app/utilities/institution_builder/scorecard_builder.rb
+++ b/app/utilities/institution_builder/scorecard_builder.rb
@@ -22,6 +22,8 @@ module InstitutionBuilder
       WHERE institutions.cross = scorecards.cross
       AND institutions.version_id = #{version_id}
       AND institutions.latitude is NULL
+      AND scorecards.latitude BETWEEN -90 AND 90
+      AND scorecards.longitude BETWEEN -180 AND 180
       SQL
 
       Institution.connection.update(str)

--- a/spec/factories/ipeds_hds.rb
+++ b/spec/factories/ipeds_hds.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     f1sysnam { 'example school' }
     f1syscod { 123 }
     ialias { 'exsc' }
+    latitude { 0.0 }
+    longitud { 0.0 }
 
     trait :institution_builder do
       cross { '999999' }


### PR DESCRIPTION
## Description
Latitude and longitude values from ipeds_hd and scorecard are occasionally outside valid ranges for latitude and longitude.
This prevents those values from going into the institutions table.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24261

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
