### PR TITLE
VEBT-502 fix Makefile to use the correct docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ else
     ENV_ARG  := test
 endif
 
-COMPOSE_DEV  := docker-compose
-COMPOSE_TEST := docker-compose -f docker-compose.test.yml
+COMPOSE_DEV  := docker compose
+COMPOSE_TEST := docker compose -f docker-compose.test.yml
 BASH         := run --rm gibct bash --login
 BASH_DEV     := $(COMPOSE_DEV) $(BASH) -c
 BASH_TEST    := $(COMPOSE_TEST) $(BASH) -c

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ else
 endif
 
 COMPOSE_DEV  := docker compose
-COMPOSE_TEST := docker compose -f docker-compose.test.yml
+COMPOSE_TEST := docker compose
 BASH         := run --rm gibct bash --login
 BASH_DEV     := $(COMPOSE_DEV) $(BASH) -c
-BASH_TEST    := $(COMPOSE_TEST) $(BASH) -c
+BASH_TEST    := $(COMPOSE_TEST) -f docker-compose.test.yml $(BASH) -c
 DOWN         := down
 
 .PHONY: default
@@ -68,7 +68,7 @@ build:  ## Builds the service
 ifeq ($(ENV_ARG), dev)
 	$(COMPOSE_DEV) build
 else
-	$(COMPOSE_TEST) build
+	$(COMPOSE_TEST) -f docker-compose.test.yml build
 endif
 
 .PHONY: down
@@ -86,6 +86,6 @@ ifeq ($(ENV_ARG), dev)
 	$(COMPOSE_DEV) run gibct rm -r coverage log/* tmp || true
 	$(COMPOSE_DEV) down
 else
-	$(COMPOSE_TEST) run gibct rm -r coverage log/* tmp || true
+	$(COMPOSE_TEST) -f docker-compose.test.yml run gibct rm -r coverage log/* tmp || true
 	$(COMPOSE_TEST) down
 endif

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build:  ## Builds the service
 ifeq ($(ENV_ARG), dev)
 	$(COMPOSE_DEV) build
 else
-	$(COMPOSE_TEST) -f docker-compose.test.yml build
+	$(COMPOSE_TEST) build
 endif
 
 .PHONY: down

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,6 @@ ifeq ($(ENV_ARG), dev)
 	$(COMPOSE_DEV) run gibct rm -r coverage log/* tmp || true
 	$(COMPOSE_DEV) down
 else
-	$(COMPOSE_TEST) -f docker-compose.test.yml run gibct rm -r coverage log/* tmp || true
+	$(COMPOSE_TEST) run gibct rm -r coverage log/* tmp || true
 	$(COMPOSE_TEST) down
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ else
     ENV_ARG  := test
 endif
 
-COMPOSE_DEV  := docker compose
-COMPOSE_TEST := docker compose
+COMPOSE_DEV  := docker-compose
+COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm gibct bash --login
 BASH_DEV     := $(COMPOSE_DEV) $(BASH) -c
-BASH_TEST    := $(COMPOSE_TEST) -f docker-compose.test.yml $(BASH) -c
+BASH_TEST    := $(COMPOSE_TEST) $(BASH) -c
 DOWN         := down
 
 .PHONY: default

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ else
 endif
 
 .PHONY: down
-down:  ## Stops all docker services
+down:  # Stops all docker services
 ifeq ($(ENV_ARG), dev)
 	@$(COMPOSE_DEV) $(DOWN)
 else

--- a/app/models/dashboard_exporter_importer.rb
+++ b/app/models/dashboard_exporter_importer.rb
@@ -5,7 +5,7 @@ class DashboardExporterImporter
   # :nocov:
   include DashboardWatir
 
-  TABLES_TO_SKIP = %w[CipCode InstitutionSchoolRating VrrapProvider Weam].freeze
+  TABLES_TO_SKIP = %w[CipCode InstitutionSchoolRating VrrapProvider].freeze
 
   def initialize(user, pass, load_env = nil)
     common_initialize_watir(user, pass, load_env)


### PR DESCRIPTION
## Description
BE - Update makefile to use the correct docker compose command

## Original issue(s)
[VEBT-502](https://jira.devops.va.gov/browse/VEBT-502)

## Testing done
All RSpec tests pass although this is really a change to the configuration file for the CI/CD Pipeline

## Screenshots
<img width="206" alt="MakefileCapture" src="https://github.com/user-attachments/assets/d7969dde-a6b8-401b-8acf-ae3dadd664d8">

Observe that it now shows 'docker compose' instead of 'docker-compose' with a hyphen between the two words.

## Acceptance criteria
- [ ] There are no pipeline issues beyond the normal flaky tests and it deploys to Staging correctly.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
