### PR TITLE
Vebt 887 - Search by program

### DIFF
--- a/app/controllers/v1/institutions_controller.rb
+++ b/app/controllers/v1/institutions_controller.rb
@@ -72,15 +72,15 @@ module V1
              meta: @meta
     end
 
-    # GET /v1/institutions?description=nursing&latitude=42.3601&longitude=-71.0589
+    # GET /v1/gi/institutions/search?description=nursing&latitude=42.3601&longitude=-71.0589
     def program
       @query ||= normalized_query_params
 
       # Start with filtering by institution programs based on description
       institution_programs = InstitutionProgram.joins(:institution)
-                                                .where('institution_programs.description ILIKE ?', "%#{@query[:description]}%")
-                                                .where(institutions: { version: @version })
-      
+                                               .where('institution_programs.description ILIKE ?', "%#{@query[:description]}%")
+                                               .where(institutions: { version: @version })
+
       # Now filter by location
       location_results = Institution.approved_institutions(@version)
                                     .location_search(@query)

--- a/app/controllers/v1/institutions_controller.rb
+++ b/app/controllers/v1/institutions_controller.rb
@@ -92,7 +92,7 @@ module V1
 
       @meta = {
         version: @version,
-        count: results.unscope(:select).count,  # Add unscope
+        count: results.unscope(:select).count, # Add unscope
         facets: facets(location_results)
       }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,11 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: 'json' } do
     get '/calculator/constants' => 'calculator_constants#index'
     get '/institutions', to: 'institutions#facility_codes', constraints: lambda { |request| request.query_parameters.key?(:facility_codes) }
+    get '/institutions', to: 'institutions#program', constraints: lambda { |request| 
+      request.query_parameters.key?(:description) && 
+      request.query_parameters.key?(:latitude) && 
+      request.query_parameters.key?(:longitude)
+    }
     get '/institutions', to: 'institutions#location', constraints: lambda { |request| request.query_parameters.key?(:latitude) && request.query_parameters.key?(:longitude) }
 
     resources :institutions, only: [:index, :show] do

--- a/spec/controllers/v1/institutions_controller_spec.rb
+++ b/spec/controllers/v1/institutions_controller_spec.rb
@@ -535,4 +535,33 @@ RSpec.describe V1::InstitutionsController, type: :controller do
       expect(JSON.parse(response.body)['data'].count).to eq(0)
     end
   end
+
+  context 'with program search results' do
+    before do
+      create(:version, :production)
+      create(:institution, :production_version, latitude: 30.1659, longitude: -93.2146) # Example institution
+      create(:institution_program, institution: Institution.last, description: 'Software Engineering') # Program associated with the institution
+    end
+
+    it 'search returns results matching program description and location' do
+      get(:program, params: { description: 'Software Engineering', latitude: 30.1659, longitude: -93.2146 })
+      expect(JSON.parse(response.body)['data'].count).to eq(1) # Expecting one result
+      expect(response.media_type).to eq('application/json')
+      expect(response).to match_response_schema('institution_search_results')
+    end
+
+    it 'returns no results for non-matching program description' do
+      get(:program, params: { description: 'Non-existing Program', latitude: 30.1659, longitude: -93.2146 })
+      expect(JSON.parse(response.body)['data'].count).to eq(0) # Expecting no results
+      expect(response.media_type).to eq('application/json')
+      expect(response).to match_response_schema('institution_search_results')
+    end
+
+    it 'returns no results for non-matching location' do
+      get(:program, params: { description: 'Software Engineering', latitude: 0.0, longitude: 0.0 })
+      expect(JSON.parse(response.body)['data'].count).to eq(0) # Expecting no results
+      expect(response.media_type).to eq('application/json')
+      expect(response).to match_response_schema('institution_search_results')
+    end
+  end
 end


### PR DESCRIPTION
## Description
Add to Comparison Tool ability to search by program. The endpoint is called program and is hit when a program description and coordinates are sent.

## Original issue(s)
[877](https://jira.devops.va.gov/browse/VEBT-887)

As a...

VEBT Developer

I want…

To build the Search By Name section of the CT redesign

So that…

CT redesign work can be completed

Acceptance Criteria

User must search for a program AND location
School, employer or training program & city, state or postal code are both *REQUIRED fields. 
Search by program mimic search by name.
Back end to do both name and location as part of code 
Technical Details:

Dependencies: 

Collaborate with EDM to utilize one feature toggle
BE will need the URL parameters for the data call
EDM will need to provide the program data via excel doc in GIDS
Feature Flag needed: Yes

## Definition of done
- [x ] Events are logged appropriately
- [x ] Documentation has been updated, if applicable
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
