### PR TITLE
Add fields to institution compare serializer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,7 @@ Metrics/ClassLength:
     - "app/controllers/v0/institution_programs_controller.rb"
     - "app/models/institution_builder.rb"
     - "app/controllers/v1/institutions_controller.rb"
+    - "app/serializers/institution_compare_serializer.rb"
 
 Metrics/AbcSize:
   Max: 40

--- a/app/serializers/institution_compare_serializer.rb
+++ b/app/serializers/institution_compare_serializer.rb
@@ -88,6 +88,8 @@ class InstitutionCompareSerializer < ActiveModel::Serializer
   attribute :pctfloan
   attribute :institution_category_ratings
   attribute :school_provider
+  attribute :vet_tec_provider
+  attribute :employer_provider
 
   def yellow_ribbon_programs
     object.yellow_ribbon_programs.map do |yrp|

--- a/app/serializers/institution_compare_serializer.rb
+++ b/app/serializers/institution_compare_serializer.rb
@@ -87,6 +87,7 @@ class InstitutionCompareSerializer < ActiveModel::Serializer
   attribute :hcm2
   attribute :pctfloan
   attribute :institution_category_ratings
+  attribute :school_provider
 
   def yellow_ribbon_programs
     object.yellow_ribbon_programs.map do |yrp|

--- a/spec/support/api/schemas/institution_compare_results.json
+++ b/spec/support/api/schemas/institution_compare_results.json
@@ -443,6 +443,15 @@
               },
               "vrrap": {
                 "type": ["null", "boolean"]
+              },
+              "school_provider": {
+                "type": ["null", "string"]
+              },
+              "vet_tec_provider": {
+                "type": ["null", "string"]
+              },
+              "employer_provider": {
+                "type": ["null", "string"]
               }
             },
             "required": [

--- a/spec/support/api/schemas/institution_compare_results.json
+++ b/spec/support/api/schemas/institution_compare_results.json
@@ -445,13 +445,13 @@
                 "type": ["null", "boolean"]
               },
               "school_provider": {
-                "type": ["null", "string"]
+                "type": ["null", "boolean"]
               },
               "vet_tec_provider": {
-                "type": ["null", "string"]
+                "type": ["null", "boolean"]
               },
               "employer_provider": {
-                "type": ["null", "string"]
+                "type": ["null", "boolean"]
               }
             },
             "required": [


### PR DESCRIPTION
## Description
Add fields to `institution_compare_serializer.rb`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28124
department-of-veterans-affairs/va.gov-team#27797

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
(please see linked ZenHub Issues)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
