### PR TITLE
vfep-847: Modify sql not to override cross, ope & ope6 with crosswalk data if it's already there

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -156,8 +156,13 @@ module InstitutionBuilder
     def self.add_crosswalk(version_id)
       log_info_status 'Updating Crosswalk information'
 
+      # Weams should be the source of truth if it contains any Crosswalk data for
+      # the fields cross, ope & ope6 (derived from ope). Do not overrwrite with
+      # data from the crosswalks table.
       str = <<-SQL
         institutions.facility_code = crosswalks.facility_code
+        and institutions.cross is null
+        and institutions.ope   is null
       SQL
       add_columns_for_update(version_id, Crosswalk, str)
 

--- a/app/models/weam.rb
+++ b/app/models/weam.rb
@@ -23,6 +23,8 @@ class Weam < ImportableRecord
     'educational institution is approved for chapter 31 only'
   ].freeze
 
+  # vfep-847 Add cross, ope & ope6 to the list of columns used. cross is a postgresql
+  # keyword and must be escaped to work properly
   COLS_USED_IN_INSTITUTION = %i[
     facility_code institution city state zip
     high_school address_1 address_2 address_3
@@ -33,6 +35,7 @@ class Weam < ImportableRecord
     physical_city physical_state physical_zip physical_country
     dod_bah online_only distance_learning approved preferred_provider stem_indicator
     campus_type parent_facility_code_id institution_search in_state_tuition_information
+    ope ope6 "cross"
   ].freeze
 
   # Used by loadable and (TODO) will be used with added include: true|false when building data.csv

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -140,6 +140,7 @@ FactoryBot.define do
 
     trait :institution_builder do
       facility_code { '1ZZZZZZZ' }
+      ope {}
       poo_status { 'aprvd' }
       applicable_law_code { 'educational institution is approved for all chapters' }
       state { 'NY' }
@@ -148,6 +149,7 @@ FactoryBot.define do
     end
 
     trait :weam_builder do
+      ope {}
       poo_status { 'aprvd' }
       applicable_law_code { 'educational institution is approved for all chapters' }
       state { 'NY' }


### PR DESCRIPTION
## Description
The original functionality of the Institution Builder is/was to override the crosswalk data in the institutions table regardless if it was populated from the weams table.

As per the user (Brian Grubb) this is not correct and weams data should be used if it is there.

Accordingly, the SQL was modified to work this way. One test was created to prove this and 3 or 4 were refactored.

## Testing done
RSpec & Sandbox testing completed satisfactorily.


## Acceptance criteria
- [x ] Weams crosswalk data takes precedence over Crosswalk data if it's present.

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
        https://github.com/department-of-veterans-affairs/gibct-data-service/issues/1009
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
