### PR TITLE
Vfep 761- add 100+ fields to Scorecard so it matches manual upload, fix blank AccreditationAction action dates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,7 @@ Metrics/MethodLength:
     - "lib/roo_helper/loader.rb"
     - "lib/seed_utils.rb"
     - "app/utilities/scorecard_api/service.rb"
+    - "app/models/converters/accreditation_date_time_converter.rb"
 
 Metrics/ClassLength:
   Exclude:
@@ -184,6 +185,7 @@ Metrics/PerceivedComplexity:
     - "app/controllers/v1/institutions_controller.rb"
     - "app/validators/va_caution_flag_validator.rb"
     - "lib/roo_helper/loader.rb"
+    - "app/models/converters/accreditation_date_time_converter.rb"
 
 # Don't worry about ambiguous blocks in RSpec
 # Official recommendation from rubocop team is to disable this rule for specs.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,6 +141,7 @@ Metrics/ClassLength:
     - "app/models/institution_builder.rb"
     - "app/controllers/v1/institutions_controller.rb"
     - "app/serializers/institution_compare_serializer.rb"
+    - "app/utilities/scorecard_api/service.rb"
 
 Metrics/AbcSize:
   Max: 40

--- a/app/models/converters/accreditation_date_time_converter.rb
+++ b/app/models/converters/accreditation_date_time_converter.rb
@@ -17,7 +17,11 @@ class AccreditationDateTimeConverter < BaseConverter
 
       # Accreditation Date format
       when value.is_a?(String) && value.length > 10
-        date = DateTime.strptime(value, '%m/%d/%Y %H:%M:%S %p').to_date
+        begin
+          date = DateTime.strptime(value, '%m/%d/%Y %H:%M:%S %p').to_date
+        rescue ArgumentError
+          date = DateTime.strptime(value, '%m/%d/%Y %H:%M').to_date
+        end
       when value.is_a?(String)
         begin
           date = DateTime.strptime(value, '%Y-%m-%d').to_date

--- a/app/models/converters/accreditation_date_time_converter.rb
+++ b/app/models/converters/accreditation_date_time_converter.rb
@@ -19,7 +19,11 @@ class AccreditationDateTimeConverter < BaseConverter
       when value.is_a?(String) && value.length > 10
         date = DateTime.strptime(value, '%m/%d/%Y %H:%M:%S %p').to_date
       when value.is_a?(String)
-        date = DateTime.strptime(value, '%Y-%m-%d').to_date
+        begin
+          date = DateTime.strptime(value, '%Y-%m-%d').to_date
+        rescue ArgumentError
+          date = DateTime.strptime(value, '%m/%d/%Y').to_date
+        end
       end
       # rubocop:enable Style/EmptyCaseCondition
 

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -142,7 +142,7 @@ class Scorecard < ImportableRecord
     'md_earn_wne_p10' => { column: :salary_all_students, converter: NumberConverter },
     'gt_25k_p6' => { column: :gt_25k_p6, converter: NumberConverter },
     'grad_debt_mdn_supp' => { column: :avg_stu_loan_debt, converter: NumberConverter },
-    'grad_debt_mdn10yr_supp' => { column: :avg_stu_loan_debt, converter: NumberConverter },
+    'grad_debt_mdn10yr_supp' => { column: :grad_debt_mdn10yr_supp, converter: NumberConverter },
     'rpy_3yr_rt_supp' => { column: :repayment_rate_all_students, converter: NumberConverter },
     'c150_4_pooled_supp' => { column: :c150_4_pooled_supp, converter: NumberConverter },
     'c150_l4_pooled_supp' => { column: :c150_l4_pooled_supp, converter: NumberConverter },

--- a/app/utilities/scorecard_api/service.rb
+++ b/app/utilities/scorecard_api/service.rb
@@ -103,7 +103,7 @@ module ScorecardApi
         'latest.student.demographics.race_ethnicity.two_or_more': :ugds_2mor,
         'latest.student.demographics.race_ethnicity.non_resident_alien': :ugds_nra,
         'latest.student.demographics.race_ethnicity.unknown': :ugds_unkn,
-        'latest.student.part_time_share': :pptug_ef,
+        'latest.student.part_time_share': :pptugi_ef,
         'school.operating': :curroper,
         'latest.cost.avg_net_price.public': :npt4_pub,
         'latest.cost.avg_net_price.private': :npt4_priv,
@@ -131,8 +131,7 @@ module ScorecardApi
         'latest.repayment.3_yr_repayment_suppressed.overall': :repayment_rate_all_students,
         'latest.completion.rate_suppressed.four_year': :c150_4_pooled_supp,
         'latest.completion.rate_suppressed.lt_four_year_150percent': :c150_l4_pooled_supp,
-        'school.alias': :alias
-      }.freeze
+        'school.alias': :alias }.freeze
     end
 
     def self.populate
@@ -160,18 +159,20 @@ module ScorecardApi
     def self.map_results(results)
       results.map do |result|
         scorecard = Scorecard.new
-        result.each_pair { |key, value|
+
+        result.each_pair do |key, value|
           key = restore_key_hyphen(key.to_s) if key.to_s.include?('latest.cost.net_price.public.by_income_level') ||
                                                 key.to_s.include?('latest.cost.net_price.private.by_income_level')
-          scorecard[api_mappings[key]] = value 
-        }
+          scorecard[api_mappings[key]] = value
+        end
+
         scorecard.derive_dependent_columns
         scorecard
       end
     end
 
     def self.restore_key_hyphen(key_string)
-      key_string.reverse.sub('_','-').reverse.to_sym
+      key_string.reverse.sub('_', '-').reverse.to_sym
     end
   end
 end

--- a/app/utilities/scorecard_api/service.rb
+++ b/app/utilities/scorecard_api/service.rb
@@ -63,9 +63,15 @@ module ScorecardApi
     end
 
     def self.map_results(results)
+      idx = 0
       results.map do |result|
+        idx += 1
         scorecard = Scorecard.new
-        result.each_pair { |key, value| scorecard[api_mappings[key]] = value }
+        result.each_pair { |key, value|
+
+puts "key: #{key}, value: #{value}\n" if idx < 2
+           scorecard[api_mappings[key]] = value 
+        }
         scorecard.derive_dependent_columns
         scorecard
       end

--- a/app/utilities/scorecard_api/service.rb
+++ b/app/utilities/scorecard_api/service.rb
@@ -12,30 +12,127 @@ module ScorecardApi
       { id: :cross,
         ope8_id: :ope,
         ope6_id: :ope6,
-        'latest.aid.federal_loan_rate': :pctfloan,
-        'latest.aid.median_debt_suppressed.completers.overall': :avg_stu_loan_debt,
-        'latest.completion.rate_suppressed.four_year': :c150_4_pooled_supp,
-        'latest.completion.rate_suppressed.lt_four_year_150percent': :c150_l4_pooled_supp,
-        'latest.earnings.10_yrs_after_entry.median': :salary_all_students,
-        'latest.repayment.3_yr_repayment_suppressed.overall': :repayment_rate_all_students,
-        'latest.student.retention_rate.four_year.full_time': :retention_all_students_ba,
-        'latest.student.retention_rate.lt_four_year.full_time': :retention_all_students_otb,
-        'latest.student.size': :undergrad_enrollment,
+        'school.name': :institution,
+        'school.city': :city,
+        'school.state': :state,
         'school.school_url': :insturl,
+        'school.price_calculator_url': :npcurl,
+        'school.under_investigation': :hcm2,
         'school.degrees_awarded.predominant': :pred_degree_awarded,
+        'school.ownership': :control,
         'school.locale': :locale,
         'school.minority_serving.historically_black': :hbcu,
+        'school.minority_serving.predominantly_black': :pbi,
+        'school.minority_serving.annh': :annhi,
+        'school.minority_serving.tribal': :tribal,
+        'school.minority_serving.aanipi': :aanapii,
+        'school.minority_serving.hispanic': :hsi,
+        'school.minority_serving.nant': :nanti,
         'school.men_only': :menonly,
         'school.women_only': :womenonly,
         'school.religious_affiliation': :relaffil,
-        'school.minority_serving.hispanic': :hsi,
-        'school.minority_serving.nant': :nanti,
-        'school.minority_serving.annh': :annhi,
-        'school.minority_serving.aanipi': :aanapii,
-        'school.minority_serving.predominantly_black': :pbi,
-        'school.minority_serving.tribal': :tribal,
-        'school.under_investigation': :hcm2,
-        'school.alias': :alias }.freeze
+        'latest.admissions.sat_scores.25th_percentile.critical_reading': :satvr25,
+        'latest.admissions.sat_scores.75th_percentile.critical_reading': :satvr75,
+        'latest.admissions.sat_scores.25th_percentile.math': :satmt25,
+        'latest.admissions.sat_scores.75th_percentile.math': :satmt75,
+        'latest.admissions.sat_scores.25th_percentile.writing': :satwr25,
+        'latest.admissions.sat_scores.75th_percentile.writing': :satwr75,
+        'latest.admissions.sat_scores.midpoint.critical_reading': :satvrmid,
+        'latest.admissions.sat_scores.midpoint.math': :satmtmid,
+        'latest.admissions.sat_scores.midpoint.writing': :satwrmid,
+        'latest.admissions.act_scores.25th_percentile.cumulative': :actcm25,
+        'latest.admissions.act_scores.75th_percentile.cumulative': :actcm75,
+        'latest.admissions.act_scores.25th_percentile.english': :acten25,
+        'latest.admissions.act_scores.75th_percentile.english': :acten75,
+        'latest.admissions.act_scores.25th_percentile.math': :actmt25,
+        'latest.admissions.act_scores.75th_percentile.math': :actmt75,
+        'latest.admissions.act_scores.25th_percentile.writing': :actwr25,
+        'latest.admissions.act_scores.75th_percentile.writing': :actwr75,
+        'latest.admissions.act_scores.midpoint.cumulative': :actcmmid,
+        'latest.admissions.act_scores.midpoint.english': :actenmid,
+        'latest.admissions.act_scores.midpoint.math': :actmtmid,
+        'latest.admissions.act_scores.midpoint.writing': :actwrmid,
+        'latest.admissions.sat_scores.average.overall': :sat_avg,
+        'latest.admissions.sat_scores.average.by_ope_id': :sat_avg_all,
+        'latest.academics.program_percentage.agriculture': :pcip01,
+        'latest.academics.program_percentage.resources': :pcip03,
+        'latest.academics.program_percentage.architecture': :pcip04,
+        'latest.academics.program_percentage.ethnic_cultural_gender': :pcip05,
+        'latest.academics.program_percentage.communication': :pcip09,
+        'latest.academics.program_percentage.communications_technology': :pcip10,
+        'latest.academics.program_percentage.computer': :pcip11,
+        'latest.academics.program_percentage.personal_culinary': :pcip12,
+        'latest.academics.program_percentage.education': :pcip13,
+        'latest.academics.program_percentage.engineering': :pcip14,
+        'latest.academics.program_percentage.engineering_technology': :pcip15,
+        'latest.academics.program_percentage.language': :pcip16,
+        'latest.academics.program_percentage.family_consumer_science': :pcip19,
+        'latest.academics.program_percentage.legal': :pcip22,
+        'latest.academics.program_percentage.english': :pcip23,
+        'latest.academics.program_percentage.humanities': :pcip24,
+        'latest.academics.program_percentage.library': :pcip25,
+        'latest.academics.program_percentage.biological': :pcip26,
+        'latest.academics.program_percentage.mathematics': :pcip27,
+        'latest.academics.program_percentage.military': :pcip29,
+        'latest.academics.program_percentage.multidiscipline': :pcip30,
+        'latest.academics.program_percentage.parks_recreation_fitness': :pcip31,
+        'latest.academics.program_percentage.philosophy_religious': :pcip38,
+        'latest.academics.program_percentage.theology_religious_vocation': :pcip39,
+        'latest.academics.program_percentage.physical_science': :pcip40,
+        'latest.academics.program_percentage.science_technology': :pcip41,
+        'latest.academics.program_percentage.psychology': :pcip42,
+        'latest.academics.program_percentage.security_law_enforcement': :pcip43,
+        'latest.academics.program_percentage.public_administration_social_service': :pcip44,
+        'latest.academics.program_percentage.social_science': :pcip45,
+        'latest.academics.program_percentage.construction': :pcip46,
+        'latest.academics.program_percentage.mechanic_repair_technology': :pcip47,
+        'latest.academics.program_percentage.precision_production': :pcip48,
+        'latest.academics.program_percentage.transportation': :pcip49,
+        'latest.academics.program_percentage.visual_performing': :pcip50,
+        'latest.academics.program_percentage.health': :pcip51,
+        'latest.academics.program_percentage.business_marketing': :pcip52,
+        'latest.academics.program_percentage.history': :pcip54,
+        'school.online_only': :distanceonly,
+        'latest.student.size': :undergrad_enrollment,
+        'latest.student.demographics.race_ethnicity.white': :ugds_white,
+        'latest.student.demographics.race_ethnicity.black': :ugds_black,
+        'latest.student.demographics.race_ethnicity.hispanic': :ugds_hisp,
+        'latest.student.demographics.race_ethnicity.asian': :ugds_asian,
+        'latest.student.demographics.race_ethnicity.aian': :ugds_aian,
+        'latest.student.demographics.race_ethnicity.nhpi': :ugds_nhpi,
+        'latest.student.demographics.race_ethnicity.two_or_more': :ugds_2mor,
+        'latest.student.demographics.race_ethnicity.non_resident_alien': :ugds_nra,
+        'latest.student.demographics.race_ethnicity.unknown': :ugds_unkn,
+        'latest.student.part_time_share': :pptug_ef,
+        'school.operating': :curroper,
+        'latest.cost.avg_net_price.public': :npt4_pub,
+        'latest.cost.avg_net_price.private': :npt4_priv,
+        'latest.cost.net_price.public.by_income_level.0-30000': :npt41_pub,
+        'latest.cost.net_price.public.by_income_level.30001-48000': :npt42_pub,
+        'latest.cost.net_price.public.by_income_level.48001-75000': :npt43_pub,
+        'latest.cost.net_price.public.by_income_level.75001-110000': :npt44_pub,
+        'latest.cost.net_price.public.by_income_level.110001-plus': :npt45_pub,
+        'latest.cost.net_price.private.by_income_level.0-30000': :npt41_priv,
+        'latest.cost.net_price.private.by_income_level.30001-48000': :npt42_priv,
+        'latest.cost.net_price.private.by_income_level.48001-75000': :npt43_priv,
+        'latest.cost.net_price.private.by_income_level.75001-110000': :npt44_priv,
+        'latest.cost.net_price.private.by_income_level.110001-plus': :npt45_priv,
+        'latest.aid.pell_grant_rate': :pctpell,
+        'latest.student.retention_rate.four_year.full_time': :retention_all_students_ba,
+        'latest.student.retention_rate.lt_four_year.full_time': :retention_all_students_otb,
+        'latest.student.retention_rate.four_year.part_time': :ret_pt4,
+        'latest.student.retention_rate.lt_four_year.part_time': :ret_ptl4,
+        'latest.aid.federal_loan_rate': :pctfloan,
+        'latest.student.share_25_older': :ug25abv,
+        'latest.earnings.10_yrs_after_entry.median': :salary_all_students,
+        'latest.earnings.6_yrs_after_entry.percent_greater_than_25000': :gt_25k_p6,
+        'latest.aid.median_debt_suppressed.completers.overall': :avg_stu_loan_debt,
+        'latest.aid.median_debt_suppressed.completers.monthly_payments': :grad_debt_mdn10yr_supp,
+        'latest.repayment.3_yr_repayment_suppressed.overall': :repayment_rate_all_students,
+        'latest.completion.rate_suppressed.four_year': :c150_4_pooled_supp,
+        'latest.completion.rate_suppressed.lt_four_year_150percent': :c150_l4_pooled_supp,
+        'school.alias': :alias
+      }.freeze
     end
 
     def self.populate
@@ -43,9 +140,7 @@ module ScorecardApi
       response_body = schools_api_call(0) #  call for page 0 to get initial @total
       results.push(*response_body[:results])
       number_of_pages = (response_body[:metadata][:total] / MAX_PAGE_SIZE).to_f.ceil
-
       (1..number_of_pages).each { |page_num| results.push(*schools_api_call(page_num)[:results]) }
-
       map_results(results)
     end
 
@@ -63,18 +158,20 @@ module ScorecardApi
     end
 
     def self.map_results(results)
-      idx = 0
       results.map do |result|
-        idx += 1
         scorecard = Scorecard.new
         result.each_pair { |key, value|
-
-puts "key: #{key}, value: #{value}\n" if idx < 2
-           scorecard[api_mappings[key]] = value 
+          key = restore_key_hyphen(key.to_s) if key.to_s.include?('latest.cost.net_price.public.by_income_level') ||
+                                                key.to_s.include?('latest.cost.net_price.private.by_income_level')
+          scorecard[api_mappings[key]] = value 
         }
         scorecard.derive_dependent_columns
         scorecard
       end
+    end
+
+    def self.restore_key_hyphen(key_string)
+      key_string.reverse.sub('_','-').reverse.to_sym
     end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,4 +27,8 @@ workers 3
 #
 worker_timeout 60
 
+if ENV['RACK_ENV'] == 'development'
+  worker_timeout 3600
+end
+
 preload_app!

--- a/lib/scorecard_api/configuration.rb
+++ b/lib/scorecard_api/configuration.rb
@@ -23,6 +23,7 @@ module ScorecardApi
         conn.response :json_parser
 
         conn.adapter Faraday.default_adapter
+
       end
     end
   end

--- a/lib/scorecard_api/configuration.rb
+++ b/lib/scorecard_api/configuration.rb
@@ -23,7 +23,6 @@ module ScorecardApi
         conn.response :json_parser
 
         conn.adapter Faraday.default_adapter
-
       end
     end
   end

--- a/spec/models/converters/accreditation_date_time_converter_spec.rb
+++ b/spec/models/converters/accreditation_date_time_converter_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe AccreditationDateTimeConverter do
 
   it 'converts timestamp strings to date' do
     expect(described_class.convert('4/17/2017 00:00:01 AM')).to eq(Date.parse('April 17, 2017'))
+    expect(described_class.convert('4/17/2017 00:00')).to eq(Date.parse('April 17, 2017'))
   end
 
   it 'converts date strings to date' do
     expect(described_class.convert('2017-04-17')).to eq(Date.parse('April 17, 2017'))
+    expect(described_class.convert('04/17/2017')).to eq(Date.parse('April 17, 2017'))
   end
 
   it 'converts datetimes to dates' do


### PR DESCRIPTION
## Description
Vfep 761- add 100+ fields to Scorecard so it matches manual upload, fix blank AccreditationAction action dates

## Original issue(s)
[vfep-761 - add fields to Scorecard](https://jira.devops.va.gov/browse/VFEP-761)
[vfep-771 - fix action date](https://jira.devops.va.gov/browse/VFEP-771)

## Testing done
Rspec, rubocop, developer user testing pass.

## Acceptance criteria
- [ ] when uploading an AccreditationAction spreadsheet that Brian saved, then exporting it, the action dates are populated.
- [ ] when fetching the scorecard spreadsheet, then exporting, it contains 123 fields/columns 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
