### PR TITLE
Removed all non APRVD and SUSP schools from school locations section

### DIFF
--- a/app/models/institution_tree.rb
+++ b/app/models/institution_tree.rb
@@ -66,7 +66,7 @@ module InstitutionTree
             SELECT i.facility_code
             FROM institutions i
             INNER JOIN related_down r ON i.parent_facility_code_id = r.facility_code
-            WHERE i.version_id = ? AND i.poo_status = 'APRVD' OR i.poo_status = 'SUSP'
+            WHERE i.version_id = ? AND i.poo_status IN ('APRVD', 'SUSP')
         ) SELECT facility_code FROM related_down WHERE facility_code != ?
       SQL
 

--- a/app/models/institution_tree.rb
+++ b/app/models/institution_tree.rb
@@ -66,7 +66,7 @@ module InstitutionTree
             SELECT i.facility_code
             FROM institutions i
             INNER JOIN related_down r ON i.parent_facility_code_id = r.facility_code
-            WHERE i.version_id = ?
+            WHERE i.version_id = ? AND i.poo_status = 'APRVD' OR i.poo_status = 'SUSP'
         ) SELECT facility_code FROM related_down WHERE facility_code != ?
       SQL
 

--- a/spec/models/institution_tree_spec.rb
+++ b/spec/models/institution_tree_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe InstitutionTree, type: :model do
   describe 'institution tree' do
     before do
       create :version, :production
-      create(:institution, facility_code: '100', campus_type: 'Y', poo_status: 'SUSP',  version_id: Version.current_production.id)
+      create(:institution, facility_code: '100', campus_type: 'Y', poo_status: 'APRVD',  version_id: Version.current_production.id)
       create(:institution, facility_code: '101', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id: Version.current_production.id)
-      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'APRVD',  version_id:  Version.current_production.id)
       create(:institution, facility_code: '103', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
       create(:institution, facility_code: '105', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
       create(:institution, facility_code: '107', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
       create(:institution, facility_code: '109', version_id: Version.current_production.id)
       create :version, :production
       create(:institution, facility_code: '110', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'SUSP', version_id: Version.current_production.id)

--- a/spec/models/institution_tree_spec.rb
+++ b/spec/models/institution_tree_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe InstitutionTree, type: :model do
   describe 'institution tree' do
     before do
       create :version, :production
-      create(:institution, facility_code: '100', campus_type: 'Y', poo_status: 'APRVD',  version_id: Version.current_production.id)
-      create(:institution, facility_code: '101', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id: Version.current_production.id)
-      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'APRVD',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '103', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '105', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '107', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
-      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'APRVD',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '100', campus_type: 'Y', poo_status: 'APRVD', version_id: Version.current_production.id)
+      create(:institution, facility_code: '101', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP', version_id: Version.current_production.id)
+      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'APRVD', version_id: Version.current_production.id)
+      create(:institution, facility_code: '103', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP', version_id: Version.current_production.id)
+      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', poo_status: 'APRVD', version_id: Version.current_production.id)
+      create(:institution, facility_code: '105', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP', version_id: Version.current_production.id)
+      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'APRVD', version_id: Version.current_production.id)
+      create(:institution, facility_code: '107', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP', version_id: Version.current_production.id)
+      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'APRVD', version_id: Version.current_production.id)
       create(:institution, facility_code: '109', version_id: Version.current_production.id)
       create :version, :production
       create(:institution, facility_code: '110', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'SUSP', version_id: Version.current_production.id)

--- a/spec/models/institution_tree_spec.rb
+++ b/spec/models/institution_tree_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe InstitutionTree, type: :model do
   describe 'institution tree' do
     before do
       create :version, :production
-      create(:institution, facility_code: '100', campus_type: 'Y', version_id: Version.current_production.id)
-      create(:institution, facility_code: '101', parent_facility_code_id: '100', campus_type: 'N', version_id: Version.current_production.id)
-      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '103', parent_facility_code_id: '100', campus_type: 'N', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '105', parent_facility_code_id: '103', campus_type: 'E', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '107', parent_facility_code_id: '103', campus_type: 'E', version_id:  Version.current_production.id)
-      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', version_id:  Version.current_production.id)
+      create(:institution, facility_code: '100', campus_type: 'Y', poo_status: 'SUSP',  version_id: Version.current_production.id)
+      create(:institution, facility_code: '101', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id: Version.current_production.id)
+      create(:institution, facility_code: '102', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '103', parent_facility_code_id: '100', campus_type: 'N', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '104', parent_facility_code_id: '102', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '105', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '106', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '107', parent_facility_code_id: '103', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
+      create(:institution, facility_code: '108', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'SUSP',  version_id:  Version.current_production.id)
       create(:institution, facility_code: '109', version_id: Version.current_production.id)
       create :version, :production
-      create(:institution, facility_code: '110', parent_facility_code_id: '100', campus_type: 'E', version_id: Version.current_production.id)
+      create(:institution, facility_code: '110', parent_facility_code_id: '100', campus_type: 'E', poo_status: 'SUSP', version_id: Version.current_production.id)
     end
 
     context 'when built' do


### PR DESCRIPTION
## Description
As a developer, I need to remove the display of non-approved institutions from the "School locations" section of the profile pages so that institutions that are not approved for display are not shown in the comparison tool.
## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/27657
## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] Only institutions with the following WEAMS poo status are displayed in the "School locations" section of the profile page:
a. APRVD
b. SUSP

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
