### PR TITLE
vfep-641 - handle new case object format for complaints spreadsheet upload

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -181,7 +181,6 @@ class DashboardsController < ApplicationController
     Zip::File.open('tmp/download.zip') do |zip_file|
       zip_file.each do |f|
         f_path = File.join('tmp', f.name)
-        FileUtils.mkdir_p(File.dirname(f_path))
         File.delete(f_path) if File.exist?(f_path)
         zip_file.extract(f, f_path)
       end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -181,6 +181,7 @@ class DashboardsController < ApplicationController
     Zip::File.open('tmp/download.zip') do |zip_file|
       zip_file.each do |f|
         f_path = File.join('tmp', f.name)
+        FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
         File.delete(f_path) if File.exist?(f_path)
         zip_file.extract(f, f_path)
       end

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -17,7 +17,6 @@
 
 class Complaint < ImportableRecord
   STATUSES = %w[active closed pending reserved].freeze
-  CLOSED_REASONS = ['resolved', 'invalid', 'information only', 'no response', 'unresolved'].freeze
 
   # COMPLAINT_COLUMNS contain substrings in each complaint that identify the type of complaint. There may
   # be several types of complaints for each campus (facility code), and institution (ope6). FAC_CODE_SUMS map the
@@ -64,25 +63,23 @@ class Complaint < ImportableRecord
 
   CSV_CONVERTER_INFO = {
     'case_id' => { column: :case_id, converter: BaseConverter },
-    'level' => { column: :level, converter: BaseConverter },
+    'escalation_level' => { column: :level, converter: BaseConverter },
     'status' => { column: :status, converter: DowncaseConverter },
     'case_owner' => { column: :case_owner, converter: BaseConverter },
-    'school' => { column: :institution, converter: InstitutionConverter },
+    'school_name' => { column: :institution, converter: InstitutionConverter },
     'opeid' => { column: :ope, converter: OpeConverter },
     'facility_code' => { column: :facility_code, converter: FacilityCodeConverter },
     'school_city' => { column: :city, converter: BaseConverter },
-    'school_state' => { column: :state, converter: BaseConverter },
-    'submitted' => { column: :submitted, converter: BaseConverter },
-    'closed' => { column: :closed, converter: BaseConverter },
-    'closed_reason' => { column: :closed_reason, converter: DowncaseConverter },
-    'issues' => { column: :issues, converter: BaseConverter },
-    'education_benefits' => { column: :education_benefits, converter: BaseConverter }
+    'school_state' => { column: :state, converter: StateConverter },
+    'date/time_opened' => { column: :submitted, converter: DateTimeConverter },
+    'date_closed' => { column: :closed, converter: DateConverter },
+    'sub_status' => { column: :closed_reason, converter: DowncaseConverter },
+    'issue' => { column: :issues, converter: BaseConverter },
+    'va_education_program' => { column: :education_benefits, converter: BaseConverter }
   }.freeze
 
   validates :facility_code, presence: true
   validates :status, inclusion: { in: STATUSES }
-  validates :closed_reason, inclusion: { in: CLOSED_REASONS }, allow_blank: true
-
   after_initialize :derive_dependent_columns
 
   def derive_dependent_columns

--- a/lib/common/exporter.rb
+++ b/lib/common/exporter.rb
@@ -27,9 +27,7 @@ module Common
 
     def export_partials(partials)
       partials.each do |p|
-        p[4] = format_ope(p[4])
-        p[6] = format_ope(p[6])
-        p[8] = format_ope(p[8])
+        [4, 6, 8].each { |ii| p[ii] = format_ope(p[ii]) }
       end
 
       partials.prepend(

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe Complaint, type: :model do
       expect(complaint_bad_status).not_to be_valid
     end
 
-    it 'must have a valid closed_reason' do
-      expect(complaint_bad_reason).not_to be_valid
-    end
-
     it 'computes the ope6 from the ope' do
       expect(complaint.ope6).to eql(complaint.ope[1, 5])
     end


### PR DESCRIPTION
## Description
vfep-641 - handle new case object format for complaints spreadsheet upload

## Original issue(s)
[vfep-641](https://jira.devops.va.gov/browse/VFEP-641)

## Testing done
RSpec and Rubocop tests passed.  Developer user tests passed.

## Screenshots


## Acceptance criteria
- [ ]  new CASE Object format for the Complaints spreadsheet uploads without errors.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
