### PR TITLE
vfep-439 add northwest to list of regional accreditations

### DIFF
--- a/app/models/accreditation_record.rb
+++ b/app/models/accreditation_record.rb
@@ -24,9 +24,11 @@ class AccreditationRecord < ImportableRecord
   # Hybrid) to substrings in the name of the accrediting body. So, for example,
   # if the accrediting agency is the "New England Medical Association", then
   # the accreditation is 'Regional'.
+
+  # vfep-439 - add northwest
   ACCREDITATIONS = {
     'regional' => [/middle/i, /new england/i, /north central/i, /southern/i, /western/i,
-                   /higher learning commission/i, /wasc/i],
+                   /higher learning commission/i, /wasc/i, /northwest/i],
     'national' => [/career schools/i, /continuing education/i, /independent colleges/i,
                    /biblical/i, /occupational/i, /distance/i, /new york/i, /transnational/i],
     'hybrid' => [/acupuncture/i, /nursing/i, /health education/i, /liberal/i, /legal/i,

--- a/spec/factories/accreditation_records.rb
+++ b/spec/factories/accreditation_records.rb
@@ -18,6 +18,22 @@ FactoryBot.define do
       accreditation_end_date { '2000-01-01' }
     end
 
+    factory :regional_accreditation_type do
+      agency_name { 'NORTHWEST COMMISSION ON COLLEGES AND UNIVERSITIES' }
+    end
+
+    factory :national_accreditation_type do
+      agency_name { 'ACCREDITING COMMISSION OF CAREER SCHOOLS AND COLLEGES' }
+    end
+
+    factory :hybrid_accreditation_type do
+      agency_name { 'MIDWIFERY EDUCATION ACCREDITATION COUNCIL' }
+    end
+
+    factory :nil_accreditation_type do
+      agency_name { 'TRUMP U' }
+    end
+
     initialize_with do
       new(attributes)
     end

--- a/spec/models/accreditation_record_spec.rb
+++ b/spec/models/accreditation_record_spec.rb
@@ -14,9 +14,39 @@ RSpec.describe AccreditationRecord, type: :model do
     it 'has a valid factory' do
       expect(accreditation_record).to be_valid
     end
+  end
 
-    it 'determines the `accreditation_type` from the agency_name' do
-      expect(accreditation_record.accreditation_type).to eq('regional')
+  describe 'it sets the accreditation type depending on the agency name' do
+    context 'with regional accreditation' do
+      subject(:accreditation_record) { build :regional_accreditation_type }
+
+      it 'assigns regional to accreditation_type' do
+        expect(accreditation_record.accreditation_type).to eq('regional')
+      end
+    end
+
+    context 'with national accreditation' do
+      subject(:accreditation_record) { build :national_accreditation_type }
+
+      it 'assigns national to accreditation_type' do
+        expect(accreditation_record.accreditation_type).to eq('national')
+      end
+    end
+
+    context 'with hybrid accreditation' do
+      subject(:accreditation_record) { build :hybrid_accreditation_type }
+
+      it 'assigns hybrid to accreditation_type' do
+        expect(accreditation_record.accreditation_type).to eq('hybrid')
+      end
+    end
+
+    context 'with unaccreditable' do
+      subject(:accreditation_record) { build :nil_accreditation_type }
+
+      it 'does not assign an accreditation type' do
+        expect(accreditation_record.accreditation_type).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
add northwest to list of regional accreditations

## Original issue(s)
[vfep-439](https://vajira.max.gov/browse/VFEP-439)

## Testing done
RSpec tests added and passed. Rubocop passed. Developer testing passed.

## Screenshots


## Acceptance criteria
- Shows proper accreditation type for Portland Community College. Preview Generation sets the accreditation type correctly for northwest accreditations. Comparison tool shows the correct accreditation type after publishing.

## Definition of done
- [ ] Events are logged appropriately N/A
- [ ] Documentation has been updated, if applicable N/A
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub) N/A
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs N/A

