### PR TITLE
Update bundler 2.4.10 -> 2.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--", "./docker-entrypoint.sh"]
 ###
 FROM development AS builder
 
-ENV BUNDLER_VERSION='2.4.10'
+ENV BUNDLER_VERSION='2.5.7'
 
 ARG bundler_opts
 COPY --chown=gi-bill-data-service:gi-bill-data-service . .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,4 +533,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.10
+   2.5.7

--- a/spec/config/docker_spec.rb
+++ b/spec/config/docker_spec.rb
@@ -7,7 +7,7 @@ describe 'Docker' do
     let(:locked_bundle_version) do
       # seems to be depreciated with ruby version upgrade
       # Bundler::Definition.build('Gemfile', nil, {}).locked_bundler_version
-      '2.4.10'
+      '2.5.7'
     end
 
     it 'in Dockerfile' do


### PR DESCRIPTION
## Description
Update bundler 2.4.10 -> 2.5.7

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79339 (though this ticket was related to bumping it in "new" dockerfile (WIP)
