### PR TITLE
Revert "Bump puma from 5.6.5 to 5.6.7 (#1000)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.2.2'
 # Application server: Puma
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
-gem 'puma', '~> 5.6.7'
+gem 'puma', '~> 5.6.4'
 gem 'rails', '~> 6.1.7.4'
 
 # Gems with special version/repo needs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
     public_suffix (5.0.1)
-    puma (5.6.7)
+    puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
@@ -498,7 +498,7 @@ DEPENDENCIES
   parallel_tests
   pg
   pry-nav
-  puma (~> 5.6.7)
+  puma (~> 5.6.4)
   rack (>= 2.2.3.1)
   rack-cors
   rails (~> 6.1.7.4)

--- a/spec/models/search_geocoder_spec.rb
+++ b/spec/models/search_geocoder_spec.rb
@@ -196,8 +196,8 @@ RSpec.describe SearchGeocoder, type: :model do
       geocoder.process_geocoder_address
 
       # addresses get combined into address[0], address[1] and address[2] behave as expected
-      expect(Institution.first.latitude.round(2)).to eq(39.0)
-      expect(Institution.first.longitude.round(2)).to be_between(-77.20, -77.15)
+      expect(Institution.first.latitude.round(2)).to eq(38.9890174.round(2))
+      expect(Institution.first.longitude.round(2)).to eq(-77.149411.round(2))
     end
 
     it 'geocodes foreign address in bad_address logic if unable to geocode by address lines' do


### PR DESCRIPTION
This reverts commit e1bfa3f938d0d9d78f6c19d3bbc256886c0a1da3.

## Description

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
