### PR TITLE
VEBT-516 BE - GIDS - Remove foreign schools from Crosswalk Partial Matches report

### DIFF
--- a/app/models/crosswalk_issue.rb
+++ b/app/models/crosswalk_issue.rb
@@ -14,10 +14,57 @@ class CrosswalkIssue < ApplicationRecord
 
   scope :by_issue_type, ->(n) { where(issue_type: n) }
 
+  scope :by_domestic_crosswalks, lambda {
+    joins(
+      'JOIN crosswalks crs on crosswalk_issues.crosswalk_id = crs.id ' \
+      " AND RIGHT(crs.facility_code, 2) ~ '^[0-9]{2}$' " \
+      ' AND CAST(right(crs.facility_code, 2) as integer) < 51 '
+    ).merge(by_issue_type(PARTIAL_MATCH_TYPE))
+  }
+
+  scope :by_domestic_weams, lambda {
+    joins(
+      'JOIN weams wms on crosswalk_issues.weam_id = wms.id ' \
+      " AND RIGHT(wms.facility_code, 2) ~ '^[0-9]{2}$' " \
+      ' AND CAST(right(wms.facility_code, 2) as integer) < 51 '
+    ).merge(by_issue_type(PARTIAL_MATCH_TYPE))
+  }
+
+  scope :by_domestic_iped_hds, lambda {
+    joins(
+      'JOIN ipeds_hds ihs on crosswalk_issues.ipeds_hd_id = ihs.id ' \
+      'JOIN weams iws on ihs.cross = iws.cross ' \
+      " AND RIGHT(iws.facility_code, 2) ~ '^[0-9]{2}$' " \
+      ' AND CAST(right(iws.facility_code, 2) as integer) < 51'
+    ).merge(by_issue_type(PARTIAL_MATCH_TYPE))
+  }
+
+  # The issue here is activerecord doesn't have a union clause per se.
+  # https://stackoverflow.com/questions/6686920/activerecord-query-union
+  # See solution by Vlad Hilko near the bottom of the page. However, this
+  # soltion only works when you have two pieces to the union. For more, you
+  # have to chain them as described in this solution describe by Sebastian Palma
+  # https://stackoverflow.com/questions/59294114/build-triple-union-query-using-arel-rails-5
+  def self.domestic_partial_matches
+    domestic_crosswalks = by_domestic_crosswalks.arel
+    domestic_weams = by_domestic_weams.arel
+    domestic_iped_hds = by_domestic_iped_hds.arel
+
+    subquery = Arel::Nodes::As.new(
+      Arel::Nodes::Union.new(
+        Arel::Nodes::Union.new(
+          domestic_crosswalks, domestic_weams
+        ), domestic_iped_hds),
+      CrosswalkIssue.arel_table
+    )
+
+    from(subquery)
+  end
+
   # class methods
   def self.partials
     includes(:crosswalk, :ipeds_hd, weam: :arf_gi_bill)
-      .by_issue_type(CrosswalkIssue::PARTIAL_MATCH_TYPE)
+      .domestic_partial_matches
       .order('arf_gi_bills.gibill desc nulls last, weams.institution, weams.facility_code')
   end
 

--- a/app/models/crosswalk_issue.rb
+++ b/app/models/crosswalk_issue.rb
@@ -54,8 +54,8 @@ class CrosswalkIssue < ApplicationRecord
       Arel::Nodes::Union.new(
         Arel::Nodes::Union.new(
           domestic_crosswalks, domestic_weams
-        ), domestic_iped_hds),
-      CrosswalkIssue.arel_table
+        ), domestic_iped_hds
+      ), CrosswalkIssue.arel_table
     )
 
     from(subquery)

--- a/app/views/dashboards/_issues.html.erb
+++ b/app/views/dashboards/_issues.html.erb
@@ -9,7 +9,7 @@
         <%= link_to crosswalk_issues_partials_path do %>
           <button class="btn dashboard-btn-success">
             View
-            <span class="badge"><%= CrosswalkIssue.by_issue_type(CrosswalkIssue::PARTIAL_MATCH_TYPE).count %></span>
+            <span class="badge"><%= CrosswalkIssue.domestic_partial_matches.count %></span>
           </button>
         <% end %>
         </div>

--- a/spec/controllers/crosswalk_issues_controller_spec.rb
+++ b/spec/controllers/crosswalk_issues_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe CrosswalkIssuesController, type: :controller do
     it 'orders by arf_gi_bill.gibill' do
       issues = assigns(:issues)
       issues_last = issues[issues.length - 1]
+
       expect(issues.first.weam.arf_gi_bill.gibill).to be > issues_last.weam.arf_gi_bill.gibill
     end
   end

--- a/spec/factories/crosswalks.rb
+++ b/spec/factories/crosswalks.rb
@@ -20,6 +20,22 @@ FactoryBot.define do
       facility_code { '99Z99999' }
     end
 
+    # last 2 characters are less than 51
+    trait :domestic_with_crosswalk_issue do
+      facility_code { '99Z99950' }
+      after(:create) do |crosswalk|
+        create(:crosswalk_issue, :partial_match_type, crosswalk: crosswalk)
+      end
+    end
+
+    # last 2 characters are 51 or greater
+    trait :foreign_with_crosswalk_issue do
+      facility_code { '99Z99951' }
+      after(:create) do |crosswalk|
+        create(:crosswalk_issue, :partial_match_type, crosswalk: crosswalk)
+      end
+    end
+
     trait :crosswalk_issue_matchable_by_cross do
       cross { '888888' }
     end

--- a/spec/factories/ipeds_hds.rb
+++ b/spec/factories/ipeds_hds.rb
@@ -27,6 +27,12 @@ FactoryBot.define do
       zip { '94107' }
     end
 
+    trait :with_crosswalk_issue do
+      after(:create) do |ipeds_hd|
+        create(:crosswalk_issue, :partial_match_type, ipeds_hd: ipeds_hd)
+      end
+    end
+
     initialize_with do
       new(
         cross: cross, vet_tuition_policy_url: vet_tuition_policy_url,

--- a/spec/factories/weams.rb
+++ b/spec/factories/weams.rb
@@ -178,6 +178,40 @@ FactoryBot.define do
       facility_code { '99Z99999' }
     end
 
+    # last 2 characters are less than 51
+    trait :domestic_with_crosswalk_issue do
+      facility_code { '99Z99950' }
+      after(:create) do |weam|
+        create(:crosswalk_issue, :partial_match_type, weam: weam)
+      end
+    end
+
+    trait :domestic_with_ipeds_hd_crosswalk_issue do
+      facility_code { '99Z99950' }
+      cross { '888889' }
+
+      after(:create) do |weam|
+        create(:ipeds_hd, :with_crosswalk_issue, cross: weam.cross)
+      end
+    end
+
+    # last 2 characters are 51 or greater
+    trait :foreign_with_crosswalk_issue do
+      facility_code { '99Z99951' }
+      after(:create) do |weam|
+        create(:crosswalk_issue, :partial_match_type, weam: weam)
+      end
+    end
+
+    trait :foreign_with_ipeds_hd_crosswalk_issue do
+      facility_code { '99Z99951' }
+      cross { '888890' }
+
+      after(:create) do |weam|
+        create(:ipeds_hd, :with_crosswalk_issue, cross: weam.cross)
+      end
+    end
+
     trait :arf_gi_bill do
       city { 'Test' }
       state { 'TN' }

--- a/spec/models/crosswalk_issue_spec.rb
+++ b/spec/models/crosswalk_issue_spec.rb
@@ -213,6 +213,46 @@ RSpec.describe CrosswalkIssue, type: :model do
     end
   end
 
+  describe '#by_domestic_crosswalks via crosswalk' do
+    it 'includes crosswalks that have facility codes with the last 2 characters < 51' do
+      create(:crosswalk, :domestic_with_crosswalk_issue)
+      create(:crosswalk, :foreign_with_crosswalk_issue)
+
+      expect(described_class.by_domestic_crosswalks.count).to eq(1)
+    end
+  end
+
+  describe '#by_domestic_crosswalks via weams' do
+    it 'includes crosswalks that have facility codes with the last 2 characters < 51' do
+      create(:weam, :domestic_with_crosswalk_issue)
+      create(:weam, :foreign_with_crosswalk_issue)
+
+      expect(described_class.by_domestic_weams.count).to eq(1)
+    end
+  end
+
+  describe '#by_domestic_crosswalks via ipeds_hds' do
+    it 'includes crosswalks that have facility codes with the last 2 characters < 51' do
+      create(:weam, :domestic_with_ipeds_hd_crosswalk_issue)
+      create(:weam, :foreign_with_ipeds_hd_crosswalk_issue)
+
+      expect(described_class.by_domestic_iped_hds.count).to eq(1)
+    end
+  end
+
+  describe '#domestic_partial_matches' do
+    it 'includes crosswalks that have facility codes with the last 2 characters < 51' do
+      create(:crosswalk, :domestic_with_crosswalk_issue)
+      create(:crosswalk, :foreign_with_crosswalk_issue)
+      create(:weam, :domestic_with_crosswalk_issue)
+      create(:weam, :foreign_with_crosswalk_issue)
+      create(:weam, :domestic_with_ipeds_hd_crosswalk_issue)
+      create(:weam, :foreign_with_ipeds_hd_crosswalk_issue)
+
+      expect(described_class.domestic_partial_matches.count).to eq(3)
+    end
+  end
+
   describe 'when building IPEDS orphans' do
     it 'excludes IpedsHD that match Crosswalk by cross (IPEDS)' do
       create :ipeds_hd, :crosswalk_issue_matchable_by_cross

--- a/spec/support/factory_generators.rb
+++ b/spec/support/factory_generators.rb
@@ -2,7 +2,10 @@
 
 FactoryBot.define do
   sequence(:facility_code) do |n|
-    n.to_s(32).rjust(8, '0').upcase
+    base32_part = n.to_s(32).rjust(6, '0').upcase
+    # default facility code to domestic. Last 2 digits are numeric and less than 51
+    numeric_part = (n % 50).to_s.rjust(2, '0')
+    base32_part + numeric_part
   end
 
   sequence(:facility_code_ojt) do |n|


### PR DESCRIPTION
## Description
VEBT-516 BE - GIDS - Remove foreign schools from Crosswalk Partial Matches report

## Original issue(s)
[VEBT-516](https://jira.devops.va.gov/browse/VEBT-516)

## Testing done
Sandbox Testing and RSpec tests. Some refactoring was needed with RSpec tests and new tests were added.

## Acceptance criteria
- [x] Foreign institutions no longer show in the Crosswalk Issues count on the GIDS Dashboard, the online screen and the exported spreadsheet for same.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
