### PR TITLE
Vfep 522 - GIBCT dashboard - add ungeocodable report

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -53,9 +53,7 @@ class DashboardsController < ApplicationController
             :institution, :facility_code, :address_1, :address_2, :address_3, :city, :state,
             :zip, :physical_country, :cross, :ope
           )
-        ),
-                  type: 'text/csv',
-                  filename: 'ungeocodables.csv'
+        ), type: 'text/csv', filename: 'ungeocodables.csv'
       end
     end
   rescue ArgumentError, Common::Exceptions::RecordNotFound, ActionController::UnknownFormat => e
@@ -70,8 +68,7 @@ class DashboardsController < ApplicationController
     elsif class_name.present?
       csv = "#{class_name}::API_SOURCE".safe_constantize || "#{class_name} API"
       begin
-        api_upload = Upload.new(csv_type: class_name, user: current_user, csv: csv,
-                                comment: "#{class_name} API Request")
+        api_upload = Upload.new(csv_type: class_name, user: current_user, csv: csv, comment: "#{class_name} API Request")
         flash.notice = fetch_api_data(api_upload) if api_upload.save!
       rescue StandardError => e
         message = Common::Exceptions::ExceptionHandler.new(e, api_upload&.csv_type).serialize_error
@@ -111,7 +108,6 @@ class DashboardsController < ApplicationController
     api_upload.update(ok: populated, completed_at: Time.now.utc.to_s(:db))
 
     if populated
-
       message = "#{klass.name}::POPULATE_SUCCESS_MESSAGE".safe_constantize
       return message if message.present?
 

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -45,6 +45,23 @@ class DashboardsController < ApplicationController
     log_error(e)
   end
 
+  def export_ungeocodables
+    respond_to do |format|
+      format.csv do
+        send_data Institution.export_ungeocodables(
+          Institution.ungeocodables.pluck(
+            :institution, :facility_code, :address_1, :address_2, :address_3, :city, :state,
+            :zip, :physical_country, :cross, :ope
+          )
+        ),
+                  type: 'text/csv',
+                  filename: 'ungeocodables.csv'
+      end
+    end
+  rescue ArgumentError, Common::Exceptions::RecordNotFound, ActionController::UnknownFormat => e
+    log_error(e)
+  end
+
   def api_fetch
     class_name = CSV_TYPES_HAS_API_TABLE_NAMES.find { |csv_type| csv_type == params[:csv_type] }
 
@@ -68,6 +85,10 @@ class DashboardsController < ApplicationController
     end
 
     redirect_to dashboards_path
+  end
+
+  def geocoding_issues
+    @ungeocodables = Institution.ungeocodables
   end
 
   private

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -61,14 +61,14 @@ class DashboardsController < ApplicationController
   end
 
   def api_fetch
-    class_name = CSV_TYPES_HAS_API_TABLE_NAMES.find { |csv_type| csv_type == params[:csv_type] }
+    class_nm = CSV_TYPES_HAS_API_TABLE_NAMES.find { |csv_type| csv_type == params[:csv_type] }
 
     if Upload.fetching_for?(params[:csv_type])
       flash.alert = "#{params[:csv_type]} is already being fetched by another user"
-    elsif class_name.present?
-      csv = "#{class_name}::API_SOURCE".safe_constantize || "#{class_name} API"
+    elsif class_nm.present?
+      csv = "#{class_nm}::API_SOURCE".safe_constantize || "#{class_nm} API"
       begin
-        api_upload = Upload.new(csv_type: class_name, user: current_user, csv: csv, comment: "#{class_name} API Request")
+        api_upload = Upload.new(csv_type: class_nm, user: current_user, csv: csv, comment: "#{class_nm} API Request")
         flash.notice = fetch_api_data(api_upload) if api_upload.save!
       rescue StandardError => e
         message = Common::Exceptions::ExceptionHandler.new(e, api_upload&.csv_type).serialize_error

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -302,6 +302,15 @@ class Institution < ImportableRecord
     where(high_school: false)
   end
 
+  def self.ungeocodable_count
+    ungeocodables.count
+  end
+
+  def self.ungeocodables
+    version = Version.current_production
+    approved_institutions(version).where(latitude: nil, longitude: nil, ungeocodable: true).order(:institution)
+  end
+
   #
   # Scopes
   #

--- a/app/views/dashboards/_geocoding_issues.html.erb
+++ b/app/views/dashboards/_geocoding_issues.html.erb
@@ -1,0 +1,14 @@
+<tr class="<%= cycle('even', 'odd') -%>">
+  <td><%= ungeocodable.institution %></td>
+  <td><%= ungeocodable.facility_code %></td>
+  <td><%= ungeocodable.address_1 %></td>
+  <td><%= ungeocodable.address_2 %></td>  
+  <td><%= ungeocodable.address_3 %></td>  
+  <td><%= ungeocodable.city %></td>
+  <td><%= ungeocodable.state %></td>
+  <td><%= ungeocodable.zip %></td>
+  <td><%= ungeocodable.physical_country %></td>
+  <td><%= ungeocodable.cross %></td>
+  <td><%= ungeocodable.ope %></td>
+</tr>
+

--- a/app/views/dashboards/_issues.html.erb
+++ b/app/views/dashboards/_issues.html.erb
@@ -1,8 +1,8 @@
-<h2>Crosswalk Issues</h2>
+<h2>Issues</h2>
 <div id="crosswalk-issues-dashboard" class="row row-space-12 equal">
   <div class="col col-xs-12 col-md-6 col-lg-3">
     <div class="panel panel-default">
-      <div class="panel-heading">Partial Matches</div>
+      <div class="panel-heading">Crosswalk Partial Matches</div>
       <div class="panel-body">
         <p>Weams records that partially match IPEDS or Crosswalk records</p>
         <div>
@@ -18,7 +18,7 @@
   </div>
   <div class="col col-xs-12 col-md-6 col-lg-3">
     <div class="panel panel-default">
-      <div class="panel-heading">IPEDS Orphans</div>
+      <div class="panel-heading">Crosswalk IPEDS Orphans</div>
       <div class="panel-body">
         <p>IPEDS records without matching Crosswalk record</p>
         <div>
@@ -32,4 +32,21 @@
       </div>
     </div>
   </div>
+    <div class="col col-xs-12 col-md-6 col-lg-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">Geocoding</div>
+      <div class="panel-body">
+        <p>Institutions Unable to be Geocoded</p>
+        <div>
+        <%= link_to dashboard_geocoding_issues_path do %>
+          <button class="btn dashboard-btn-success">
+            View
+            <span class="badge"><%= Institution.ungeocodable_count %></span>
+          </button>
+        <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/app/views/dashboards/geocoding_issues.html.erb
+++ b/app/views/dashboards/geocoding_issues.html.erb
@@ -1,0 +1,27 @@
+<div class="row row-space-6" style="padding-bottom: 10px">
+  <div class="col-xs-12">
+    <h2>
+      Geocoding Issues
+      <%= link_to 'Export', dashboard_export_ungeocodables_path,
+          class: "btn dashboard-btn-success btn-xs", role: "button" %>
+    </h2>
+    <table class="table table-hover table-condensed table-bordered table-responsive crosswalk-issues">
+      <thead class="sub">
+        <th>Institution Name</th>
+        <th>Facility Code</th>
+        <th>Address 1</th>
+        <th>Address 2</th>
+        <th>Address 3</th>
+        <th>City</th>
+        <th>State</th>
+        <th>Zip</th>
+        <th>Country</th>
+        <th>IPEDS</th>
+        <th>OPE</th>
+      </thead>
+      <tbody>
+      <%= render partial: 'geocoding_issues', collection: @ungeocodables, as: :ungeocodable %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -63,7 +63,7 @@
 </div>
 
 <button id="preview_opener" class="btn dashboard-btn-warning btn-xs" <%= can_generate_preview(@preview_versions) %>>Generate and Publish a new Version</button>
-<%= render partial: 'crosswalk_issues' %>
+<%= render partial: 'issues' %>
 
 <h2>Latest Uploads
   <%= link_to 'View Upload History', uploads_path, class: "btn dashboard-btn-info btn-xs", role: "button" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   get '/dashboards/export/:csv_type' => 'dashboards#export', as: :dashboard_export, defaults: { format: 'csv' }
   get '/dashboards/api_fetch/:csv_type' => 'dashboards#api_fetch', as: :dashboard_api_fetch
   get '/dashboards/export/institutions/:number' => 'dashboards#export_version', as: :dashboard_export_version, defaults: { format: 'csv' }
-  
+  get '/dashboards/export_ungeocodables' => 'dashboards#export_ungeocodables', as: :dashboard_export_ungeocodables, defaults: { format: 'csv' }
+  get '/dashboards/geocoding_issues' => 'dashboards#geocoding_issues', as: :dashboard_geocoding_issues
+
   resources :uploads, except: [:new, :destroy, :edit, :update] do
     get '(:csv_type)' => 'uploads#new', on: :new, as: ''
   end

--- a/lib/common/exporter.rb
+++ b/lib/common/exporter.rb
@@ -17,6 +17,14 @@ module Common
       end
     end
 
+    def export_ungeocodables(ungeocodables)
+      ungeocodables.prepend(
+        ['Institution', 'Facility Code', 'Address 1', 'Address 2', 'Address 3', 'City', 'State',
+         'Zip', 'Country', 'IPED', 'OPE']
+      )
+      generate_csv(ungeocodables)
+    end
+
     private
 
     def defaults

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DashboardsController, type: :controller do
   end
 
   it_behaves_like 'an authenticating controller', :index, 'dashboards'
-  #it_behaves_like 'an authenticating controller', :ungeocodables, 'dashboards'
 
   def load_table(klass)
     csv_name = "#{klass.name.underscore}.csv"

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -343,5 +343,11 @@ FactoryBot.define do
       country { 'UNITED KINGDOM' }
       zip { nil }
     end
+
+    trait :ungeocodable do
+      longitude { nil }
+      latitude { nil }
+      ungeocodable { true }
+    end
   end
 end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -346,4 +346,24 @@ RSpec.describe Institution, type: :model do
       expect(institution.physical_address).to eq(nil)
     end
   end
+
+  context 'when reporting on ungeocodables' do
+    before do
+      create(:version, :production)
+      create(:institution, :location, :lat_long)
+      create(:institution, :foreign_bad_address, :ungeocodable)
+
+      # rubocop:disable Rails/SkipsModelValidations
+      described_class.update_all version_id: Version.first.id
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    it 'returns ungeocodable institutions for #ungeocodables' do
+      expect(described_class.ungeocodables.size).to eq(1)
+    end
+
+    it 'returns a count of ungeocodable institutions for #ungeocodable_count' do
+      expect(described_class.ungeocodable_count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Description
Vfep 522 - GIBCT dashboard - add ungeocodable report

## Original issue(s)
[vfep-522](https://vajira.max.gov/browse/VFEP-522)

## Testing done
rspec, rubocop, developer user testing

## Screenshots


## Acceptance criteria
- ungeocodable report can be run from gibct dashboard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
