### PR TITLE
Vfep 294 - fix high school filter to handle blank and false scenarios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'rack', '>= 2.2.8.1'
 gem 'rack-cors', require: 'rack/cors' # CORS
 gem 'rails-html-sanitizer', '>= 1.4.4'
 gem 'rainbow'
+gem 'rexml', '~> 3.3.2'
 gem 'roo', '~> 2.10'
 gem 'roo-xls', '~> 1.2'
 gem 'ruby-saml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     roo (2.10.1)
       nokogiri (~> 1)
@@ -580,6 +580,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-html-sanitizer (>= 1.4.4)
   rainbow
+  rexml (~> 3.3.2)
   roo (~> 2.10)
   roo-xls (~> 1.2)
   rspec-rails

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -352,7 +352,7 @@ class Institution < ImportableRecord
   end
 
   def self.filter_high_school
-    where(high_school: nil)
+    where.not(high_school: true)
   end
 
   def self.ungeocodable_count

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -352,7 +352,7 @@ class Institution < ImportableRecord
   end
 
   def self.filter_high_school
-    where.not(high_school: true)
+    where('high_school is null or high_school = FALSE')
   end
 
   def self.ungeocodable_count

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -307,10 +307,12 @@ RSpec.describe Institution, type: :model do
 
     it 'excludes high schools when filtering them out' do
       create(:version, :production)
-      create(:institution, :production_version)
+      create(:institution, :production_version, high_school: false)
+      create(:institution, :production_version, high_school: nil)
       create(:institution, :production_version, :high_school_institution)
+      expect(described_class.count).to eq(3)
       results = described_class.filter_high_school
-      expect(results.count).to eq(0)
+      expect(results.count).to eq(1)
     end
 
     describe '#institution_search_term' do

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Institution, type: :model do
       create(:institution, :production_version, :high_school_institution)
       expect(described_class.count).to eq(3)
       results = described_class.filter_high_school
-      expect(results.count).to eq(1)
+      expect(results.count).to eq(2)
     end
 
     describe '#institution_search_term' do


### PR DESCRIPTION
## Description
Vfep 294 - fix high school filter to handle blank and false scenarios

## Original issue(s)
[vfep-294](https://jira.devops.va.gov/browse/VFEP-294)

## Testing done
Developer user testing.  All Rspec and Rubocop tests pass.

## Acceptance criteria
- [x]  This is a production data issue, so QA will confirm all still works properly on staging.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
