### PR TITLE
Update Makefile to use updated docker compose syntax

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Verify Docker Compose Installation
+        run: |
+        docker-compose --version || echo "docker-compose not found"
       - name: Run Tests
         run: |
           make ci

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Verify Docker Compose Installation
         run: |
-        docker-compose --version || echo "docker-compose not found"
+          docker-compose --version || echo "docker-compose not found"
       - name: Run Tests
         run: |
           make ci

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Verify Docker Compose Installation
         run: |
-          docker-compose --version || echo "docker-compose not found"
+          docker compose --version || echo "docker-compose not found"
       - name: Run Tests
         run: |
           make ci

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,7 +2,7 @@ name: runs test on dev/staging
 on:
   push:
     branches:
-      - master
+      - '*'
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ else
     ENV_ARG  := test
 endif
 
-COMPOSE_DEV  := docker-compose
-COMPOSE_TEST := docker-compose -f docker-compose.test.yml
+COMPOSE_DEV  := docker compose
+COMPOSE_TEST := docker compose -f docker-compose.test.yml
 BASH         := run --rm gibct bash --login
 BASH_DEV     := $(COMPOSE_DEV) $(BASH) -c
 BASH_TEST    := $(COMPOSE_TEST) $(BASH) -c


### PR DESCRIPTION
## Description

## Original issue(s)
In some runs, we are seeing `docker-compose` not found. Using docker compose ensures compatibility with up to date Docker installations and reduces dependency on the legacy docker-compose.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
