### PR TITLE
vfep-1202: fix database timeout issue on dashboard

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -83,6 +83,8 @@ module InstitutionBuilder
       build_messages = {}
       begin
         Institution.transaction do
+          # to fix 'cancelling statement due to statement timeout' issue
+          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '120s';")
           if staging?
             # Skipping validation here because of the scale of this query (it will timeout updating all 70k records)
             # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
## Description
vfep-1202: fix database timeout issue on dashboard

## Original issue(s)
[vfep-1202](https://jira.devops.va.gov/browse/VFEP-1202)

## Testing done
Developer user testing passes.  Rspec & Rubocop tests pass.

## Acceptance criteria
- [x] can generate a new preview without errors

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
