### PR TITLE
vfep-1111/1093 - disable upload buttons for 2 spreadsheets

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -66,4 +66,8 @@ module DashboardsHelper
       .pluck(:keyword_match)
       .join(', ')
   end
+
+  def disable_upload?(upload)
+    CSV_TYPES_NO_UPLOAD_TABLE_NAMES.include?(upload.csv_type)
+  end
 end

--- a/app/views/dashboards/_latest_upload.html.erb
+++ b/app/views/dashboards/_latest_upload.html.erb
@@ -15,12 +15,23 @@
                     id: "api_fetch_" + upload.csv_type,
                     disabled: cannot_fetch_api(upload.csv_type) %>
       <% end %>
+
       <% if GROUP_FILE_TYPES_NAMES.include?(upload.csv_type) %>
-        <%= link_to 'Upload', new_group_path(upload.csv_type),
-                    class: "btn dashboard-btn-success btn-xs", role: "button" %>
+        <% if disable_upload?(upload) %>
+          <span class="btn dashboard-btn-success btn-xs disabled">Upload</span>
+        <% else %>
+          <%= link_to 'Upload', new_group_path(upload.csv_type),
+                  class: "btn dashboard-btn-success btn-xs", 
+                  role: "button" %>
+        <% end %>          
       <% else %>
-        <%= link_to 'Upload', new_upload_path(upload.csv_type),
-                    class: "btn dashboard-btn-success btn-xs", role: "button" %>
+        <% if disable_upload?(upload) %>
+          <span class="btn dashboard-btn-success btn-xs disabled">Upload</span>
+        <% else %>
+          <%= link_to 'Upload', new_upload_path(upload.csv_type),
+                  class: "btn dashboard-btn-success btn-xs", 
+                  role: "button" %>
+        <% end %>            
       <% end %>
 
       <% if upload.ok? %>

--- a/config/initializers/csv_types.rb
+++ b/config/initializers/csv_types.rb
@@ -3,7 +3,7 @@ CSV_TYPES_TABLES = [
   { klass: AccreditationInstituteCampus, required?: true, has_api?: true, no_api_key?: true },
   { klass: AccreditationRecord, required?: true, has_api?: true, no_api_key?: true },
   { klass: ArfGiBill, required?: true },
-  { klass: CipCode, required?: false },
+  { klass: CipCode, required?: false, no_upload?: true },
   { klass: Complaint, required?: true },
   { klass: Crosswalk, required?: true },
   { klass: EightKey, required?: true },
@@ -31,7 +31,7 @@ CSV_TYPES_TABLES = [
   { klass: Sec103, required?: false },
   { klass: VaCautionFlag, required?: false },
   { klass: Post911Stat, required?: false },
-  { klass: VrrapProvider, required?: false },
+  { klass: VrrapProvider, required?: false, no_upload?: true },
   { klass: InstitutionOwner, required?: false },
   { klass: InstitutionSchoolRating, required?: false },
   { klass: Section1015, required?: false }
@@ -39,4 +39,5 @@ CSV_TYPES_TABLES = [
 
 CSV_TYPES_HAS_API_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:has_api?] }.map { |table| table[:klass].name }.freeze
 CSV_TYPES_NO_API_KEY_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:no_api_key?] }.map { |table| table[:klass].name }.freeze
+CSV_TYPES_NO_UPLOAD_TABLE_NAMES = CSV_TYPES_TABLES.select { |table| table[:no_upload?] }.map { |table| table[:klass].name }.freeze
 CSV_TYPES_ALL_TABLES_CLASSES = CSV_TYPES_TABLES.map { |table| table[:klass] }.freeze

--- a/spec/config/initializers/csv_types_spec.rb
+++ b/spec/config/initializers/csv_types_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe 'CSV_TYPES' do
     end
   end
 
+  describe 'has_no_upload_table_names' do
+    it 'contains tables' do
+      CSV_TYPES_TABLES.each do |upload_type|
+        if upload_type[:no_upload?]
+          expect(CSV_TYPES_NO_UPLOAD_TABLE_NAMES).to include(klass_name(upload_type))
+        else
+          expect(CSV_TYPES_NO_UPLOAD_TABLE_NAMES).not_to include(klass_name(upload_type))
+        end
+      end
+    end
+  end
+
   describe 'fields checks' do
     CSV_TYPES_TABLES.each do |upload|
       it "#{klass_name(upload)} csv type config has_api? is a boolean" do


### PR DESCRIPTION
## Description
vfep-1111/1093 - disable upload buttons for 2 spreadsheets

## Original issue(s)
[vfep-1111](https://jira.devops.va.gov/browse/VFEP-1111)
[vfep-1093](https://jira.devops.va.gov/browse/VFEP-1093)

## Testing done
developer testing, RSpec, Rubocop tests passed


## Acceptance criteria
- [x]  CipCode and VrrapProvider spreadsheets have the Upload button disabled

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
