### PR TITLE
removed latitude and longitude from ipedshd and adjusted tests

### DIFF
--- a/app/models/ipeds_hd.rb
+++ b/app/models/ipeds_hd.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IpedsHd < ImportableRecord
-  COLS_USED_IN_INSTITUTION = %i[vet_tuition_policy_url f1sysnam f1syscod latitude].freeze
+  COLS_USED_IN_INSTITUTION = %i[vet_tuition_policy_url f1sysnam f1syscod].freeze
 
   CSV_CONVERTER_INFO = {
     'unitid' => { column: :cross, converter: CrossConverter },
@@ -69,14 +69,14 @@ class IpedsHd < ImportableRecord
     'countycd' => { column: :countycd, converter: NumberConverter },
     'countynm' => { column: :countynm, converter: BaseConverter },
     'cngdstcd' => { column: :cngdstcd, converter: NumberConverter },
-    'longitud' => { column: :longitud, converter: NumberConverter },
-    'latitude' => { column: :latitude, converter: NumberConverter },
     'dfrcgid' => { column: :dfrcgid, converter: NumberConverter },
     'dfrcuscg' => { column: :dfrcuscg, converter: BaseConverter }
   }.freeze
 
   has_many :crosswalk_issue, dependent: :delete_all
   validates :cross, presence: true
+
+  self.ignored_columns = %w[longitud latitude]
 
   def full_address
     [addr, city, state, zip].compact

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -145,12 +145,12 @@ class Scorecard < ImportableRecord
     'rpy_3yr_rt_supp' => { column: :repayment_rate_all_students, converter: NumberConverter },
     'c150_4_pooled_supp' => { column: :c150_4_pooled_supp, converter: NumberConverter },
     'c150_l4_pooled_supp' => { column: :c150_l4_pooled_supp, converter: NumberConverter },
-    'alias' => { column: :alias, converter: BaseConverter },
-    'latitude' => { column: :latitude, converter: NumberConverter },
-    'longitude' => { column: :longitude, converter: NumberConverter }
+    'alias' => { column: :alias, converter: BaseConverter }
   }.freeze
 
   after_initialize :derive_dependent_columns
+
+  self.ignored_columns = %w[longitude latitude]
 
   POPULATE_SUCCESS_MESSAGE = 'Scorecard CSV table populated from https://collegescorecard.ed.gov/data/'
   API_SOURCE = 'https://collegescorecard.ed.gov/data/'

--- a/app/utilities/institution_builder/ipeds_builder.rb
+++ b/app/utilities/institution_builder/ipeds_builder.rb
@@ -14,11 +14,9 @@ module InstitutionBuilder
 
     def self.build_hd(version_id)
       str = <<-SQL
-        UPDATE institutions SET #{columns_for_update(IpedsHd)}, longitude = ipeds_hds.longitud
+        UPDATE institutions SET #{columns_for_update(IpedsHd)}
         FROM ipeds_hds
         WHERE institutions.cross = ipeds_hds.cross
-        AND ipeds_hds.latitude BETWEEN -90 AND 90
-        AND ipeds_hds.longitud BETWEEN -180 AND 180
         AND institutions.version_id = #{version_id}
       SQL
 

--- a/spec/factories/ipeds_hds.rb
+++ b/spec/factories/ipeds_hds.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
     f1sysnam { 'example school' }
     f1syscod { 123 }
     ialias { 'exsc' }
-    latitude { 0.0 }
-    longitud { 0.0 }
 
     trait :institution_builder do
       cross { '999999' }


### PR DESCRIPTION
Updates to institution build process related to issue with latitude and longitude being read in. A step in that process called IpedsBuilder.build_hd was still reading in the latitude and longitude and reverting the updates to the institutions coordinates with the geocoder gem. 
