### PR TITLE
vfep-1263: Database Migrations for Rails 7, gem updates for ruby 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,16 @@ gem 'rails', '~> 6.1.7.7'
 # JSON API
 gem 'active_model_serializers', '~> 0.10.14'
 
+gem 'base64', '~> 0.2.0' # ruby 3.4.0 warning said to add
 gem 'bcrypt', '~> 3.1.20'
 # Use cancancan for authorization
 gem 'cancancan', '~> 1.13', '>= 1.13.1'
+gem 'csv', '~> 3.3' # ruby 3.4.0 warning said to add
+gem 'drb', '~> 2.2', '>= 2.2.1' # ruby 3.4.0 warning said to add
 gem 'geocoder', '~> 1.3', '>= 1.3.7'
 gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'json', '>= 2.3.0'
+gem 'mutex_m', '~> 0.2.0' # ruby 3.4.0 warning said to add
 # Use postgresql as the database for Active Record
 gem 'nokogiri', '~> 1.16.3'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
     bindex (0.8.1)
@@ -128,6 +129,7 @@ GEM
     config (5.4.0)
       deep_merge (~> 1.2, >= 1.2.1)
     crass (1.0.6)
+    csv (3.3.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -146,6 +148,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.1)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.4.6)
@@ -228,6 +231,7 @@ GEM
     minitest (5.22.3)
     multi_json (1.15.0)
     multipart-post (2.4.0)
+    mutex_m (0.2.0)
     nenv (0.3.0)
     net-imap (0.4.10)
       date
@@ -466,6 +470,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.14)
   activerecord-import
   activerecord-session_store
+  base64 (~> 0.2.0)
   bcrypt (~> 3.1.20)
   brakeman
   bundler-audit
@@ -473,8 +478,10 @@ DEPENDENCIES
   cancancan (~> 1.13, >= 1.13.1)
   capybara (= 3.40.0)
   config
+  csv (~> 3.3)
   database_cleaner
   devise
+  drb (~> 2.2, >= 2.2.1)
   factory_bot_rails (> 5)
   faker (~> 3.3)
   faraday
@@ -491,6 +498,7 @@ DEPENDENCIES
   json_matchers
   libv8-node (= 18.19.0.0)
   mini_racer
+  mutex_m (~> 0.2.0)
   newrelic_rpm
   nokogiri (~> 1.16.3)
   oj

--- a/db/migrate/20240220182659_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20240220182659_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,0 +1,22 @@
+# This migration comes from active_storage (originally 20190112182829)
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    return unless table_exists?(:active_storage_blobs)
+
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    return unless table_exists?(:active_storage_blobs)
+
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/migrate/20240220182660_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20240220182660_create_active_storage_variant_records.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20191206030411)
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:active_storage_blobs)
+
+    # Use Active Record's configured type for primary key
+    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
+      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
+
+    def blobs_primary_key_type
+      pkey_name = connection.primary_key(:active_storage_blobs)
+      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+      pkey_column.bigint? ? :bigint : pkey_column.type
+    end
+end

--- a/db/migrate/20240220182661_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20240220182661_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,0 +1,8 @@
+# This migration comes from active_storage (originally 20211119233751)
+class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:active_storage_blobs)
+
+    change_column_null(:active_storage_blobs, :checksum, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_22_235820) do
+ActiveRecord::Schema.define(version: 2024_02_20_182661) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"


### PR DESCRIPTION
## Description
vfep-1263: Database Migrations for Rails 7, gem updates for ruby 3.3.0

## Original issue(s)
[vfep-1263](https://jira.devops.va.gov/browse/VFEP-1263)

## Testing done
Developer user testing, RSpec & Rubocop pass.

## Acceptance criteria
- [x]  Nothing breaks on GIBCT dashboard and Comparison Tool

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
