### PR TITLE
vfep-1075: fix error when searching a name that is nil (split error)

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -562,8 +562,8 @@ class Institution < ImportableRecord
       # checks text field for a state and country else uses the state/country in filter
       # added step that makes sure it won't return results where the state field is null
       if filter_args.first == 'name'
-        state_country_search = query['name'].split(',')
-        if state_country_search.length > 1
+        state_country_search = query['name'].split(',') if query['name'].present?
+        if state_country_search
           # tests cover this, but SimpleCov doesn't pick it up
           # :nocov:
           if state_country_search[1].present?


### PR DESCRIPTION
## Description
vfep-1075: fix error when searching a name that is nil (split error)

## Original issue(s)
[vfep-1075](https://jira.dev.ops.va.gov/browse/VFEP-1075)

## Testing done
Developer user testing, searched with nil name and error no longer exists.

## Acceptance criteria
- [ ]  error when searching with nil name no longer throws an error

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
