### PR TITLE
Vebt 352 - Automate Vsoc Spreadsheet on GIDS Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Secondarily, institution information may be exported as a CSV for regulatory rep
 GIDS data is accessible via an API intended for use by the GI Bill Comparison Tool client (**GIBCT**), which is part of
 the `vets-api` and `vets-website` applications.
 
-### Data Modes and Versions
+### Data Modes and Versions 
 GIDS profile data is logically partitioned in two modes: **preview** mode and **production** mode. In preview mode the
 data retrieved via the API has not yet been completely processed and built out by the InstitutionBuilder model. In 
 contrast, production mode is the actual data pushed to **GIBCT** for public consumption.

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -210,7 +210,7 @@ class DashboardsController < ApplicationController
 
   def unzip_csv(class_nm)
     # Some downloads do are not a zip file, so skip and return true
-    return true if class_nm.eql?('Hcm') || class_nm.eql?('EightKey') || class_nm.eql?('Mou')
+    return true if class_nm.eql?('Hcm') || class_nm.eql?('EightKey') || class_nm.eql?('Mou') || class_nm.eql?('Vsoc')
 
     ZipFileUtils::Unzipper.new.unzip_the_file
   end

--- a/app/models/vsoc.rb
+++ b/app/models/vsoc.rb
@@ -10,5 +10,7 @@ class Vsoc < ImportableRecord
     'vetsuccess_email' => { column: :vetsuccess_email, converter: Converters::BaseConverter }
   }.freeze
 
+  API_SOURCE = 'https://vbaw.vba.va.gov/EDUCATION/job_aids/documents/'
+
   validates :facility_code, presence: true
 end

--- a/app/utilities/no_key_apis/no_key_api_downloader.rb
+++ b/app/utilities/no_key_apis/no_key_api_downloader.rb
@@ -12,7 +12,8 @@ module  NoKeyApis
       'IpedsIcAy' => 'tmp/ic2022_ay.csv',
       'IpedsIcPy' => 'tmp/ic2022_py.csv',
       'IpedsIc' => 'tmp/ic2022.csv',
-      'Mou' => 'tmp/mou.xlsx'
+      'Mou' => 'tmp/mou.xlsx',
+      'Vsoc' => 'tmp/vsoc.csv'
     }.freeze
 
     API_NO_KEY_DOWNLOAD_SOURCES = {
@@ -26,7 +27,8 @@ module  NoKeyApis
       'IpedsIc' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022.zip'],
       'IpedsIcAy' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022_AY.zip'],
       'IpedsIcPy' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022_PY.zip'],
-      'Mou' => [' -X GET', "'https://www.dodmou.com/Home/DownloadS3File?s3bucket=dodmou-private-ah9xbf&s3Key=participatinginstitutionslist%2Fproduction%2FInstitutionsList.xlsx'"]
+      'Mou' => [' -X GET', "'https://www.dodmou.com/Home/DownloadS3File?s3bucket=dodmou-private-ah9xbf&s3Key=participatinginstitutionslist%2Fproduction%2FInstitutionsList.xlsx'"],
+      'Vsoc' => [' -X GET', "'https://vbaw.vba.va.gov/EDUCATION/job_aids/documents/Vsoc_08132024.csv'"]
     }.freeze
 
     attr_accessor :class_nm, :curl_command
@@ -56,6 +58,7 @@ module  NoKeyApis
       when 'Hcm' then '-o tmp/hcm.xlsx'
       when 'EightKey' then '-o tmp/eight_key.xls'
       when 'Mou' then '-o tmp/mou.xlsx'
+      when 'Vsoc' then '-o tmp/vsoc.csv'
       else '-o tmp/download.zip'
       end
     end

--- a/app/utilities/no_key_apis/no_key_api_downloader.rb
+++ b/app/utilities/no_key_apis/no_key_api_downloader.rb
@@ -28,7 +28,7 @@ module  NoKeyApis
       'IpedsIcAy' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022_AY.zip'],
       'IpedsIcPy' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022_PY.zip'],
       'Mou' => [' -X GET', "'https://www.dodmou.com/Home/DownloadS3File?s3bucket=dodmou-private-ah9xbf&s3Key=participatinginstitutionslist%2Fproduction%2FInstitutionsList.xlsx'"],
-      'Vsoc' => [' -X GET', "'https://vbaw.vba.va.gov/EDUCATION/job_aids/documents/Vsoc_08132024.csv'"]
+      'Vsoc' => [' -k -X GET', "'https://vbaw.vba.va.gov/EDUCATION/job_aids/documents/Vsoc_08132024.csv'"]
     }.freeze
 
     attr_accessor :class_nm, :curl_command
@@ -49,6 +49,7 @@ module  NoKeyApis
 
     def h_parm
       return '-H "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"' if @class_nm.eql?('Hcm')
+      return '-H \'Content-Type: application/octet-stream\'' if @class_nm.eql?('Vsoc')
 
       '-H \'Content-Type: application/json\''
     end

--- a/app/utilities/no_key_apis/no_key_api_downloader.rb
+++ b/app/utilities/no_key_apis/no_key_api_downloader.rb
@@ -16,6 +16,7 @@ module  NoKeyApis
       'Vsoc' => 'tmp/vsoc.csv'
     }.freeze
 
+    # Vsoc uses -k parameter to bypass SSL certificate errors
     API_NO_KEY_DOWNLOAD_SOURCES = {
       'Accreditation' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
       'AccreditationAction' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
@@ -48,6 +49,7 @@ module  NoKeyApis
     private
 
     def h_parm
+      # Vsoc uses the octet-stream header to pull down from source
       return '-H "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"' if @class_nm.eql?('Hcm')
       return '-H \'Content-Type: application/octet-stream\'' if @class_nm.eql?('Vsoc')
 

--- a/config/initializers/csv_types.rb
+++ b/config/initializers/csv_types.rb
@@ -19,7 +19,7 @@ Rails.application.config.to_prepare do
     { klass: ScorecardDegreeProgram, required?: false, has_api?: true },
     { klass: Sec702, required?: true },
     { klass: Sva, required?: true },
-    { klass: Vsoc, required?: true },
+    { klass: Vsoc, required?: true, has_api?: true, no_api_key?: true },
     { klass: Weam, required?: true },
     { klass: CalculatorConstant, required?: false },
     { klass: IpedsCipCode, required?: true },


### PR DESCRIPTION
## Description
Automate the Vsoc Spreadsheet fetch on the GIDS dashboard. The fetch button is now available on the dashboard to pull down the Vsoc.csv file into GIDS.

## Original issue(s)
https://jira.devops.va.gov/browse/VEBT-352

## Testing done
- Tested that the "Fetch" button successfully pulled down the Vsoc spreadsheet to GIDS dashboard
- Verified that the Vsoc file was reachable via the staging server

## Screenshots


## Acceptance criteria
- [x] The fetch button for Vsoc works and pulls down data as expected

## Definition of done
- [x ] Events are logged appropriately
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
