### PR TITLE
vfep-1088: fix apostrophe in state field that is causing search errors

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -568,15 +568,15 @@ class Institution < ImportableRecord
           # :nocov:
           if state_country_search[1].present?
             state = state_country_search[1].upcase.strip
-            filters << "state = '#{state}'"
-            filters << "physical_state = '#{state}'"
+            filters << "state = '#{state.gsub("'", "''")}'"
+            filters << "physical_state = '#{state.gsub("'", "''")}'"
             filters << 'state IS NOT NULL'
             filters << 'physical_state IS NOT NULL'
           end
           if state_country_search[2].present?
             country = state_country_search[2].upcase.strip
-            filters << "country = '#{country}'"
-            filters << "physical_country = '#{country}'"
+            filters << "country = '#{country.gsub("'", "''")}'"
+            filters << "physical_country = '#{country.gsub("'", "''")}'"
             filters << 'country IS NOT NULL'
             filters << 'physical_country IS NOT NULL'
           end


### PR DESCRIPTION
## Description
vfep-1088: fix apostrophe in state field that is causing search errors

## Original issue(s)
[vfep-1088](https://jira.devops.va.gov/browse/VFEP-1088)

## Testing done
developer user testing, put an apostrophe in name search and error no longer occurs

## Acceptance criteria
- [x] enter name with apostrophe (eg. james, o'conner, smith) in Name search, no longer errors out

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
