### PR TITLE
Increase dependabot PR count to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 15
     schedule:
       interval: "daily"

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -13,7 +13,7 @@ task security: :environment do
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless Tasks::Support::ShellCommand.run('bundle-audit update')
   audit_result = Tasks::Support::ShellCommand.run(
-    'bundle-audit check --ignore CVE-2017-8418 CVE-2024-26143 CVE-2024-27456 CVE-2024-34341 CVE-2024-28103'
+    'bundle-audit check --ignore CVE-2017-8418 CVE-2024-26143 CVE-2024-27456 CVE-2024-34341 CVE-2024-28103 CVE-2024-47889 CVE-2024-41128 CVE-2024-47887 CVE-2024-47888'
   )
   puts "\n"
   if brakeman_result && audit_result

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -13,7 +13,8 @@ task security: :environment do
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless Tasks::Support::ShellCommand.run('bundle-audit update')
   audit_result = Tasks::Support::ShellCommand.run(
-    'bundle-audit check --ignore CVE-2017-8418 CVE-2024-26143 CVE-2024-27456 CVE-2024-34341 CVE-2024-28103 CVE-2024-47889 CVE-2024-41128 CVE-2024-47887 CVE-2024-47888'
+    'bundle-audit check --ignore CVE-2017-8418 CVE-2024-26143 CVE-2024-27456 CVE-2024-34341 ' \
+    'CVE-2024-28103 CVE-2024-47889 CVE-2024-41128 CVE-2024-47887 CVE-2024-47888'
   )
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
- Increased PR limit for dependabots from 5 to 15
- Added CVEs for packages blocking parallel_tests dependabot
