### PR TITLE
Vfep 176 nfs - handle ungeocodables to improve performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,6 +139,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - "app/validators/va_caution_flag_validator.rb"
     - "app/controllers/v1/institutions_controller.rb"
+    - "app/models/search_geocoder.rb"
     - "lib/roo_helper/loader.rb"
     
 Metrics/PerceivedComplexity:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,7 @@ Rails:
 
 Rails/Output:
   Exclude:
+    - "app/models/db_cleanup.rb"
     - "lib/**/*.rb"
 
 Metrics/MethodLength:
@@ -95,6 +96,7 @@ Metrics/MethodLength:
     - "app/models/institution_builder.rb"
     - "app/models/archiver.rb"
     - "app/models/caution_flag.rb"
+    - "app/concerns/geocoder_logic.rb"
     - "app/controllers/v0/institutions_controller.rb"
     - "app/controllers/v1/institutions_controller.rb"
     - "lib/roo_helper/loader.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'faker', '~> 1.6', '>= 1.6.2'
   gem 'simplecov'
+  gem 'simplecov-single_file', require: false, group: :test
   gem 'vcr', '~> 3.0', '>= 3.0.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,9 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-single_file (0.1.0)
+      simplecov (~> 0.2)
+      terminal-table (~> 3.0)
     simplecov_json_formatter (0.1.4)
     sitemap_generator (6.3.0)
       builder (~> 3.0)
@@ -422,6 +425,8 @@ GEM
       sprockets (>= 3.0.0)
     strong_migrations (1.4.0)
       activerecord (>= 5.2)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -513,6 +518,7 @@ DEPENDENCIES
   scss_lint
   sentry-raven (~> 2.9.0)
   simplecov
+  simplecov-single_file
   sitemap_generator
   spring
   strong_migrations

--- a/app/concerns/geocoder_logic.rb
+++ b/app/concerns/geocoder_logic.rb
@@ -6,7 +6,9 @@ module GeocoderLogic
   def check_bad_address(result, geocoded3)
     # uses geocoder text search and looks for coords by Institution name if applicable
     inst = result.institution
-    geocode_name = Geocoder.search(inst.downcase.split('#').first) if inst.present?
+    geocode_name, timed_out = geocode_addy('search', inst.downcase.split('#').first, 0) if inst.present?
+    return if timed_out
+
     geocode_name.present? ? full_text_search(result, geocode_name, geocoded3) : search_bad_address(result, geocoded3)
   end
 
@@ -18,7 +20,10 @@ module GeocoderLogic
       add_split = result.address.split(stopwords_regex).map(&:strip)[0..1].join(' ')
       new_address = [add_split, result.state, result.zip].compact.join(' ')
     end
-    geocoded = Geocoder.coordinates(new_address)
+
+    geocoded, timed_out = geocode_addy('coordinates', new_address, 0)
+    return if timed_out
+
     update_bad_address(result, geocoded, geocoded3)
   end
 
@@ -72,5 +77,19 @@ module GeocoderLogic
     city_check = result.city.titleize if result.city
     search << geo if city == city_check || state == result.state || zip == result.zip || village == city_check
     search
+  end
+
+  def geocode_addy(geocode_type, data, retry_count = 0)
+    return [nil, true] if retry_count > 1 # only retry once, should be sufficient
+
+    begin
+      timed_out = false
+      geocoded = Geocoder.send geocode_type.to_sym, data
+    rescue Timeout::Error
+      Rails.logger.info "  Geocode.#{geocode_type} timed out with #{data} retrying"
+      geocoded, timed_out = geocode_addy(geocode_type, data, retry_count + 1)
+    end
+
+    [geocoded, timed_out]
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -36,6 +36,10 @@ module DashboardsHelper
     if pgsi.current_progress.start_with?('Complete') || pgsi.current_progress.start_with?('There was an error')
       completed = true
       PreviewGenerationStatusInformation.delete_all
+      # maintain the indexes and tables in the local, dev & staging envs.
+      # The production env times out and periodic maintenance should be run
+      # in production anyway.
+      PerformInsitutionTablesMaintenanceJob.perform_later unless production?
     end
 
     completed

--- a/app/jobs/perform_insitution_tables_maintenance_job.rb
+++ b/app/jobs/perform_insitution_tables_maintenance_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PerformInsitutionTablesMaintenanceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    DbCleanup.vacuum_and_analyze_preview_tables
+  end
+end

--- a/app/models/db_cleanup.rb
+++ b/app/models/db_cleanup.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# This utility model is primarily intended to be used in your local development environment
+# but can also be used in the va development and staging environments to clean up and tune
+# the tables involved in generating a preview. It was observed that after a while the indexes
+# get out of whack and performance really degrades because table scans wind up getting used
+# to access the data instead of indexes.
+class DbCleanup
+  # Child tables of versions
+  TABLES = %w[ caution_flags institution_programs versioned_school_certifying_officials
+               yellow_ribbon_programs institutions zipcode_rates].freeze
+
+  SIMPLE_DELETE_TABLES = %w[caution_flags institutions zipcode_rates].freeze
+
+  def self.vacuum_and_analyze_preview_tables
+    TABLES.each { |table| vacuum_and_analyze(table) }
+    vacuum_and_analyze('versions')
+  end
+
+  def self.delete_broken_preview(version_id)
+    TABLES.each { |table| delete_version_and_vacuum(table, version_id) }
+
+    puts "Deleting version #{version_id}"
+    sql = Version.send(:sanitize_sql, ["DELETE FROM versions WHERE id= #{version_id}"])
+    ActiveRecord::Base.connection.execute(sql)
+    vacuum_and_analyze('versions')
+  end
+
+  def self.vacuum_and_analyze(table)
+    puts "Vacuuming #{table}"
+    sql = Version.send(:sanitize_sql, ["VACUUM FULL ANALYZE #{table}"])
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def self.delete_version_and_vacuum(table, version_id)
+    sql1 = "DELETE FROM #{table} WHERE version_id = #{version_id}"
+    sql2 = "DELETE FROM #{table} WHERE institution_id in " \
+           "(select id from institutions where version_id = #{version_id})"
+
+    puts "deleting rows from #{table} for version #{version_id}"
+
+    unsanitized_sql = sql1
+    unsanitized_sql = sql2 unless SIMPLE_DELETE_TABLES.include?(table)
+
+    sql = Version.send(:sanitize_sql, [unsanitized_sql])
+    ActiveRecord::Base.connection.execute(sql)
+
+    vacuum_and_analyze(table)
+  end
+end

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -62,6 +62,7 @@ module InstitutionBuilder
       add_provider_type(version.id)
       VrrapBuilder.build(version.id)
       update_longitude_and_latitude(version.id)
+      update_ungeocodable(version.id)
       geocode_institutions(version)
 
       build_messages.filter { |_k, v| v.present? }
@@ -847,6 +848,8 @@ module InstitutionBuilder
                                                                                schools: Institution::SCHOOLS }]))
     end
 
+    # Pull forward into the current version the long/lat data for approved
+    # institutions where the addy hasn't changed.
     def self.update_longitude_and_latitude(version_id)
       log_info_status 'Updating Longitude & Latitude information'
       # get current version id
@@ -894,6 +897,58 @@ module InstitutionBuilder
         AND i.facility_code = prod_i.facility_code
         AND i.version_id = #{version_id}
         AND i.approved IS TRUE
+      SQL
+
+      sql = Institution.send(:sanitize_sql, [str])
+      Institution.connection.execute(sql)
+    end
+
+    # set the ungeocodable flag to true if it was ungeocodable and the addy has
+    # not changed
+    def self.update_ungeocodable(version_id)
+      log_info_status 'Updating Ungeocodable flag'
+      # get current version id
+      current_version_id = Version.current_production.id
+
+      str = <<-SQL
+        UPDATE institutions i SET
+          ungeocodable = true
+        FROM (
+          SELECT physical_address_1, physical_address_2, physical_address_3
+               , physical_city, physical_state, physical_country, physical_zip
+               , facility_code
+            FROM institutions
+           WHERE version_id = #{current_version_id}
+             AND longitude    IS NULL
+             AND latitude     IS NULL
+             AND approved     IS TRUE
+             AND ungeocodable IS TRUE
+          ) prod_i
+        WHERE (i.latitude IS NULL AND i.longitude IS NULL)
+
+          AND (i.physical_address_1 = prod_i.physical_address_1
+              or (i.physical_address_1 is null and prod_i.physical_address_1 is null))
+
+          AND (i.physical_address_2 = prod_i.physical_address_2
+              or (i.physical_address_2 is null and prod_i.physical_address_2 is null))
+
+          AND (i.physical_address_3 = prod_i.physical_address_3
+              or (i.physical_address_3 is null and prod_i.physical_address_3 is null))
+
+          AND (i.physical_city = prod_i.physical_city
+              or (i.physical_city is null and prod_i.physical_city is null))
+
+          AND (i.physical_state = prod_i.physical_state
+              or (i.physical_state is null and prod_i.physical_state is null))
+
+          AND (i.physical_zip = prod_i.physical_zip
+              or (i.physical_zip is null and prod_i.physical_zip is null))
+
+          AND i.physical_country = prod_i.physical_country
+          AND i.facility_code    = prod_i.facility_code
+          AND i.version_id       = #{version_id}
+
+          AND i.approved IS TRUE
       SQL
 
       sql = Institution.send(:sanitize_sql, [str])

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -69,6 +69,7 @@ module InstitutionBuilder
     end
 
     def self.run(user)
+      prev_gen_start = Time.now.utc
       version = Version.create!(production: false, user: user)
       build_messages = {}
       begin
@@ -106,6 +107,11 @@ module InstitutionBuilder
         Rails.logger.error "#{notice}: #{error_msg}"
         version.delete
       end
+      prev_gen_end = Time.now.utc
+
+      Rails.logger.info "\n\n\n"
+      Rails.logger.info "*** Preview Generation Beg: #{prev_gen_start}"
+      Rails.logger.info "*** Preview Generation End: #{prev_gen_end}\n\n\n"
     end
 
     def self.initialize_with_weams(version)
@@ -962,8 +968,9 @@ module InstitutionBuilder
       search_geocoder.process_geocoder_address if search_geocoder.by_address.present?
       version.update(geocoded: true)
       finish = Time.now.utc
-      Rails.logger.info "*** Beg: #{start}"
-      Rails.logger.info "*** End: #{finish}"
+      Rails.logger.info "\n\n\n"
+      Rails.logger.info "*** Goecoding Beg: #{start}"
+      Rails.logger.info "*** Geocoding End: #{finish}\n\n\n"
     end
 
     def self.delete_prior_preview_data(prior_preview_ids)

--- a/app/models/search_geocoder.rb
+++ b/app/models/search_geocoder.rb
@@ -71,7 +71,7 @@ class SearchGeocoder
     timed_out = nil
 
     [address[0], address[1], address[2]].each do |addy|
-      geocoded, timed_out = geocode_addy('coordinates', data, 0) if addy.present?
+      geocoded, timed_out = geocode_addy('coordinates', addy, 0) if addy.present?
       if geocoded.present?
         update_mismatch(result, geocoded)
         break

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,4 +1,4 @@
 Geocoder.configure(
   timeout: 15,
-  always_raise: [Timeout::Error]
+  always_raise: :all
 )

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,3 +1,4 @@
 Geocoder.configure(
-  timeout: 15
+  timeout: 15,
+  always_raise: [Timeout::Error]
 )

--- a/db/migrate/20221215000914_add_ungeocodable_to_institution.rb
+++ b/db/migrate/20221215000914_add_ungeocodable_to_institution.rb
@@ -1,0 +1,6 @@
+class AddUngeocodableToInstitution < ActiveRecord::Migration[6.1]
+  def change
+    add_column :institutions, :ungeocodable, :boolean, default: false
+    add_column :institutions_archives, :ungeocodable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_09_161802) do
+ActiveRecord::Schema.define(version: 2022_12_15_000914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
@@ -472,6 +472,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_161802) do
     t.integer "aanapii"
     t.integer "pbi"
     t.integer "tribal"
+    t.boolean "ungeocodable", default: false
     t.index "lower((address_1)::text) gin_trgm_ops", name: "index_institutions_on_address_1", using: :gin
     t.index "lower((address_2)::text) gin_trgm_ops", name: "index_institutions_on_address_2", using: :gin
     t.index "lower((address_3)::text) gin_trgm_ops", name: "index_institutions_on_address_3", using: :gin
@@ -652,6 +653,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_161802) do
     t.integer "aanapii"
     t.integer "pbi"
     t.integer "tribal"
+    t.boolean "ungeocodable"
   end
 
   create_table "ipeds_cip_codes", id: :serial, force: :cascade do |t|

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,6 +4,16 @@ require 'fileutils'
 
 # rubocop:disable Metrics/BlockLength
 namespace :db do
+  desc 'Vacuum and Analyze Institution tables used in generating previews'
+  task vac_and_analyze_prev_tables: :environment do
+    DbCleanup.vacuum_and_analyze_preview_tables
+  end
+
+  desc 'Delete a broken preview'
+  task :delete_broken_preview, [:version_id] => :environment do |_t, args|
+    DbCleanup.delete_broken_preview(args.version_id)
+  end
+
   desc 'Dumps the database to backups'
   task dump: :environment do
     dump_fmt = 'c' # or 'p', 't', 'd'

--- a/spec/jobs/perform_insitution_tables_maintenance_job_spec.rb
+++ b/spec/jobs/perform_insitution_tables_maintenance_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PerformInsitutionTablesMaintenanceJob, type: :job do
+  describe '#perform' do
+    let(:job) { described_class.new }
+
+    it 'writes messages to stdout' do
+      # This seems necessary to overcome RSpec's wrapping things
+      # in transactions and Postgresql does not like wrapping
+      # vacuum commands in transactions. Tail the test log for why
+      ActiveRecord::Base.connection.commit_db_transaction
+
+      expect { job.perform }.to output(/Vacuuming/).to_stdout
+    end
+  end
+end

--- a/spec/jobs/perform_insitution_tables_maintenance_job_spec.rb
+++ b/spec/jobs/perform_insitution_tables_maintenance_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PerformInsitutionTablesMaintenanceJob, type: :job do

--- a/spec/models/db_cleanup_spec.rb
+++ b/spec/models/db_cleanup_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DbCleanup, type: :model do
+  let(:version) { create(:version, :preview) }
+
+  describe '#delete_broken_preview' do
+    it 'removes all dependant version preview data' do
+      institution = create :institution, :regular_address
+      institution.update(version: version, version_id: version.id)
+
+      # This seems necessary to overcome RSpec's wrapping things
+      # in transactions and Postgresql does not like wrapping
+      # vacuum commands in transactions. Tail the test log for why
+      ActiveRecord::Base.connection.commit_db_transaction
+
+      expect(Institution.count).to eq(1)
+      expect(Version.count).to eq(1)
+      described_class.delete_broken_preview(version.id)
+      expect(Institution.count).to eq(0)
+      expect(Version.count).to eq(0)
+    end
+  end
+end

--- a/spec/models/search_geocoder_spec.rb
+++ b/spec/models/search_geocoder_spec.rb
@@ -133,8 +133,7 @@ RSpec.describe SearchGeocoder, type: :model do
       it 'handles exceptions when calling the geocoder api' do
         sleep(5)
         [Timeout::Error, SocketError, Geocoder::OverQueryLimitError, Geocoder::RequestDenied,
-         Geocoder::InvalidRequest, Geocoder::InvalidApiKey, Geocoder::ServiceUnavailable
-        ].each do |geocoding_exception|
+         Geocoder::InvalidRequest, Geocoder::InvalidApiKey, Geocoder::ServiceUnavailable].each do |geocoding_exception|
           run_exception_test(geocoding_exception)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+require 'simplecov/single_file'
 SimpleCov.start do
   SimpleCov.minimum_coverage_by_file 90
 


### PR DESCRIPTION
## Description
Vfep 176 nfs - handle ungeocodables to improve performance

## Original issue(s)
[VFEP-176](https://vajira.max.gov/browse/VFEP-176)

## Testing done
ran generate preview, rspec tests

## Screenshots


## Acceptance criteria
- [ ]  Generate preview runs faster because it doesn't try to geocode those flagged as ungeocodable addresses

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
