### PR TITLE
Vfep 677 - add ability to export Crosswalk Partials and Orphans reports

### DIFF
--- a/app/controllers/crosswalk_issues_controller.rb
+++ b/app/controllers/crosswalk_issues_controller.rb
@@ -2,9 +2,7 @@
 
 class CrosswalkIssuesController < ApplicationController
   def partials
-    @issues = CrosswalkIssue.includes(:crosswalk, :ipeds_hd, weam: :arf_gi_bill)
-                            .by_issue_type(CrosswalkIssue::PARTIAL_MATCH_TYPE)
-                            .order('arf_gi_bills.gibill desc nulls last, weams.institution, weams.facility_code')
+    @issues = CrosswalkIssue.partials
   end
 
   def show_partial
@@ -32,9 +30,7 @@ class CrosswalkIssuesController < ApplicationController
   end
 
   def orphans
-    @issues = CrosswalkIssue.includes(%i[weam crosswalk ipeds_hd])
-                            .by_issue_type(CrosswalkIssue::IPEDS_ORPHAN_TYPE)
-                            .order('ipeds_hds.institution')
+    @issues = CrosswalkIssue.orphans
   end
 
   private

--- a/app/models/crosswalk.rb
+++ b/app/models/crosswalk.rb
@@ -17,6 +17,7 @@ class Crosswalk < ImportableRecord
   validates :facility_code, presence: true
   after_initialize :derive_dependent_columns
 
+  # Instance methods
   def derive_dependent_columns
     self.ope6 = Ope6Converter.convert(ope)
   end

--- a/app/models/crosswalk_issue.rb
+++ b/app/models/crosswalk_issue.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CrosswalkIssue < ApplicationRecord
+  include RooHelper
+
   PARTIAL_MATCH_TYPE = 'PARTIAL_MATCH_TYPE'
   IPEDS_ORPHAN_TYPE = 'IPEDS_ORPHAN_TYPE'
 

--- a/app/views/crosswalk_issues/orphans.html.erb
+++ b/app/views/crosswalk_issues/orphans.html.erb
@@ -1,6 +1,10 @@
 <div class="row row-space-6" style="padding-bottom: 10px">
   <div class="col-xs-12">
-    <h3>Ipeds issues</h3>
+    <h3>
+      Ipeds issues
+        <%= link_to 'Export', dashboard_export_orphans_path,
+          class: "btn dashboard-btn-success btn-xs", role: "button" %>
+    </h3>
     <table class="table table-hover table-condensed table-bordered table-responsive crosswalk-issues">
       <thead class="system-header">
         <th colspan="3">IPEDS HD</th>

--- a/app/views/crosswalk_issues/partials.html.erb
+++ b/app/views/crosswalk_issues/partials.html.erb
@@ -1,6 +1,10 @@
 <div class="row row-space-6" style="padding-bottom: 10px">
   <div class="col-xs-12">
-    <h2>Issues</h2>
+    <h2>
+      Issues
+              <%= link_to 'Export', dashboard_export_partials_path,
+          class: "btn dashboard-btn-success btn-xs", role: "button" %>
+    </h2>
     <table class="table table-hover table-condensed table-bordered table-responsive crosswalk-issues">
       <thead class="system-header">
         <th colspan="1">ArfGiBill</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get '/dashboards/api_fetch/:csv_type' => 'dashboards#api_fetch', as: :dashboard_api_fetch
   get '/dashboards/export/institutions/:number' => 'dashboards#export_version', as: :dashboard_export_version, defaults: { format: 'csv' }
   get '/dashboards/export_ungeocodables' => 'dashboards#export_ungeocodables', as: :dashboard_export_ungeocodables, defaults: { format: 'csv' }
+  get '/dashboards/export_orphans' => 'dashboards#export_orphans', as: :dashboard_export_orphans, defaults: { format: 'csv' }
+  get '/dashboards/export_partials' => 'dashboards#export_partials', as: :dashboard_export_partials, defaults: { format: 'csv' }
   get '/dashboards/geocoding_issues' => 'dashboards#geocoding_issues', as: :dashboard_geocoding_issues
 
   resources :uploads, except: [:new, :destroy, :edit, :update] do

--- a/lib/common/exporter.rb
+++ b/lib/common/exporter.rb
@@ -25,6 +25,21 @@ module Common
       generate_csv(ungeocodables)
     end
 
+    def export_partials(partials)
+      partials.prepend(
+        ['# GI Bill Students', 'Institution Name', 'Facility code', 'Weams IPEDS', 'Weams OPE', 'Ipeds IPEDS', 'Ipeds OPE',
+          'Crosswalk IPEDS', 'Crosswalk OPE']
+      )
+      generate_csv(partials)
+    end
+
+    def export_orphans(orphans)
+      orphans.prepend(
+        ['Institution Name', 'IPEDS', 'OPE']
+      )
+      generate_csv(orphans)
+    end
+
     private
 
     def defaults

--- a/lib/common/exporter.rb
+++ b/lib/common/exporter.rb
@@ -27,16 +27,14 @@ module Common
 
     def export_partials(partials)
       partials.prepend(
-        ['# GI Bill Students', 'Institution Name', 'Facility code', 'Weams IPEDS', 'Weams OPE', 'Ipeds IPEDS', 'Ipeds OPE',
-          'Crosswalk IPEDS', 'Crosswalk OPE']
+        ['# GI Bill Students', 'Institution Name', 'Facility code', 'Weams IPEDS', 'Weams OPE', 'Ipeds IPEDS',
+         'Ipeds OPE', 'Crosswalk IPEDS', 'Crosswalk OPE']
       )
       generate_csv(partials)
     end
 
     def export_orphans(orphans)
-      orphans.prepend(
-        ['Institution Name', 'IPEDS', 'OPE']
-      )
+      orphans.prepend(['Institution Name', 'IPEDS', 'OPE'])
       generate_csv(orphans)
     end
 

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -250,4 +250,42 @@ RSpec.describe DashboardsController, type: :controller do
       expect(get(:export_ungeocodables, params: { format: :xml })).to redirect_to(action: :index)
     end
   end
+
+  describe 'GET #export_orphans' do
+    login_user
+
+    it 'causes a CSV to be exported' do
+      allow(CrosswalkIssue).to receive(:export_orphans)
+      get(:export_orphans, params: { format: :csv })
+      expect(CrosswalkIssue).to have_received(:export_orphans)
+    end
+
+    it 'includes filename parameter in content-disposition header' do
+      get(:export_orphans, params: { format: :csv })
+      expect(response.headers['Content-Disposition']).to include('filename="orphans.csv"')
+    end
+
+    it 'redirects to index on error' do
+      expect(get(:export_orphans, params: { format: :xml })).to redirect_to(action: :index)
+    end
+  end
+
+  describe 'GET #export_partials' do
+    login_user
+
+    it 'causes a CSV to be exported' do
+      allow(CrosswalkIssue).to receive(:export_partials)
+      get(:export_partials, params: { format: :csv })
+      expect(CrosswalkIssue).to have_received(:export_partials)
+    end
+
+    it 'includes filename parameter in content-disposition header' do
+      get(:export_partials, params: { format: :csv })
+      expect(response.headers['Content-Disposition']).to include('filename="partials.csv"')
+    end
+
+    it 'redirects to index on error' do
+      expect(get(:export_partials, params: { format: :xml })).to redirect_to(action: :index)
+    end
+  end
 end


### PR DESCRIPTION
Vfep 677 - add ability to export Crosswalk Partials and Orphans reports

[VFEP-677](https://jira.devops.va.gov/browse/VFEP-677)
[VFEP-678](https://jira.devops.va.gov/browse/VFEP-678)

## Testing done
RSpec and Rubocop tests pass.  Developer user testing passed.

## Screenshots


## Acceptance criteria
- [ ] Export buttons display on dashboard Crosswalk reports, correctly export data to csv/spreadsheets

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
