### PR TITLE
Added susp schools and caution flag

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -46,6 +46,7 @@ module InstitutionBuilder
       add_sec_702(version.id)
       add_settlement(version.id)
       add_hcm(version.id)
+      add_poo_status_caution_flag(version.id)
       add_complaint(version.id)
       add_outcome(version.id)
       add_stem_offered(version.id)
@@ -520,6 +521,27 @@ module InstitutionBuilder
       SQL
 
       CautionFlag.build(version_id, HcmCautionFlag, caution_flag_clause)
+    end
+
+    def self.add_poo_status_caution_flag(version_id)
+
+      str = <<-SQL
+      UPDATE institutions SET
+        caution_flag = TRUE,
+        caution_flag_reason = 'caution_flag_reason'
+      WHERE institutions.poo_status = 'SUSP'
+      AND institutions.version_id = #{version_id}
+    SQL
+        
+      Institution.connection.update(str)
+      
+      caution_flag_clause = <<-SQL
+      FROM institutions
+      WHERE institutions.poo_status = 'SUSP'
+      AND institutions.version_id = #{version_id}
+    SQL
+
+      CautionFlag.build(version_id, PooStatusFlag, caution_flag_clause)
     end
 
     def self.add_complaint(version_id)

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -46,7 +46,6 @@ module InstitutionBuilder
       add_sec_702(version.id)
       add_settlement(version.id)
       add_hcm(version.id)
-      add_poo_status_caution_flag(version.id)
       add_complaint(version.id)
       add_outcome(version.id)
       add_stem_offered(version.id)
@@ -59,6 +58,7 @@ module InstitutionBuilder
       build_institution_programs(version.id)
       build_versioned_school_certifying_official(version.id)
       ScorecardBuilder.add_lat_lon_from_scorecard(version.id)
+      SuspendedCautionFlags.build(version.id)
       add_provider_type(version.id)
       VrrapBuilder.build(version.id)
       build_messages[CensusLatLong.name] = LatLongBuilder.build(version.id)
@@ -521,26 +521,6 @@ module InstitutionBuilder
       SQL
 
       CautionFlag.build(version_id, HcmCautionFlag, caution_flag_clause)
-    end
-
-    def self.add_poo_status_caution_flag(version_id)
-      str = <<-SQL
-      UPDATE institutions SET
-        caution_flag = TRUE,
-        caution_flag_reason = 'caution_flag_reason'
-      WHERE institutions.poo_status = 'SUSP'
-      AND institutions.version_id = #{version_id}
-      SQL
-
-      Institution.connection.update(str)
-
-      caution_flag_clause = <<-SQL
-      FROM institutions
-      WHERE institutions.poo_status = 'SUSP'
-      AND institutions.version_id = #{version_id}
-      SQL
-
-      CautionFlag.build(version_id, PooStatusFlag, caution_flag_clause)
     end
 
     def self.add_complaint(version_id)

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -524,22 +524,21 @@ module InstitutionBuilder
     end
 
     def self.add_poo_status_caution_flag(version_id)
-
       str = <<-SQL
       UPDATE institutions SET
         caution_flag = TRUE,
         caution_flag_reason = 'caution_flag_reason'
       WHERE institutions.poo_status = 'SUSP'
       AND institutions.version_id = #{version_id}
-    SQL
-        
+      SQL
+
       Institution.connection.update(str)
-      
+
       caution_flag_clause = <<-SQL
       FROM institutions
       WHERE institutions.poo_status = 'SUSP'
       AND institutions.version_id = #{version_id}
-    SQL
+      SQL
 
       CautionFlag.build(version_id, PooStatusFlag, caution_flag_clause)
     end

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -294,7 +294,7 @@ class Weam < ImportableRecord
   private
 
   def poo_status_valid?
-    !poo_status.nil? && poo_status.match?(/aprvd/i)
+    !poo_status.nil? && poo_status.match?(/aprvd|susp/i)
   end
 
   def invalid_law_code?

--- a/app/utilities/caution_flag_templates/poo_status_flag.rb
+++ b/app/utilities/caution_flag_templates/poo_status_flag.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'caution_flag_template'
+
+class PooStatusFlag < CautionFlagTemplate
+  NAME = 'Poo_Status_Susp'
+  TITLE = 'School may not be able to accept new GI Bill students'
+  DESCRIPTION = 'This school currently doesn\'\'t meet the approval criteria for receiving GI Bill funds and has been suspended. The suspension doesn\'\'t impact current students.'
+  LINK_TEXT = nil
+  LINK_URL = nil
+end

--- a/app/utilities/caution_flag_templates/poo_status_flag.rb
+++ b/app/utilities/caution_flag_templates/poo_status_flag.rb
@@ -5,7 +5,8 @@ require_relative 'caution_flag_template'
 class PooStatusFlag < CautionFlagTemplate
   NAME = 'Poo_Status_Susp'
   TITLE = 'School may not be able to accept new GI Bill students'
-  DESCRIPTION = 'This school currently doesn\'\'t meet the approval criteria for receiving GI Bill funds and has been suspended. The suspension doesn\'\'t impact current students.'
+  DESCRIPTION = 'This school currently doesn\'\'t meet the approval criteria for receiving GI Bill funds and has been '\
+  'suspended. The suspension doesn\'\'t impact current students.'
   LINK_TEXT = nil
   LINK_URL = nil
 end

--- a/app/utilities/caution_flag_templates/sec702_caution_flag.rb
+++ b/app/utilities/caution_flag_templates/sec702_caution_flag.rb
@@ -5,9 +5,9 @@ require_relative 'caution_flag_template'
 class Sec702CautionFlag < CautionFlagTemplate
   NAME = 'Sec702'
   TITLE = 'School isn\'\'t approved for Post-9/11 GI Bill or Montgomery GI Bill-Active Duty benefits'
-  DESCRIPTION = 'This school isn\'\'t approved for Post-9/11 GI Bill or Montgomery GI Bill-Active Duty'\
-                'benefits because it doesn\'\'t comply with Section 702. This law requires public universities'\
-                'to offer recent Veterans and other covered individuals in-state tuition, regardless of their'\
+  DESCRIPTION = 'This school isn\'\'t approved for Post-9/11 GI Bill or Montgomery GI Bill-Active Duty '\
+                'benefits because it doesn\'\'t comply with Section 702. This law requires public universities '\
+                'to offer recent Veterans and other covered individuals in-state tuition, regardless of their '\
                 'state residency.'
   LINK_TEXT = 'Learn more about Section 702 requirements'
   LINK_URL = 'https://www.benefits.va.gov/gibill/docs/factsheets/section_702_factsheet.pdf'

--- a/app/utilities/institution_builder/suspended_caution_flags.rb
+++ b/app/utilities/institution_builder/suspended_caution_flags.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module InstitutionBuilder
+  class SuspendedCautionFlags
+    extend Common
+
+    def self.build(version_id)
+      str = <<-SQL
+        UPDATE institutions SET
+          caution_flag = TRUE,
+          caution_flag_reason = 'caution_flag_reason'
+        WHERE institutions.poo_status = 'SUSP'
+        AND institutions.version_id = #{version_id}
+      SQL
+
+      Institution.connection.update(str)
+
+      caution_flag_clause = <<-SQL
+        FROM institutions
+        WHERE institutions.poo_status = 'SUSP'
+        AND institutions.version_id = #{version_id}
+      SQL
+
+      CautionFlag.build(version_id, PooStatusFlag, caution_flag_clause)
+    end
+  end
+end


### PR DESCRIPTION
## Description
As an education team member, I need institutions that are suspended to be displayed within the comparison tool, because they have 60 days to address any issues before being changed to a withdrawn status and removed from the comparison tool.

Caution flag bug:
Institutions that are not approved for Post-9/11 GI Bill or Montgomery GI Bill-Active Duty benefits receive a caution flag in the Comparison Tool. On the institution profile page, a user can see a more detailed description of the warning. Currently, there are spaces missing from the description

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/27210

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/28191

## Testing done


## Screenshots
<img width="769" alt="Screen Shot 2021-08-04 at 1 32 09 PM" src="https://user-images.githubusercontent.com/50601724/128230523-25f484bb-1bb0-417d-add4-7562d0ce6583.png">
<img width="572" alt="Screen Shot 2021-08-04 at 12 32 58 PM" src="https://user-images.githubusercontent.com/50601724/128230532-be0ab139-d902-4d5e-9092-34e720ded6cb.png">
<img width="572" alt="Screen Shot 2021-08-04 at 12 32 54 PM" src="https://user-images.githubusercontent.com/50601724/128230539-8c428245-83a6-4d78-98f5-c3b9ee2b3376.png">
<img width="572" alt="Screen Shot 2021-08-04 at 12 31 29 PM" src="https://user-images.githubusercontent.com/50601724/128230545-6dce4326-bf48-4e3a-a8ec-4fe87bf3a713.png">
<img width="870" alt="Screen Shot 2021-08-04 at 12 30 55 PM" src="https://user-images.githubusercontent.com/50601724/128230587-7a345d11-ebbd-4df6-937c-67e38da3e749.png">
<img width="870" alt="Screen Shot 2021-08-04 at 12 30 15 PM" src="https://user-images.githubusercontent.com/50601724/128230614-c8fc0658-09cb-43c9-b829-14f28fe393d0.png">
<img width="870" alt="Screen Shot 2021-08-04 at 12 29 34 PM" src="https://user-images.githubusercontent.com/50601724/128230641-16613242-2714-458a-ac32-0adde6520766.png">


## Acceptance criteria
- [x] Institutions with a WEAMS poo status of "SUSP" are included in GIDS version generation.

- [x] Institutions with a status of "SUSP" are assigned a caution flag.

- [x] Suspended institutions are displayed within the Comparison Tool with the suspended caution flag text:

Title: School may not be able to accept new GI Bill students

Description: This school currently doesn't meet the approval criteria for receiving GI Bill funds and has been suspended. The suspension doesn't impact current students.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
