### PR TITLE
Add ability to enable disabled fetch buttons

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -241,6 +241,11 @@ table.crosswalk-issues thead.sub th {
   background-color: #dd5050;
 }
 
+.dashboard-btn-aligned-right {
+  float: right;
+  margin-right: 50px;
+}
+
 .archives .even:not(:hover) td {
     background-color: #f3f3ff;
 }

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -10,6 +10,7 @@ class ApiController < ApplicationController
 
   private
 
+  # :nocov:
   def page
     Integer(params[:page] || '1')
   rescue ArgumentError
@@ -21,6 +22,7 @@ class ApiController < ApplicationController
   rescue ArgumentError
     nil
   end
+  # :nocov:
 
   # Newest production data version assumed when version param is undefined
   def resolve_version

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -100,6 +100,16 @@ class DashboardsController < ApplicationController
     @ungeocodables = Institution.ungeocodables
   end
 
+  def unlock_fetches
+    if Upload.unlock_fetches
+      flash.notice = 'All fetches have been unlocked'
+    else
+      flash.alert = 'Unlocking fetches failed'
+    end
+
+    redirect_to dashboards_path
+  end
+
   private
 
   def log_error(error)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -54,4 +54,8 @@ module DashboardsHelper
 
     completed
   end
+
+  def locked_fetches_exist?
+    Upload.locked_fetches_exist?
+  end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -95,4 +95,12 @@ class Upload < ApplicationRecord
   def self.fetching_for?(csv_type)
     Upload.where(ok: false, completed_at: nil, csv_type: csv_type).any?
   end
+
+  def self.unlock_fetches
+    where(ok: false).update(ok: true)
+  end
+
+  def self.locked_fetches_exist?
+    where(ok: false).any?
+  end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -67,6 +67,9 @@
 
 <h2>Latest Uploads
   <%= link_to 'View Upload History', uploads_path, class: "btn dashboard-btn-info btn-xs", role: "button" %>
+  <% if locked_fetches_exist? %>
+    <%= link_to 'Enable locked Fetches', unlock_fetches_path, class: "btn dashboard-btn-info dashboard-btn-aligned-right btn-xs", role: "button" %>
+  <% end %>
 </h2>
 <div class="row row-space-6" id="latest_uploads">
   <div class="col-xs-12">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get '/dashboards/export_orphans' => 'dashboards#export_orphans', as: :dashboard_export_orphans, defaults: { format: 'csv' }
   get '/dashboards/export_partials' => 'dashboards#export_partials', as: :dashboard_export_partials, defaults: { format: 'csv' }
   get '/dashboards/geocoding_issues' => 'dashboards#geocoding_issues', as: :dashboard_geocoding_issues
+  get '/unlock_fetches' => 'dashboards#unlock_fetches', as: :unlock_fetches
 
   resources :uploads, except: [:new, :destroy, :edit, :update] do
     get '(:csv_type)' => 'uploads#new', on: :new, as: ''

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -288,4 +288,29 @@ RSpec.describe DashboardsController, type: :controller do
       expect(get(:export_partials, params: { format: :xml })).to redirect_to(action: :index)
     end
   end
+
+  describe 'GET #unlock_fetches' do
+    login_user
+
+    it 'redirects to the index page on completion' do
+      expect(get(:unlock_fetches, params: { format: :html })).to redirect_to(action: :index)
+    end
+
+    it 'unlocks all fetches' do
+      create(:upload, :failed_upload)
+      expect(Upload.locked_fetches_exist?).to eq(true)
+      get(:unlock_fetches, params: { format: :html })
+      expect(Upload.locked_fetches_exist?).to eq(false)
+      expect(flash[:notice]).to match(/All fetches have been unlocked/)
+    end
+
+    it 'flashes an error message if unlocking fails' do
+      allow(Upload).to receive(:unlock_fetches).and_return(false)
+      create(:upload, :failed_upload)
+      expect(Upload.locked_fetches_exist?).to eq(true)
+      get(:unlock_fetches, params: { format: :html })
+      expect(Upload.locked_fetches_exist?).to eq(true)
+      expect(flash[:alert]).to match(/Unlocking fetches failed/)
+    end
+  end
 end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -65,5 +65,12 @@ FactoryBot.define do
       csv_name { 'census_lat_long.csv' }
       ok { true }
     end
+
+    trait :failed_upload do
+      csv_type { Scorecard.name }
+      csv { Scorecard.name }
+      ok { false }
+      completed_at { nil }
+    end
   end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -104,4 +104,16 @@ RSpec.describe DashboardsHelper, type: :helper do
       expect(helper.preview_generation_completed?).to eq(true)
     end
   end
+
+  describe 'locked_fetches_exist?' do
+    it 'returns true if there are failed fetches' do
+      create(:upload, :failed_upload)
+      expect(helper.locked_fetches_exist?).to eq(true)
+    end
+
+    it 'returns false if there are failed fetches' do
+      create(:upload, :valid_upload)
+      expect(helper.locked_fetches_exist?).to eq(false)
+    end
+  end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -102,4 +102,20 @@ RSpec.describe Upload, type: :model do
       expect(upload.skip_lines).to eq(0)
     end
   end
+
+  describe 'failed fetches (which locks the fetch button)' do
+    before do
+      create(:upload, :failed_upload)
+    end
+
+    it 'returns true if there are locked fetches' do
+      expect(described_class.locked_fetches_exist?).to eq(true)
+    end
+
+    it '#unlock_fetches removes locked fetches' do
+      expect(described_class.locked_fetches_exist?).to eq(true)
+      described_class.unlock_fetches
+      expect(described_class.locked_fetches_exist?).to eq(false)
+    end
+  end
 end

--- a/spec/views/dashboards/index.html.erb_spec.rb
+++ b/spec/views/dashboards/index.html.erb_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'dashboards/index', type: :view do
+  before do # set the instance variables from the controller before the view is rendered or tests fail
+    @production_versions = Version.production.newest.includes(:user).limit(1)
+    @preview_versions = Version.preview.newest.includes(:user).limit(1)
+    @latest_uploads = Upload.since_last_version
+  end
+
+  it 'does not show the button if there are no failed fetches' do
+    create(:upload, :valid_upload)
+    render
+    expect(rendered).not_to match(/Enable locked Fetches/)
+  end
+
+  it 'shows the button if there are failed fetches' do
+    create(:upload, :failed_upload)
+    render
+    expect(rendered).to match(/Enable locked Fetches/)
+  end
+end


### PR DESCRIPTION
## Description
The 'Fetch' button gets disabled when an API fetch to a remote site fails. The user is unable to retry as the button is disabled. The purpose of this release is to remediate that.

## Original issue(s)
[VFEP-654](https://jira.devops.va.gov/browse/VFEP-654)

## Testing done
Sandbox testing and RSpec tests performed and working as expected.

## Screenshots


## Acceptance criteria
- [x] The user is able to click the 'Enable locked Fetches' button and the disabled 'Fetch' buttons are enabled and the user is able to click them and they function as expected.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
