### PR TITLE
added prod flag to prevent site mapper calls on staging

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -62,9 +62,11 @@ class DashboardsController < ApplicationController
 
       flash.notice = 'Production data updated'
 
-      # Build Sitemap and notify search engines in production only
-      ping = request.original_url.include?(GibctSiteMapper::PRODUCTION_HOST)
-      GibctSiteMapper.new(ping: ping)
+      if production?
+        # Build Sitemap and notify search engines in production only
+        ping = request.original_url.include?(GibctSiteMapper::PRODUCTION_HOST)
+        GibctSiteMapper.new(ping: ping)
+      end
 
       if Settings.archiver.archive
         # Archive previous versions of generated data

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -97,7 +97,7 @@ module InstitutionBuilder
         success = false
       end
 
-      missing_lat_long = Institution.where(latitude: nil, longitude: nil)
+      missing_lat_long = Institution.where(version: version, latitude: nil, longitude: nil)
 
       if missing_lat_long.present?
         Rails.logger.info "Updating #{missing_lat_long.count} without latitude and longitude"

--- a/app/utilities/scorecard_api/service.rb
+++ b/app/utilities/scorecard_api/service.rb
@@ -21,8 +21,6 @@ module ScorecardApi
         'latest.student.retention_rate.four_year.full_time': :retention_all_students_ba,
         'latest.student.retention_rate.lt_four_year.full_time': :retention_all_students_otb,
         'latest.student.size': :undergrad_enrollment,
-        'location.lat': :latitude,
-        'location.lon': :longitude,
         'school.school_url': :insturl,
         'school.degrees_awarded.predominant': :pred_degree_awarded,
         'school.locale': :locale,

--- a/lib/roo_helper/loader.rb
+++ b/lib/roo_helper/loader.rb
@@ -68,20 +68,11 @@ module RooHelper
     # Load multiple files at a time
     #
     # Assume all files are of the same type
-    def load_multiple_files(files, klass)
+    def load_multiple_files(_files, klass)
       options = Common::Shared.file_type_defaults(klass.name)
-      file_options = { liberal_parsing: options[:liberal_parsing],
-                       sheets: [{ klass: klass,
-                                  skip_lines: options[:skip_lines],
-                                  multiple_files: options[:multiple_files],
-                                  no_headers: options[:no_headers] }] }
 
       # The option disables deleting when each file is loaded and instead allows for a single deletion before loading
       klass.delete_all if options[:multiple_files]
-
-      files.map do |file|
-        CensusLatLong.load_with_roo(file, file_options)
-      end
     end
 
     private


### PR DESCRIPTION
Needed to add a production only flag to push route on Dashboard Controller. Removed a few remaining instances where lat and long is still present.
