### PR TITLE
vfep-233 add CT Ratings migrations

### DIFF
--- a/db/migrate/20230116152710_create_institution_school_ratings.rb
+++ b/db/migrate/20230116152710_create_institution_school_ratings.rb
@@ -1,0 +1,41 @@
+class CreateInstitutionSchoolRatings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :institution_school_ratings do |t|
+      t.string  :survey_key
+      t.string  :email
+      t.string  :age
+      t.string  :gender
+      t.string  :school
+      t.string  :facility_code
+      t.string  :degree
+      t.date    :graduation_date
+      t.string  :benefit_program
+      t.string  :enrollment_type
+      t.string  :monthly_payment_benefit
+      t.string  :payee_number
+      t.string  :objective_code
+      t.date    :response_date
+      t.date    :sent_date
+      t.integer :q1    # Instructors' knowledge in the subject being taught
+      t.integer :q2    # Instructors' ability to engage with students around course content
+      t.integer :q3    # Support of course materials in meeting learning objectives
+      t.integer :q4    # Contribution of school-supplied technology and/or facilities to successful learning experience
+      t.integer :q5    # Contribution of learning experience to skills needed for career journey
+      t.string  :q6    # Did you interact with the School Certifying Officials (school staff who assist Veterans/beneficiaries with enrollment, submit documentation to VA, advise on other VA benefits)?
+      t.integer :q7    # Supportiveness of School Certifying Officials (school staff who assist Veterans/beneficiaries with enrollment, submit documentation to VA, advise on other VA benefits)
+      t.integer :q8    # Availability of School Certifying Officials (school staff who assist Veterans/beneficiaries with enrollment, submit documentation to VA, advise on other VA benefits)
+      t.integer :q9    # School's timely completion of VA enrollment documentation
+      t.integer :q10   # Helpfulness of school-provided information about GI Bill, other VA benefits
+      t.integer :q11   # Extent of school's support for its Veteran community
+      t.integer :q12   # Extent of support from others in the school's Veteran community
+      t.integer :q13   # Overall learning experience
+      t.integer :q14   # Overall school experience
+      t.integer :q15   # for future use
+      t.integer :q16   # for future use
+      t.integer :q17   # for future use
+      t.integer :q18   # for future use
+      t.integer :q19   # for future use
+      t.integer :q20   # for future use
+    end
+  end
+end

--- a/db/migrate/20230117010055_create_institution_ratings.rb
+++ b/db/migrate/20230117010055_create_institution_ratings.rb
@@ -1,0 +1,58 @@
+class CreateInstitutionRatings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :institution_ratings do |t|
+      t.integer :institution_id
+      t.decimal :q1_avg, precision: 2, scale: 1
+      t.integer :q1_count
+      t.decimal :q2_avg, precision: 2, scale: 1
+      t.integer :q2_count
+      t.decimal :q3_avg, precision: 2, scale: 1
+      t.integer :q3_count
+      t.decimal :q4_avg, precision: 2, scale: 1
+      t.integer :q4_count
+      t.decimal :q5_avg, precision: 2, scale: 1
+      t.integer :q5_count
+      t.decimal :q7_avg, precision: 2, scale: 1
+      t.integer :q7_count
+      t.decimal :q8_avg, precision: 2, scale: 1
+      t.integer :q8_count
+      t.decimal :q9_avg, precision: 2, scale: 1
+      t.integer :q9_count
+      t.decimal :q10_avg, precision: 2, scale: 1
+      t.integer :q10_count
+      t.decimal :q11_avg, precision: 2, scale: 1
+      t.integer :q11_count
+      t.decimal :q12_avg, precision: 2, scale: 1
+      t.integer :q12_count
+      t.decimal :q13_avg, precision: 2, scale: 1
+      t.integer :q13_count
+      t.decimal :q14_avg, precision: 2, scale: 1
+      t.integer :q14_count
+      t.decimal :q15_avg, precision: 2, scale: 1
+      t.integer :q15_count
+      t.decimal :q16_avg, precision: 2, scale: 1
+      t.integer :q16_count
+      t.decimal :q17_avg, precision: 2, scale: 1
+      t.integer :q17_count
+      t.decimal :q18_avg, precision: 2, scale: 1
+      t.integer :q18_count
+      t.decimal :q19_avg, precision: 2, scale: 1
+      t.integer :q19_count
+      t.decimal :q20_avg, precision: 2, scale: 1
+      t.integer :q20_count
+
+      t.decimal :m1_avg, precision: 2, scale: 1
+      t.decimal :m2_avg, precision: 2, scale: 1
+      t.decimal :m3_avg, precision: 2, scale: 1
+      t.decimal :m4_avg, precision: 2, scale: 1
+      t.decimal :m5_avg, precision: 2, scale: 1
+      t.decimal :m6_avg, precision: 2, scale: 1
+      t.decimal :m7_avg, precision: 2, scale: 1
+
+      t.decimal :overall_avg, precision: 2, scale: 1
+      t.integer :institution_rating_count
+    end
+
+    add_index :institution_ratings, :institution_id, unique: true 
+  end
+end

--- a/db/migrate/20230117170722_create_institution_ratings_archives.rb
+++ b/db/migrate/20230117170722_create_institution_ratings_archives.rb
@@ -1,0 +1,56 @@
+class CreateInstitutionRatingsArchives < ActiveRecord::Migration[6.1]
+  def change
+    create_table :institution_ratings_archives do |t|
+      t.integer :institution_id
+      t.decimal :q1_avg, precision: 2, scale: 1
+      t.integer :q1_count
+      t.decimal :q2_avg, precision: 2, scale: 1
+      t.integer :q2_count
+      t.decimal :q3_avg, precision: 2, scale: 1
+      t.integer :q3_count
+      t.decimal :q4_avg, precision: 2, scale: 1
+      t.integer :q4_count
+      t.decimal :q5_avg, precision: 2, scale: 1
+      t.integer :q5_count
+      t.decimal :q7_avg, precision: 2, scale: 1
+      t.integer :q7_count
+      t.decimal :q8_avg, precision: 2, scale: 1
+      t.integer :q8_count
+      t.decimal :q9_avg, precision: 2, scale: 1
+      t.integer :q9_count
+      t.decimal :q10_avg, precision: 2, scale: 1
+      t.integer :q10_count
+      t.decimal :q11_avg, precision: 2, scale: 1
+      t.integer :q11_count
+      t.decimal :q12_avg, precision: 2, scale: 1
+      t.integer :q12_count
+      t.decimal :q13_avg, precision: 2, scale: 1
+      t.integer :q13_count
+      t.decimal :q14_avg, precision: 2, scale: 1
+      t.integer :q14_count
+      t.decimal :q15_avg, precision: 2, scale: 1
+      t.integer :q15_count
+      t.decimal :q16_avg, precision: 2, scale: 1
+      t.integer :q16_count
+      t.decimal :q17_avg, precision: 2, scale: 1
+      t.integer :q17_count
+      t.decimal :q18_avg, precision: 2, scale: 1
+      t.integer :q18_count
+      t.decimal :q19_avg, precision: 2, scale: 1
+      t.integer :q19_count
+      t.decimal :q20_avg, precision: 2, scale: 1
+      t.integer :q20_count
+
+      t.decimal :m1_avg, precision: 2, scale: 1
+      t.decimal :m2_avg, precision: 2, scale: 1
+      t.decimal :m3_avg, precision: 2, scale: 1
+      t.decimal :m4_avg, precision: 2, scale: 1
+      t.decimal :m5_avg, precision: 2, scale: 1
+      t.decimal :m6_avg, precision: 2, scale: 1
+      t.decimal :m7_avg, precision: 2, scale: 1
+
+      t.decimal :overall_avg, precision: 2, scale: 1
+      t.integer :institution_rating_count
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_15_000914) do
+ActiveRecord::Schema.define(version: 2023_01_17_170722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
@@ -317,6 +317,147 @@ ActiveRecord::Schema.define(version: 2022_12_15_000914) do
     t.integer "institution_id"
     t.index ["description", "version"], name: "index_institution_programs_archives"
     t.index ["institution_id"], name: "index_institution_programs_archives_on_institution_id"
+  end
+
+  create_table "institution_ratings", force: :cascade do |t|
+    t.integer "institution_id"
+    t.decimal "q1_avg", precision: 2, scale: 1
+    t.integer "q1_count"
+    t.decimal "q2_avg", precision: 2, scale: 1
+    t.integer "q2_count"
+    t.decimal "q3_avg", precision: 2, scale: 1
+    t.integer "q3_count"
+    t.decimal "q4_avg", precision: 2, scale: 1
+    t.integer "q4_count"
+    t.decimal "q5_avg", precision: 2, scale: 1
+    t.integer "q5_count"
+    t.decimal "q7_avg", precision: 2, scale: 1
+    t.integer "q7_count"
+    t.decimal "q8_avg", precision: 2, scale: 1
+    t.integer "q8_count"
+    t.decimal "q9_avg", precision: 2, scale: 1
+    t.integer "q9_count"
+    t.decimal "q10_avg", precision: 2, scale: 1
+    t.integer "q10_count"
+    t.decimal "q11_avg", precision: 2, scale: 1
+    t.integer "q11_count"
+    t.decimal "q12_avg", precision: 2, scale: 1
+    t.integer "q12_count"
+    t.decimal "q13_avg", precision: 2, scale: 1
+    t.integer "q13_count"
+    t.decimal "q14_avg", precision: 2, scale: 1
+    t.integer "q14_count"
+    t.decimal "q15_avg", precision: 2, scale: 1
+    t.integer "q15_count"
+    t.decimal "q16_avg", precision: 2, scale: 1
+    t.integer "q16_count"
+    t.decimal "q17_avg", precision: 2, scale: 1
+    t.integer "q17_count"
+    t.decimal "q18_avg", precision: 2, scale: 1
+    t.integer "q18_count"
+    t.decimal "q19_avg", precision: 2, scale: 1
+    t.integer "q19_count"
+    t.decimal "q20_avg", precision: 2, scale: 1
+    t.integer "q20_count"
+    t.decimal "m1_avg", precision: 2, scale: 1
+    t.decimal "m2_avg", precision: 2, scale: 1
+    t.decimal "m3_avg", precision: 2, scale: 1
+    t.decimal "m4_avg", precision: 2, scale: 1
+    t.decimal "m5_avg", precision: 2, scale: 1
+    t.decimal "m6_avg", precision: 2, scale: 1
+    t.decimal "m7_avg", precision: 2, scale: 1
+    t.decimal "overall_avg", precision: 2, scale: 1
+    t.integer "institution_rating_count"
+    t.index ["institution_id"], name: "index_institution_ratings_on_institution_id", unique: true
+  end
+
+  create_table "institution_ratings_archives", force: :cascade do |t|
+    t.integer "institution_id"
+    t.decimal "q1_avg", precision: 2, scale: 1
+    t.integer "q1_count"
+    t.decimal "q2_avg", precision: 2, scale: 1
+    t.integer "q2_count"
+    t.decimal "q3_avg", precision: 2, scale: 1
+    t.integer "q3_count"
+    t.decimal "q4_avg", precision: 2, scale: 1
+    t.integer "q4_count"
+    t.decimal "q5_avg", precision: 2, scale: 1
+    t.integer "q5_count"
+    t.decimal "q7_avg", precision: 2, scale: 1
+    t.integer "q7_count"
+    t.decimal "q8_avg", precision: 2, scale: 1
+    t.integer "q8_count"
+    t.decimal "q9_avg", precision: 2, scale: 1
+    t.integer "q9_count"
+    t.decimal "q10_avg", precision: 2, scale: 1
+    t.integer "q10_count"
+    t.decimal "q11_avg", precision: 2, scale: 1
+    t.integer "q11_count"
+    t.decimal "q12_avg", precision: 2, scale: 1
+    t.integer "q12_count"
+    t.decimal "q13_avg", precision: 2, scale: 1
+    t.integer "q13_count"
+    t.decimal "q14_avg", precision: 2, scale: 1
+    t.integer "q14_count"
+    t.decimal "q15_avg", precision: 2, scale: 1
+    t.integer "q15_count"
+    t.decimal "q16_avg", precision: 2, scale: 1
+    t.integer "q16_count"
+    t.decimal "q17_avg", precision: 2, scale: 1
+    t.integer "q17_count"
+    t.decimal "q18_avg", precision: 2, scale: 1
+    t.integer "q18_count"
+    t.decimal "q19_avg", precision: 2, scale: 1
+    t.integer "q19_count"
+    t.decimal "q20_avg", precision: 2, scale: 1
+    t.integer "q20_count"
+    t.decimal "m1_avg", precision: 2, scale: 1
+    t.decimal "m2_avg", precision: 2, scale: 1
+    t.decimal "m3_avg", precision: 2, scale: 1
+    t.decimal "m4_avg", precision: 2, scale: 1
+    t.decimal "m5_avg", precision: 2, scale: 1
+    t.decimal "m6_avg", precision: 2, scale: 1
+    t.decimal "m7_avg", precision: 2, scale: 1
+    t.decimal "overall_avg", precision: 2, scale: 1
+    t.integer "institution_rating_count"
+  end
+
+  create_table "institution_school_ratings", force: :cascade do |t|
+    t.string "survey_key"
+    t.string "email"
+    t.string "age"
+    t.string "gender"
+    t.string "school"
+    t.string "facility_code"
+    t.string "degree"
+    t.date "graduation_date"
+    t.string "benefit_program"
+    t.string "enrollment_type"
+    t.string "monthly_payment_benefit"
+    t.string "payee_number"
+    t.string "objective_code"
+    t.date "response_date"
+    t.date "sent_date"
+    t.integer "q1"
+    t.integer "q2"
+    t.integer "q3"
+    t.integer "q4"
+    t.integer "q5"
+    t.string "q6"
+    t.integer "q7"
+    t.integer "q8"
+    t.integer "q9"
+    t.integer "q10"
+    t.integer "q11"
+    t.integer "q12"
+    t.integer "q13"
+    t.integer "q14"
+    t.integer "q15"
+    t.integer "q16"
+    t.integer "q17"
+    t.integer "q18"
+    t.integer "q19"
+    t.integer "q20"
   end
 
   create_table "institutions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description
[VFEP-347 Complete DB/migration files for CT Ratings](https://vajira.max.gov/browse/VFEP-347)
Deploy db changes related to CT Ratings to staging, then live.  This will separate db changes from code to give flexibility in case we have to revert CT Ratings code on staging for any reason.

## Original issue(s)
[VFEP-233 CT Ratings](https://vajira.max.gov/browse/VFEP-233)

## Testing done


## Screenshots


## Acceptance criteria
- migrations run successfully on staging and production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
