### PR TITLE
Removing redesign link from dashboard.

### DIFF
--- a/app/views/dashboards/_version.html.erb
+++ b/app/views/dashboards/_version.html.erb
@@ -10,8 +10,6 @@
     <% else %>
       <%= link_to 'Show GIBCT', version.gibct_link, target: "_blank", rel: "noopener noreferrer",
           class: "btn dashboard-btn-success btn-xs", role: "button" %>
-      <%= link_to 'Show redesign', version.sandbox_link, target: "_blank", rel: "noopener noreferrer",
-          class: "btn dashboard-btn-success btn-xs", role: "button" %>
       <%= link_to 'Download Export CSV', dashboard_export_version_path(version.number),
           class: "btn dashboard-btn-warning btn-xs", role: "button" %>
       <% if version.publishable? %>


### PR DESCRIPTION
## Description
Removes GIBCT redesign link from dashboard.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35329

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
