### PR TITLE
Va gidct sandbox 31279

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem 'active_model_serializers', '~> 0.10.4'
 gem 'bcrypt', '~> 3.1.7'
 # Use cancancan for authorization
 gem 'cancancan', '~> 1.13', '>= 1.13.1'
-gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'geocoder', '~> 1.3', '>= 1.3.7'
+gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'json', '>= 2.3.0'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 0.15'

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'bcrypt', '~> 3.1.7'
 # Use cancancan for authorization
 gem 'cancancan', '~> 1.13', '>= 1.13.1'
 gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
+gem 'geocoder', '~> 1.3', '>= 1.3.7'
 gem 'json', '>= 2.3.0'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 0.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     formatador (0.2.5)
+    geocoder (1.7.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
     govdelivery-tms (2.8.4)
@@ -452,6 +453,7 @@ DEPENDENCIES
   faraday_middleware
   figaro
   font-awesome-rails
+  geocoder (~> 1.3, >= 1.3.7)
   govdelivery-tms (= 2.8.4)
   guard-rspec
   jquery-rails

--- a/app/controllers/v1/institutions_controller.rb
+++ b/app/controllers/v1/institutions_controller.rb
@@ -51,15 +51,13 @@ module V1
       location_results = Institution.approved_institutions(@version).location_search(@query).filter_result_v1(@query)
       results = location_results.location_select(@query).location_order
 
-      ##found a few cases where lat and longitude is wrong, added this step
+      # #found a few cases where lat and longitude is wrong, added this step
       ## using geocoder to check returned coordinates and filter out bad cases
       checked_results = []
-      
-      results.each do |result| 
-        check_result = result.check_coord_mismatch(@query)
-        if check_result.present?
-          checked_results << check_result
-        end
+
+      results.each do |result|
+        check_result = result.coordinates_mismatch(@query)
+        checked_results << check_result if check_result.present?
       end
 
       @meta = {

--- a/app/controllers/v1/institutions_controller.rb
+++ b/app/controllers/v1/institutions_controller.rb
@@ -51,13 +51,24 @@ module V1
       location_results = Institution.approved_institutions(@version).location_search(@query).filter_result_v1(@query)
       results = location_results.location_select(@query).location_order
 
+      ##found a few cases where lat and longitude is wrong, added this step
+      ## using geocoder to check returned coordinates and filter out bad cases
+      checked_results = []
+      
+      results.each do |result| 
+        check_result = result.check_coord_mismatch(@query)
+        if check_result.present?
+          checked_results << check_result
+        end
+      end
+
       @meta = {
         version: @version,
         count: location_results.count,
         facets: facets(location_results)
       }
 
-      render json: results,
+      render json: checked_results,
              each_serializer: InstitutionSearchResultSerializer,
              meta: @meta
     end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -295,6 +295,34 @@ class Institution < ImportableRecord
     escaped_term
   end
 
+  def check_coord_mismatch(query)
+    geocoded_coord = Geocoder.coordinates("#{self.address}, #{self.city}, #{self.state}")
+    if geocoded_coord.present?
+      geocoded_lat = geocoded_coord[0].round(2)
+      geocoded_long = geocoded_coord[1].round(2)
+      if geocoded_lat == self.latitude.round(2) && geocoded_long == self.longitude.round(2)
+        self
+      else
+        check_distance = Geocoder::Calculations.distance_between([geocoded_lat, geocoded_long], [query[:latitude],query[:longitude]])
+        check_distance <= query[:distance] ? self : nil
+      end
+    else
+      geocoded_coord_zip = Geocoder.coordinates(self.physical_zip)
+      if geocoded_coord_zip.present?
+        geocoded_lat = geocoded_coord_zip[0].round(2)
+        geocoded_long = geocoded_coord_zip[1].round(2)
+        if geocoded_lat == self.latitude.round(2) && geocoded_long == self.longitude.round(2)
+          self
+        else
+          check_distance = Geocoder::Calculations.distance_between([geocoded_lat, geocoded_long], [query[:latitude],query[:longitude]])
+          check_distance <= query[:distance] ? self : nil
+        end
+      else
+        nil
+      end
+    end
+  end
+
   #
   # Scopes
   #

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -151,7 +151,6 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       institution = create(:institution, :start_like_harv, :production_version)
       create(:institution, :start_like_harv, :production_version, country: 'CAN')
       get(:autocomplete, params: { term: 'harv', country: 'usa' })
-      byebug
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(JSON.parse(response.body)['data'][0]['id']).to eq(institution.id)
       expect(response.content_type).to eq('application/json')

--- a/spec/controllers/v0/institutions_controller_spec.rb
+++ b/spec/controllers/v0/institutions_controller_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe V0::InstitutionsController, type: :controller do
       institution = create(:institution, :start_like_harv, :production_version)
       create(:institution, :start_like_harv, :production_version, country: 'CAN')
       get(:autocomplete, params: { term: 'harv', country: 'usa' })
+      byebug
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(JSON.parse(response.body)['data'][0]['id']).to eq(institution.id)
       expect(response.content_type).to eq('application/json')

--- a/spec/controllers/v1/institutions_controller_spec.rb
+++ b/spec/controllers/v1/institutions_controller_spec.rb
@@ -309,14 +309,14 @@ RSpec.describe V1::InstitutionsController, type: :controller do
     end
 
     it 'filter by uppercase country returns results' do
-      get(:index, params: { name: 'institution', country: 'USA'})
+      get(:index, params: { name: 'institution', country: 'USA' })
       expect(JSON.parse(response.body)['data'].count).to eq(3)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_search_results')
     end
 
     it 'filter by lowercase country returns results' do
-      get(:index, params: { name: 'institution', country: 'usa'})
+      get(:index, params: { name: 'institution', country: 'usa' })
       expect(JSON.parse(response.body)['data'].count).to eq(3)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_search_results')

--- a/spec/controllers/v1/institutions_controller_spec.rb
+++ b/spec/controllers/v1/institutions_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe V1::InstitutionsController, type: :controller do
 
     it 'filters by country' do
       institution = create(:institution, :start_like_harv, :production_version)
-      create(:institution, :start_like_harv, :production_version, country: 'CAN')
+      create(:institution, :start_like_harv, :production_version, country: 'CAN', physical_country: 'CAN')
       get(:autocomplete, params: { term: 'harv', country: 'usa' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(JSON.parse(response.body)['data'][0]['id']).to eq(institution.id)
@@ -159,7 +159,7 @@ RSpec.describe V1::InstitutionsController, type: :controller do
 
     it 'filters by state' do
       institution = create(:institution, :start_like_harv, :production_version)
-      create(:institution, :start_like_harv, :production_version, state: 'MD')
+      create(:institution, :start_like_harv, :production_version, state: 'MD', physical_state: 'MD')
       get(:autocomplete, params: { term: 'harv', state: 'ma' })
       expect(JSON.parse(response.body)['data'].count).to eq(1)
       expect(JSON.parse(response.body)['data'][0]['id']).to eq(institution.id)
@@ -309,14 +309,14 @@ RSpec.describe V1::InstitutionsController, type: :controller do
     end
 
     it 'filter by uppercase country returns results' do
-      get(:index, params: { name: 'institution', country: 'USA' })
+      get(:index, params: { name: 'institution', country: 'USA'})
       expect(JSON.parse(response.body)['data'].count).to eq(3)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_search_results')
     end
 
     it 'filter by lowercase country returns results' do
-      get(:index, params: { name: 'institution', country: 'usa' })
+      get(:index, params: { name: 'institution', country: 'usa'})
       expect(JSON.parse(response.body)['data'].count).to eq(3)
       expect(response.content_type).to eq('application/json')
       expect(response).to match_response_schema('institution_search_results')

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -21,18 +21,22 @@ FactoryBot.define do
       city { 'NEW YORK' }
       state { 'NY' }
       country { 'USA' }
+      physical_state { 'NY' }
+      physical_country { 'USA' }
     end
 
     trait :in_new_rochelle do
       city { 'NEW ROCHELLE' }
       state { 'NY' }
       country { 'USA' }
+      physical_state { 'NY' }
+      physical_country { 'USA' }
     end
 
     trait :in_chicago do
       physical_city { 'CHICAGO' }
-      physical_state { 'IL' }
-      physical_country { 'USA' }
+      state { 'IL' }
+      country { 'USA' }
       stem_offered { true }
     end
 
@@ -42,6 +46,8 @@ FactoryBot.define do
       city { 'SOME OTHER CITY' }
       state { 'IL' }
       country { 'USA' }
+      physical_state { 'IL' }
+      physical_country { 'USA' }
     end
 
     trait :independent_study do
@@ -50,6 +56,8 @@ FactoryBot.define do
       city { 'ALBUQUERQUE' }
       state { 'NM' }
       country { 'USA' }
+      physical_state { 'NM' }
+      physical_country { 'USA' }
       independent_study { true }
     end
 
@@ -59,6 +67,8 @@ FactoryBot.define do
       city { 'ALBUQUERQUE' }
       state { 'NM' }
       country { 'USA' }
+      physical_state { 'NM' }
+      physical_country { 'USA' }
       priority_enrollment { true }
     end
 
@@ -67,6 +77,8 @@ FactoryBot.define do
       city { 'BOSTON' }
       state { 'MA' }
       country { 'USA' }
+      physical_state { 'MA' }
+      physical_country { 'USA' }
     end
 
     trait :contains_harv do
@@ -74,6 +86,8 @@ FactoryBot.define do
       city { 'BOSTON' }
       state { 'MA' }
       country { 'USA' }
+      physical_state { 'MA' }
+      physical_country { 'USA' }
     end
 
     trait :ca_employer do
@@ -82,6 +96,8 @@ FactoryBot.define do
       city { 'LOS ANGELES' }
       state { 'CA' }
       country { 'USA' }
+      physical_state { 'CA' }
+      physical_country { 'USA' }
       institution_type_name { 'OJT' }
       employer_provider { true }
       vet_tec_provider { false }
@@ -101,6 +117,8 @@ FactoryBot.define do
       city { 'CHARLESTON' }
       state { 'SC' }
       country { 'USA' }
+      physical_state { 'SC' }
+      physical_country { 'USA' }
       vet_tec_provider { true }
       school_provider { false }
       employer_provider { false }
@@ -118,6 +136,8 @@ FactoryBot.define do
 
     trait :preferred_provider do
       city { 'CHARLESTON' }
+      physical_state { 'SC' }
+      physical_country { 'USA' }
       state { 'SC' }
       country { 'USA' }
       preferred_provider { true }
@@ -137,7 +157,9 @@ FactoryBot.define do
       physical_address_3 { 'Unit abc' }
       physical_city { 'CHICAGO' }
       physical_state { 'IL' }
+      state { 'IL' }
       physical_country { 'USA' }
+      country { 'USA' }
       physical_zip { '12345' }
     end
 
@@ -146,8 +168,9 @@ FactoryBot.define do
       address_2 { 'Main St' }
       address_3 { 'Unit abc' }
       city { 'CHICAGO' }
-      state { 'IL' }
-      country { 'USA' }
+      physical_city { 'CHICAGO' }
+      physical_state { 'IL' }
+      physical_country { 'USA' }
     end
 
     trait :production_version do

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -171,6 +171,8 @@ FactoryBot.define do
       physical_city { 'CHICAGO' }
       physical_state { 'IL' }
       physical_country { 'USA' }
+      state { 'IL' }
+      country { 'USA' }
     end
 
     trait :production_version do

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -164,9 +164,6 @@ FactoryBot.define do
     end
 
     trait :mailing_address do
-      address_1 { '123' }
-      address_2 { 'Main St' }
-      address_3 { 'Unit abc' }
       city { 'CHICAGO' }
       physical_city { 'CHICAGO' }
       physical_state { 'IL' }
@@ -196,6 +193,14 @@ FactoryBot.define do
     trait :location do
       latitude { 32.790803 }
       longitude { -79.938087 }
+      address_1 { '81' }
+      address_2 { 'Mary St' }
+      city { 'Charleston' }
+      physical_city { 'Charleston' }
+      physical_state { 'SC' }
+      physical_country { 'USA' }
+      state { 'SC' }
+      country { 'USA' }
       institution { 'CHARLESTON SCHOOL OF LAW' }
     end
 


### PR DESCRIPTION
## Description
Fix to GI Sandbbox Tool name and location search issue - user can not put in a city and state in the text field, ex) Albany, NY and return results. On search by name page, user is not presented with all results, needed to change filter to also look at physical state. Issue with location search, when user puts in webster grove, missouri...extra results are returned. Upon further investigation found cases with incorrect lattitudes and longitudes. Added gecoder gem and step that double checks the coordinates on the institution model and filters if the coordinates are wrong.

