### PR TITLE
vfep-1580 - add tuition fields to search card results serializer

### DIFF
--- a/app/serializers/institution_search_result_serializer.rb
+++ b/app/serializers/institution_search_result_serializer.rb
@@ -46,7 +46,6 @@ class InstitutionSearchResultSerializer < ActiveModel::Serializer
   attribute :tuition_in_state
   attribute :tuition_out_of_state
 
-
   link(:self) { v0_institution_url(object.facility_code) }
 
   def caution_flags

--- a/app/serializers/institution_search_result_serializer.rb
+++ b/app/serializers/institution_search_result_serializer.rb
@@ -43,6 +43,9 @@ class InstitutionSearchResultSerializer < ActiveModel::Serializer
   attribute :school_provider
   attribute :employer_provider
   attribute :vrrap
+  attribute :tuition_in_state
+  attribute :tuition_out_of_state
+
 
   link(:self) { v0_institution_url(object.facility_code) }
 


### PR DESCRIPTION
## Description
vfep-1580 - add tuition fields to search card results serializer

## Original issue(s)
[vfep-1580](https://jira.devops.va.gov/browse/VFEP-1580)

## Testing done
Developer user testing, confirmed new fields are being passed to Comparison Tool.  Rspec tests pass.

## Acceptance criteria
- [x] Front end confirms new fields available in search card results.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
