### PR TITLE
EDM-480-499/Increase worker timeout and reduce batch load size for upload

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,7 +26,7 @@ workers 3
 # value is 60 seconds.
 #
 
-worker_timeout(60)
+worker_timeout(600)
 worker_timeout(3600) if ENV['RAILS_ENV'].eql?('development')
 
 preload_app!

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,6 +27,5 @@ workers 3
 #
 
 worker_timeout(600)
-worker_timeout(3600) if ENV['RAILS_ENV'].eql?('development')
 
 preload_app!

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 active_record:
   batch_size:
     find_each: 5000
-    import: 50000
+    import: 1000
 
 archiver:
   archive: true


### PR DESCRIPTION
## Description
Programs file times out during upload. Working in parallel a solution where program file is broken up on frontend and the load into postgres is performed by async job. This solution could be tried first to see if increasing puma worker timeout and reducing batch import size allows for Program file to be successfully uploaded and loaded into database in staging and production.

## Original issue(s)
https://jira.devops.va.gov/browse/EDM-480
https://jira.devops.va.gov/browse/EDM-499

## Testing done
Can perform upload locally but true test will be whether file can be uploaded and loaded into database in staging and especially in production

## Screenshots


## Acceptance criteria
- [] file uploads successfully and programs table is populated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
