### PR TITLE
Vfep 176a - migration for VFEP-176 ungeocodables

### DIFF
--- a/db/migrate/20221215000914_add_ungeocodable_to_institution.rb
+++ b/db/migrate/20221215000914_add_ungeocodable_to_institution.rb
@@ -1,0 +1,6 @@
+class AddUngeocodableToInstitution < ActiveRecord::Migration[6.1]
+  def change
+    add_column :institutions, :ungeocodable, :boolean, default: false
+    add_column :institutions_archives, :ungeocodable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_09_161802) do
+ActiveRecord::Schema.define(version: 2022_12_15_000914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
@@ -472,6 +472,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_161802) do
     t.integer "aanapii"
     t.integer "pbi"
     t.integer "tribal"
+    t.boolean "ungeocodable", default: false
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin
@@ -652,6 +653,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_161802) do
     t.integer "aanapii"
     t.integer "pbi"
     t.integer "tribal"
+    t.boolean "ungeocodable"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description
Vfep 176a - migration for VFEP-176 ungeocodables
## Original issue(s)
[Vfep 176a - migration for VFEP-176 ungeocodables](https://vajira.max.gov/browse/VFEP-176)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
