### PR TITLE
fixed ownership name in api

### DIFF
--- a/app/models/institution_owner.rb
+++ b/app/models/institution_owner.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class InstitutionOwner < ApplicationRecord
+end

--- a/app/models/institution_owner_archive.rb
+++ b/app/models/institution_owner_archive.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class InstitutionOwnerArchive < ApplicationRecord
+end

--- a/app/serializers/institution_compare_serializer.rb
+++ b/app/serializers/institution_compare_serializer.rb
@@ -90,6 +90,7 @@ class InstitutionCompareSerializer < ActiveModel::Serializer
   attribute :school_provider
   attribute :vet_tec_provider
   attribute :employer_provider
+  attribute :ownership_name
 
   def yellow_ribbon_programs
     object.yellow_ribbon_programs.map do |yrp|

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -107,6 +107,7 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :rating_count
   attribute :in_state_tuition_information
   attribute :vrrap
+  attribute :ownership_name
 
   link(:website) { object.website_link }
   link(:scorecard) { object.scorecard_link }

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     approved { true }
     bad_address { false }
     high_school { false }
+    ownership_name { nil }
 
     trait :in_nyc do
       city { 'NEW YORK' }
@@ -25,6 +26,7 @@ FactoryBot.define do
       country { 'USA' }
       physical_state { 'NY' }
       physical_country { 'USA' }
+      ownership_name { 'test' }
     end
 
     trait :in_new_rochelle do
@@ -33,6 +35,7 @@ FactoryBot.define do
       country { 'USA' }
       physical_state { 'NY' }
       physical_country { 'USA' }
+      ownership_name { 'test' }
     end
 
     trait :in_chicago do
@@ -40,6 +43,7 @@ FactoryBot.define do
       state { 'IL' }
       country { 'USA' }
       stem_offered { true }
+      ownership_name { 'test' }
     end
 
     trait :uchicago do
@@ -50,6 +54,7 @@ FactoryBot.define do
       country { 'USA' }
       physical_state { 'IL' }
       physical_country { 'USA' }
+      ownership_name { 'test' }
     end
 
     trait :independent_study do
@@ -61,6 +66,7 @@ FactoryBot.define do
       physical_state { 'NM' }
       physical_country { 'USA' }
       independent_study { true }
+      ownership_name { 'test' }
     end
 
     trait :priority_enrollment do
@@ -72,6 +78,7 @@ FactoryBot.define do
       physical_state { 'NM' }
       physical_country { 'USA' }
       priority_enrollment { true }
+      ownership_name { 'test' }
     end
 
     trait :start_like_harv do
@@ -81,6 +88,7 @@ FactoryBot.define do
       country { 'USA' }
       physical_state { 'MA' }
       physical_country { 'USA' }
+      ownership_name { 'test' }
     end
 
     trait :contains_harv do
@@ -90,6 +98,7 @@ FactoryBot.define do
       country { 'USA' }
       physical_state { 'MA' }
       physical_country { 'USA' }
+      ownership_name { 'test' }
     end
 
     trait :ca_employer do
@@ -104,6 +113,7 @@ FactoryBot.define do
       employer_provider { true }
       vet_tec_provider { false }
       school_provider { false }
+      ownership_name { 'test' }
     end
 
     trait :institution_builder do
@@ -111,6 +121,7 @@ FactoryBot.define do
       ope { '00279100' }
       ope6 { '02791' }
       cross { '999999' }
+      ownership_name { 'test' }
     end
 
     trait :vet_tec_provider do
@@ -124,6 +135,7 @@ FactoryBot.define do
       vet_tec_provider { true }
       school_provider { false }
       employer_provider { false }
+      ownership_name { 'test' }
     end
 
     trait :exclude_caution_flags do

--- a/spec/support/api/schemas/institution_compare_results.json
+++ b/spec/support/api/schemas/institution_compare_results.json
@@ -452,6 +452,9 @@
               },
               "employer_provider": {
                 "type": ["null", "boolean"]
+              },
+              "ownership_name": {
+                "type": ["null", "string"]
               }
             },
             "required": [

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -525,6 +525,9 @@
             },
             "vrrap": {
               "type": ["null", "boolean"]
+            },
+            "ownership_name": {
+                "type": ["null", "string"]
             }
           },
           "required": [


### PR DESCRIPTION
Needed to add ownership name to serializers, not showing in payload when testing. Also added an ownership model and ownership model archive fore future use.
