### PR TITLE
VEBT-525 - Update the code to only archive approved institutions - Part 2 of 2

### DIFF
--- a/app/models/archiver.rb
+++ b/app/models/archiver.rb
@@ -62,8 +62,16 @@ module Archiver
     insert_cols = (cols.map { |col| '"' + col + '"' }).join(', ')
     select_cols = (cols.map { |col| 's.' + col }).join(', ')
 
+    # Only archive approved institutions and related data.
     str = "INSERT INTO #{archive.table_name}(#{insert_cols}) SELECT #{select_cols} FROM #{source.table_name} s "
-    str += source.has_attribute?(:institution_id) ? 'JOIN institutions i ON s.institution_id = i.id JOIN versions v ON i.version_id = v.id' : 'JOIN versions v ON s.version_id = v.id'
+    str += if source.has_attribute?(:institution_id)
+             'JOIN institutions i ON s.institution_id = i.id JOIN versions v ON i.version_id = v.id AND i.approved = true'
+           elsif source.eql?(Institution)
+             'JOIN versions v ON s.version_id = v.id AND approved = true'
+           else
+             'JOIN versions v ON s.version_id = v.id'
+           end
+
     str += ' WHERE v.number >= ? AND v.number < ?;'
     sql = archive.send(:sanitize_sql_for_conditions, [str, previous_version, production_version])
     ApplicationRecord.connection.execute(sql)

--- a/spec/models/archiver_spec.rb
+++ b/spec/models/archiver_spec.rb
@@ -14,4 +14,44 @@ describe '::ARCHIVE_TYPES' do
       end
     end
   end
+
+  # only approved institutions and related data from the previous version are archived. Zip code rates are not tied to
+  # institutions, but rather to versions. They are archived. The count changes in the spec reflect this expectation.
+  # Caution flags are not archived.
+  context 'when archiving' do
+    before do
+      prev_vsn = create(:version, :production)
+      prev_appr_ins = create(:institution, version: prev_vsn)
+      create(:institution_program, institution: prev_appr_ins)
+      create(:versioned_school_certifying_official, institution: prev_appr_ins)
+      create(:zipcode_rate, version: prev_vsn)
+
+      prev_unapproved = create(:institution, version: prev_vsn, approved: false)
+      create(:institution_program, institution: prev_unapproved)
+      create(:versioned_school_certifying_official, institution: prev_unapproved)
+
+      curr_vsn = create(:version, :production)
+      curr_appr_ins = create(:institution, version: curr_vsn)
+      create(:institution_program, institution: curr_appr_ins)
+      create(:versioned_school_certifying_official, institution: curr_appr_ins)
+      create(:zipcode_rate, version: curr_vsn)
+
+      curr_unaaproved = create(:institution, version: curr_vsn, approved: false)
+      create(:institution_program, institution: curr_unaaproved)
+      create(:versioned_school_certifying_official, institution: curr_unaaproved)
+    end
+
+    it 'archives only approved institutions & related data & deletes all archivable data from the previous version' do
+      expect do
+        Archiver.archive_previous_versions
+      end.to change(InstitutionsArchive, :count).by(1)
+         .and change(InstitutionProgramsArchive, :count).by(1)
+         .and change(VersionedSchoolCertifyingOfficialsArchive, :count).by(1)
+         .and change(ZipcodeRatesArchive, :count).by(1)
+         .and change(Institution, :count).by(-2)
+         .and change(InstitutionProgram, :count).by(-2)
+         .and change(VersionedSchoolCertifyingOfficial, :count).by(-2)
+         .and change(ZipcodeRate, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## Description
VEBT-525 - Update the code to only archive approved institutions - Part 2 of 2

## Original issue(s)
[VEBT-308](https://jira.devops.va.gov/browse/VEBT-308) Part 1 of 2
[VEBT-525](https://jira.devops.va.gov/browse/VEBT-525) Part 2 of 2

## Testing done
Sandbox testing results in only data from approved institutions and zipcode rates is archived.
All RSpec tests pass

## Screenshots


## Acceptance criteria
- [x] Geocoding runs a little faster and only data from approved institutions (and zipcode rates) is archived.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
