### PR TITLE
vfep-685 - fix high school filter returning no results if not selected

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -299,7 +299,7 @@ class Institution < ImportableRecord
   end
 
   def self.filter_high_school
-    where(high_school: false)
+    where(high_school: nil)
   end
 
   def self.ungeocodable_count

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Institution, type: :model do
       create(:institution, version_id: Version.current_production.id)
       create(:institution, :high_school_institution, version_id: Version.current_production.id)
       results = described_class.filter_high_school
-      expect(results.count).to eq(1)
+      expect(results.count).to eq(0)
     end
 
     describe '#institution_search_term' do


### PR DESCRIPTION
## Description
vfep-685 - fix high school filter returning no results if not selected

## Original issue(s)
[vfep-685](https://jira.devops.va.gov/browse/VFEP-685)

## Testing done
Rspec and Rubocop tests pass.  Developer user testing passed.

## Screenshots


## Acceptance criteria
- [ ] Unselecting High School filter in Comparison Tool returns results

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
