### PR TITLE
Add bootsnap gem ahead of Dockerfile changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'activerecord-import'
 # Switch from cookie based storage to AR storage in case of failure pushing to GIBCT
 gem 'activerecord-session_store'
 
+gem 'bootsnap', require: false
 gem 'config'
 
 # Use devise for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
     bindex (0.8.1)
+    bootsnap (1.18.3)
+      msgpack (~> 1.2)
     brakeman (6.1.2)
       racc
     builder (3.2.4)
@@ -229,6 +231,7 @@ GEM
     mini_racer (0.9.0)
       libv8-node (~> 18.19.0.0)
     minitest (5.22.3)
+    msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.4.0)
     mutex_m (0.2.0)
@@ -473,6 +476,7 @@ DEPENDENCIES
   activerecord-session_store
   base64 (~> 0.2.0)
   bcrypt (~> 3.1.20)
+  bootsnap
   brakeman
   bundler-audit
   byebug


### PR DESCRIPTION
## Description

Adding bootsnap gem ahead of major Dockerfile re-structuring ([PR](https://github.com/department-of-veterans-affairs/gibct-data-service/pull/1092) here)

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/79340
