### PR TITLE
36247 - Remove unused argument in high school filter class method

### DIFF
--- a/app/controllers/v1/institutions_controller.rb
+++ b/app/controllers/v1/institutions_controller.rb
@@ -32,7 +32,7 @@ module V1
                            .filter_result_v1(@query)
                            .search_order_v1(@query, max_gibill).page(page)
 
-      results = results.filter_high_school(@query) if @query[:excluded_school_types]&.include?('HIGH SCHOOL')
+      results = results.filter_high_school if @query[:excluded_school_types]&.include?('HIGH SCHOOL')
 
       @meta = {
         version: @version,


### PR DESCRIPTION
## Remove unused argument in high school filter class method

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/board?assignees=adamfreemer&filterLogic=any&labels=afs-edu-comparisontool,afs-education&repos=133843125&useDefaultFilterLogic=false

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
