### PR TITLE
EDM-511/add program type to institution response

### DIFF
--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -134,11 +134,7 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   end
 
   def program_types
-    Benchmark.bm do |x|
-      x.report { InstitutionProgram.where(instutition: object).pluck(Arel.sql('DISTINCT program_type')) }
-      x.report { InstitutionProgram.where(instutition: object).distinct.pluck(:program_type) }
-      x.repot { object.institution_programs.group(:program_type).pluck(:program_type) }
-    end
+    InstitutionProgram.where(institution: object).distinct.pluck(:program_type)
   end
 
   def caution_flags

--- a/app/serializers/institution_profile_serializer.rb
+++ b/app/serializers/institution_profile_serializer.rb
@@ -92,7 +92,7 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
   attribute :preferred_provider
   attribute :stem_indicator
   attribute :facility_map
-  attribute :programs
+  attribute :program_types
   attribute :versioned_school_certifying_officials
   attribute :count_of_caution_flags
   attribute :section_103_message
@@ -133,11 +133,11 @@ class InstitutionProfileSerializer < ActiveModel::Serializer
     end
   end
 
-  def programs
-    return [] unless object.vet_tec_provider
-
-    object.institution_programs.map do |program|
-      InstitutionProgramProfileSerializer.new(program)
+  def program_types
+    Benchmark.bm do |x|
+      x.report { InstitutionProgram.where(instutition: object).pluck(Arel.sql('DISTINCT program_type')) }
+      x.report { InstitutionProgram.where(instutition: object).distinct.pluck(:program_type) }
+      x.repot { object.institution_programs.group(:program_type).pluck(:program_type) }
     end
   end
 

--- a/spec/support/api/schemas/institution_profile.json
+++ b/spec/support/api/schemas/institution_profile.json
@@ -472,10 +472,10 @@
                 "type": "object"
               }
             },
-            "programs": {
+            "program_types": {
               "type": ["null", "array"],
               "items": {
-                "type": "object"
+                "type": "string"
               }
             },
             "section_103_message": {


### PR DESCRIPTION
## Description
List of programs removed from institution profile serializer and replaced with program types, an array of program type strings

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://jira.devops.va.gov/browse/EDM-511)

## Testing done
Update schema matching

## Screenshots


## Acceptance criteria
- [x] /institutions/<facility_code> returns institution serialized with list of program types

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
