### PR TITLE
Vfep 583 - clean up references in code to current preview where appropriate, update readme, fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Institutions have a one to many relationship with their associated degree progra
 ### Institution Versioning
 Much of the data in the gibct-data-service is used to build instances of institutions to display relevant data to users of the comparison tool for particular institutions. Since the data comes in as various CSV types to build these institution objects, a versioning system is necessary to ensure the correct data is being used when building the institution objects and only approved information is released to production. As mentioned in the "Data Modes and Versions" section above, there are versioned preview and production modes of the institutions that are built from the data in the uploaded CSVs. 
 
-To generate a new version you must first upload any CSVs that contain changes that you wish to see in the new version of institutions being built. After you are satisfied with what has been uploaded, you must generate a new version by clicking "Generate New Version" on the GIBCT Dashboard. This will increment the version and build a new preview data set by running active record queries on the various data using [app/models/institution_builder.rb](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/master/app/models/institution_builder.rb) and produce the new institution objects. You will receive a success message when this is complete.
+To generate a new version you must first upload any CSVs that contain changes that you wish to see in the new version of institutions being built. After you are satisfied with what has been uploaded, you must generate a new version by clicking "Generate New Version" on the GIBCT Dashboard. This will increment the version and build new version data by running active record queries on the various data using [app/models/institution_builder.rb](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/master/app/models/institution_builder.rb) and produce the new institution objects. You will receive a success message when this is complete.
 
  You can view the data contained in the new version by exporting the Institutions CSV by clicking the yellow "Download Export CSV" button in the "Latest Version" table. A CSV download should begin producing a file with the naming convention of `institutions_version_x.csv` where x is the version number. If any additional CSVs need to be modified, you will need to upload them as necessary and generate another version.
 
@@ -207,7 +207,7 @@ All versioned data is archived using corresponding archive objects except for ca
  - ZipcodeRatesArchive
  - InstitutionsArchive
  - InstitutionRatingsArchive
-When a new version is created, the objects and their data in the current version are saved in the archive tables. The archived objects exist in case there is a reason to check what a previous version contained. At the moment there is no current way to roll back to previous versions, but this information can be accessed by querying the database(s) as necessary.
+When a new version is created, the objects and their data in the previous version are saved in the archive tables. The archived objects exist in case there is a reason to check what a previous version contained. At the moment there is no current way to roll back to previous versions, but this information can be accessed by querying the database(s) as necessary.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,20 @@ the `vets-api` and `vets-website` applications.
 
 ### Data Modes and Versions
 GIDS profile data is logically partitioned in two modes: **preview** mode and **production** mode. In preview mode the
-data retrieved via the API has not yet been approved by the VA Education Stakeholders. In contrast, production mode is
-the actual data pushed to **GIBCT** for public consumption.
+data retrieved via the API has not yet been completely processed and built out by the InstitutionBuilder model. In 
+contrast, production mode is the actual data pushed to **GIBCT** for public consumption.
+
+Originally, this used to be two steps as generating a preview could take 15+ hours. After some code refactoring, in particual
+carrying forward the geocoding information from insititutions that didn't change their address since the last preview was
+generated, this time was reduced to less than 15 minutes. Sometimes generating a **preview** can take less than 30 seconds.
+
+After discussions with the user(s), it was determined that it made sense to go ahead and combine generating a preview and
+publishing the results to **GIBCT**. The code was refactored to do this and provide a running status to the user on the 
+Dashboard page until the job is completed. It runs via an asynchronous job.
+
+Accordingly, the version's status is **preview** only until the job completes successfully. A decision was made to keep the
+**preview** status because while the version is generating, the public data should still be pointing to the old **production**
+version. Also, various checks while the version is generating check for the status of the version to process accordingly.
 
 ### Primary User Flow
 Institution profile data is synthesized from separate CSVs maintained by various federal sources. Once the CSVs are
@@ -174,13 +186,11 @@ Institutions have a one to many relationship with their associated degree progra
 ### Institution Versioning
 Much of the data in the gibct-data-service is used to build instances of institutions to display relevant data to users of the comparison tool for particular institutions. Since the data comes in as various CSV types to build these institution objects, a versioning system is necessary to ensure the correct data is being used when building the institution objects and only approved information is released to production. As mentioned in the "Data Modes and Versions" section above, there are versioned preview and production modes of the institutions that are built from the data in the uploaded CSVs. 
 
-To generate a new preview version you must first upload any CSVs that contain changes that you wish to see in the new version of institutions being built. After you are satisfied with what has been uploaded, you must generate a new preview version by clicking "Generate New Preview Version" under the "Latest Preview Version" header on the GIBCT Dashboard. This will increment the preview version and build a new preview data set by running active record queries on the various data using [app/models/institution_builder.rb](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/master/app/models/institution_builder.rb) and produce the new institution objects. You will receive a success message when this is complete.
+To generate a new version you must first upload any CSVs that contain changes that you wish to see in the new version of institutions being built. After you are satisfied with what has been uploaded, you must generate a new version by clicking "Generate New Version" on the GIBCT Dashboard. This will increment the version and build a new preview data set by running active record queries on the various data using [app/models/institution_builder.rb](https://github.com/department-of-veterans-affairs/gibct-data-service/blob/master/app/models/institution_builder.rb) and produce the new institution objects. You will receive a success message when this is complete.
 
+ You can view the data contained in the new version by exporting the Institutions CSV by clicking the yellow "Download Export CSV" button in the "Latest Version" table. A CSV download should begin producing a file with the naming convention of `institutions_version_x.csv` where x is the version number. If any additional CSVs need to be modified, you will need to upload them as necessary and generate another version.
 
-
- You can view the data contained in the new preview version by exporting the Institutions CSV by clicking the yellow "Download Export CSV" button in the "Latest Preview Version" table. A CSV download should begin producing a file with the naming convention of `institutions_version_x.csv` where x is the preview version number. If any additional CSVs need to be modified, you will need to upload them as necessary and generate another preview version.
-
-The preview version will not be made available to the comparison tool until it is published as a production version. To publish the latest preview version as a production version, click the red "Publish to Production" button in the Latest Preview Version. Note: this will only publish the version in the environment you are working in, for example running the GIBCT service locally and publishing a preview version will not affect the staging or production environments. To check the content of the new production version you can export the Institutions CSV by clicking the yellow "Download Export CSV" button in the "Latest Production Version" table which will produce a file with the same naming convention described above.
+Note: this will only generate the version in the environment you are working in, for example running the GIBCT service locally and generating a version will not affect the staging or production environments. To check the content of the new production version you can export the Institutions CSV by clicking the yellow "Download Export CSV" button in the "Latest Version" table which will produce a file with the same naming convention described above.
 
 ### Additional Versioning. 
 In addition to the versioned institution objects, the gibct-data-service uses versioning to keep track of other objects used in the comparison tool. These include:
@@ -188,7 +198,7 @@ In addition to the versioned institution objects, the gibct-data-service uses ve
  - School Certifying Officials: Contact information for the School's Certifying Officials
  - Zipcode Rates: Location specific payment rates.
  - Caution Flags: Warning messages specific to individual institutions.
-When generating a new preview or production version using the GIBCT, these objects are also versioned.
+When generating a new version using the GIBCT, these objects are also versioned.
 
 ### Archived Data
 All versioned data is archived using corresponding archive objects except for caution flags
@@ -197,7 +207,7 @@ All versioned data is archived using corresponding archive objects except for ca
  - ZipcodeRatesArchive
  - InstitutionsArchive
  - InstitutionRatingsArchive
-When a new preview version is created, the objects and their data in the current preview version are saved in the archive tables. The archived objects exist in case there is a reason to check what a previous version contained. At the moment there is no current way to roll back to previous versions, but this information can be accessed by querying the database(s) as necessary.
+When a new version is created, the objects and their data in the current version are saved in the archive tables. The archived objects exist in case there is a reason to check what a previous version contained. At the moment there is no current way to roll back to previous versions, but this information can be accessed by querying the database(s) as necessary.
 
 ## How to Contribute
 

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -5,8 +5,7 @@ class DashboardsController < ApplicationController
     @uploads = Upload.last_uploads_rows
     @production_versions = Version.production.newest.includes(:user).limit(1)
     @preview_versions = Version.preview.newest.includes(:user).limit(1)
-    @latest_uploads = Upload.since_last_preview_version
-    @aws_loc = (production? ? 'Publish to Production' : 'Publish to Staging')
+    @latest_uploads = Upload.since_last_version
     flash_progress_if_needed
   end
 

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module DashboardsHelper
+  include CommonInstitutionBuilder::VersionGeneration
+
   def latest_upload_class(upload)
     return '' if upload.ok?
     return 'danger' if UPLOAD_TYPES_REQUIRED_NAMES.include?(upload.csv_type)
@@ -22,7 +24,7 @@ module DashboardsHelper
     pgsi = PreviewGenerationStatusInformation.last
     return 'disabled' unless
       pgsi.nil? ||
-      pgsi.current_progress.start_with?('Preview generated and published') ||
+      pgsi.current_progress.start_with?(PUBLISH_COMPLETE_TEXT) ||
       pgsi.current_progress.start_with?('There was an error')
   end
 
@@ -40,7 +42,7 @@ module DashboardsHelper
     completed = false
 
     pgsi = PreviewGenerationStatusInformation.last
-    if pgsi.current_progress.start_with?('Preview generated and published') ||
+    if pgsi.current_progress.start_with?(PUBLISH_COMPLETE_TEXT) ||
        pgsi.current_progress.start_with?('There was an error')
       completed = true
       PreviewGenerationStatusInformation.delete_all

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -77,12 +77,12 @@ class Upload < ApplicationRecord
     uploads.sort_by { |upload| upload.csv_type.downcase }
   end
 
-  def self.since_last_preview_version
-    last_preview = Version.current_preview || Version.current_production
+  def self.since_last_version
+    last_version = Version.current_production
 
-    return Upload.last_uploads if last_preview.blank?
+    return Upload.last_uploads if last_version.blank?
 
-    Upload.last_uploads.where('updated_at > ?', last_preview.updated_at)
+    Upload.last_uploads.where('updated_at > ?', last_version.updated_at)
   end
 
   def self.from_csv_type(csv_type)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -29,25 +29,16 @@ class Version < ApplicationRecord
     Version.production.newest.second
   end
 
+  # We want to keep this method because the version is not status 'production' until
+  # all steps are successfully completed.
   def self.current_preview
     cp = preview.newest
     cp = cp.where('created_at > ?', current_production.created_at) if current_production
     cp.first
   end
 
-  def self.prior_preview_ids
-    previews = preview.order(:id)
-    return nil unless previews
-
-    previews.ids[0..-2]
-  end
-
   def self.latest
     Version.newest.first
-  end
-
-  def self.previews_exist?
-    Version.newest.first.preview?
   end
 
   def self.archived
@@ -63,10 +54,6 @@ class Version < ApplicationRecord
 
   def generating?
     preview? && completed_at.nil?
-  end
-
-  def publishable?
-    !generating? && number > Version.production.maximum(:number)
   end
 
   def current_preview?

--- a/app/views/dashboards/_version.html.erb
+++ b/app/views/dashboards/_version.html.erb
@@ -12,15 +12,6 @@
           class: "btn dashboard-btn-success btn-xs", role: "button" %>
       <%= link_to 'Download Export CSV', dashboard_export_version_path(version.number),
           class: "btn dashboard-btn-warning btn-xs", role: "button" %>
-      <% if version.publishable? && version.geocoded %>
-        <%= link_to @aws_loc, dashboard_push_path, method: :post,
-            data: { confirm: "Are you sure you wish to publish preview version #{version.number} to #{production? ? 'production' : 'staging'}?" },
-            class: "btn dashboard-btn-danger btn-xs",
-            role: "button",
-            id: "version_publish" %>
-      <% elsif version.preview? %>
-          <a class="btn dashboard-btn-danger btn-xs" disabled role="button"><%= @aws_loc %></a>
-      <% end %>
     <% end %>
   </td>
 </tr>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,13 +18,4 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
-set :job_template, nil
-
-every 1.day, at: '4:30 pm' do
-  command "sudo su - -c 'docker exec -it gi-bill-data-service bash'"
-  command 'source config/.env.sh'
-  command 'nohup rake fix_coord_mismatch & exit'
-  command "sudo su - -c 'docker exec -it gi-bill-data-service tail -f nohup.out'"
-end
-
-
+#set :job_template, nil

--- a/lib/common_institution_builder/version_generation.rb
+++ b/lib/common_institution_builder/version_generation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CommonInstitutionBuilder
+  module VersionGeneration
+    PUBLISH_COMPLETE_TEXT = 'Version generated and published'
+  end
+end

--- a/lib/tasks/fix_coord_mismatch.rake
+++ b/lib/tasks/fix_coord_mismatch.rake
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-desc 'task to update any mistmached coordinates with geocoder gem.'
-task fix_coord_mismatch: :environment do
-  version = Version.current_preview
-  search_geocoder = SearchGeocoder.new(version) if version.present? && version.geocoded == false
-  search_geocoder.process_geocoder_address if search_geocoder.by_address.present?
-end

--- a/spec/factories/preview_generation_status_informations.rb
+++ b/spec/factories/preview_generation_status_informations.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     trait :complete do
-      current_progress { 'Preview generated and published' }
+      current_progress { CommonInstitutionBuilder::VersionGeneration::PUBLISH_COMPLETE_TEXT }
     end
 
     trait :complete_error do

--- a/spec/models/institution_builder_spec.rb
+++ b/spec/models/institution_builder_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe InstitutionBuilder, type: :model do
         expect(version).not_to be_generating
       end
 
-      it 'writes "Preview generated and published" to the log' do
+      it "writes '#{CommonInstitutionBuilder::VersionGeneration::PUBLISH_COMPLETE_TEXT}' to the log" do
         allow(Rails.logger).to receive(:info)
         run_institution_builder(user)
-        expect(Rails.logger).to have_received(:info).with(/Preview\sgenerated\sand\spublished/).at_least(:once)
+        expect(Rails.logger).to have_received(:info).with(/Version\sgenerated\sand\spublished/).at_least(:once)
       end
 
       it 'does not write "error" to the log' do
@@ -1020,44 +1020,6 @@ RSpec.describe InstitutionBuilder, type: :model do
       expect(institution2.version_id).to eq(Version.current_production.id)
       expect(institution2.longitude).not_to eq(39.14)
       expect(institution2.latitude).not_to eq(-75.09)
-    end
-  end
-
-  describe 'when generating a preview version' do
-    # Rubocop flags you for too many let clauses
-    def create_preview_version
-      old_preview_version = create(:version, :preview)
-      institution = create(:institution)
-      institution.caution_flags << create(:caution_flag, :accreditation_issue)
-      institution.versioned_school_certifying_officials << create(:versioned_school_certifying_official)
-      institution.yellow_ribbon_programs << create(:yellow_ribbon_program)
-      institution.institution_rating = build(:institution_rating)
-      old_preview_version.institutions << institution
-      old_preview_version.zipcode_rates << create(:zipcode_rate)
-      old_preview_version.save
-      old_preview_version
-    end
-
-    it 'deletes any existing preview versions (not published)' do
-      old_preview_version = create_preview_version
-      Institution.where(version_id: nil).delete_all # clear out cruft institutions
-      expect(CautionFlag.count).to eq(1)
-      expect(VersionedSchoolCertifyingOfficial.count).to eq(1)
-      expect(YellowRibbonProgram.count).to eq(1)
-      expect(InstitutionRating.count).to eq(1)
-      expect(Institution.count).to eq(1)
-      expect(ZipcodeRate.count).to eq(1)
-
-      run_institution_builder(user)
-
-      # Note the syntax here
-      expect { Version.find(old_preview_version.id) }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect(CautionFlag.count).to eq(0)
-      expect(VersionedSchoolCertifyingOfficial.count).to eq(0)
-      expect(YellowRibbonProgram.count).to eq(0)
-      expect(InstitutionRating.count).to eq(0)
-      expect(Institution.count).to eq(0)
-      expect(ZipcodeRate.count).to eq(0)
     end
   end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -83,17 +83,15 @@ RSpec.describe Upload, type: :model do
     end
 
     it 'returns all uploads if preview is blank' do
-      expect(described_class.since_last_preview_version.any?).to eq(true)
+      expect(described_class.since_last_version.any?).to eq(true)
     end
 
-    it 'returns uploads after preview' do
-      create :version, :preview
+    it 'returns uploads since the last version was generated' do
       described_class.where(csv_type: 'Weam')[1].update(ok: true)
-      create :version, :production, number: Version.current_preview.number
-      create :version, :preview
+      create :version, :production
       described_class.where(csv_type: 'Crosswalk')[1].update(ok: true)
-      expect(described_class.since_last_preview_version.map(&:csv_type)).to include('Crosswalk')
-      expect(described_class.since_last_preview_version.map(&:csv_type)).not_to include('Weam')
+      expect(described_class.since_last_version.map(&:csv_type)).to include('Crosswalk')
+      expect(described_class.since_last_version.map(&:csv_type)).not_to include('Weam')
     end
   end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Version, type: :model do
         expect(version).to be_production
         expect(version).not_to be_preview
         expect(version).not_to be_latest_preview
-        expect(version).not_to be_publishable
       end
     end
 
@@ -100,7 +99,6 @@ RSpec.describe Version, type: :model do
         expect(version).not_to be_production
         expect(version).to be_preview
         expect(version).to be_latest_preview
-        expect(version).not_to be_publishable
       end
     end
   end
@@ -123,7 +121,6 @@ RSpec.describe Version, type: :model do
         expect(version).not_to be_production
         expect(version).to be_preview
         expect(version).to be_latest_preview
-        expect(version).to be_publishable
       end
     end
   end


### PR DESCRIPTION
## Description
Vfep 583 - clean up references in code to current preview where appropriate, update readme, fix tests

## Original issue(s)
[vfep-583](https://jira.devops.va.gov/browse/VFEP-583)

## Testing done
Rspec, rubocop, developer user tests

## Screenshots


## Acceptance criteria
- generating a new version on gibct dashboard still works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
