### PR TITLE
Add weams in_state_tuition_information (1 of 3)

### DIFF
--- a/db/migrate/20210716084900_add_in_state_tuition_information_to_weams.rb
+++ b/db/migrate/20210716084900_add_in_state_tuition_information_to_weams.rb
@@ -1,0 +1,5 @@
+class AddInStateTuitionInformationToWeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :weams, :in_state_tuition_information, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_151300) do
+ActiveRecord::Schema.define(version: 2021_07_16_084900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
@@ -1692,6 +1692,7 @@ ActiveRecord::Schema.define(version: 2021_07_07_151300) do
     t.string "parent_facility_code_id"
     t.integer "csv_row"
     t.string "institution_search"
+    t.string "in_state_tuition_information"
     t.index ["cross"], name: "index_weams_on_cross"
     t.index ["facility_code"], name: "index_weams_on_facility_code"
     t.index ["institution"], name: "index_weams_on_institution"


### PR DESCRIPTION
## Description
Add `in_state_tuition_information` column to `weams` table.

Related PRs:
- (2/3) https://github.com/department-of-veterans-affairs/gibct-data-service/pull/844
- (3/3) https://github.com/department-of-veterans-affairs/gibct-data-service/pull/846

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27306

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] `weams.in_state_tuition_information` exists.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
