### PR TITLE
vebt-961 add code to unlock generate version button

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -17,6 +17,24 @@ class DashboardsController < ApplicationController
     redirect_to dashboards_path
   end
 
+  def unlock_generate_button
+    begin
+      PreviewGenerationStatusInformation.delete_all
+      begin
+        Version.where(production: false).destroy_all
+        flash.notice = 'Unlock completed'
+      rescue StandardError => e
+        log_error(e)
+        flash.error = "Unlock failed on Version: #{e.message}"
+      end
+    rescue StandardError => e
+      log_error(e)
+      flash.error = "Unlock failed on PreviewGenerationStatusInformation: #{e.message}"
+    end
+
+    redirect_to dashboards_path
+  end
+
   def export
     file_type = params[:csv_type]
     if GROUP_FILE_TYPES_NAMES.include?(file_type)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -28,6 +28,25 @@ module DashboardsHelper
       pgsi.current_progress.start_with?('There was an error')
   end
 
+  def generating_in_progress?(preview_versions)
+    return true if preview_versions[0]&.generating?
+
+    pgsi = PreviewGenerationStatusInformation.last
+    pgsi.nil? ? false : true
+  end
+
+  def appears_to_be_stuck?(preview_versions)
+    preview_version = preview_versions[0]
+    if preview_version.nil?
+      pgsi = PreviewGenerationStatusInformation.last
+      return pgsi.nil? ? false : true
+    end
+
+    return true if preview_version.created_at < 10.minutes.ago && preview_version.completed_at.nil?
+
+    false
+  end
+
   def cannot_fetch_api(csv_type)
     Upload.fetching_for?(csv_type)
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -42,7 +42,7 @@ module DashboardsHelper
       return pgsi.nil? ? false : true
     end
 
-    return true if preview_version.created_at < 10.minutes.ago && preview_version.completed_at.nil?
+    return true if preview_version.created_at < 30.minutes.ago && preview_version.completed_at.nil?
 
     false
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -55,7 +55,7 @@
     <% end %>
 
     <div class="generate_preview_button_div">
-      <%= link_to 'Generate and Publish a new Version', dashboard_build_path, method: :post,
+      <%= link_to 'Generate Version', dashboard_build_path, method: :post,
                   class: "btn btn-warning",
                   role: "button",
                   id: "version_build"
@@ -64,7 +64,18 @@
   </div>
 </div>
 
-<button id="preview_opener" class="btn dashboard-btn-warning btn-xs" <%= can_generate_preview(@preview_versions) %>>Generate and Publish a new Version</button>
+<button id="preview_opener" class="btn dashboard-btn-warning btn-xs" <%= can_generate_preview(@preview_versions) %>>Generate Version</button>
+
+<% if generating_in_progress?(@preview_versions) && appears_to_be_stuck?(@preview_versions) %>
+  &nbsp;&nbsp;
+  <%= link_to 'Unlock', dashboard_unlock_generate_button_path, method: :post,
+              class: "btn dashboard-btn-info btn-xs",
+              role: "button",
+              id: "unlock_generate-button"
+  %>
+  &nbsp;&nbsp;(Use this when Generate Version is stuck)
+<% end %>
+
 <%= render partial: 'issues' %>
 
 <h2>Latest Uploads

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -14,9 +14,5 @@ Rails.application.config.action_controller.per_form_csrf_tokens = false
 # Enable origin-checking CSRF mitigation. Previous versions had false.
 Rails.application.config.action_controller.forgery_protection_origin_check = false
 
-# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
-# Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
-
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # For active? helper
   get '/dashboards' => 'dashboards#index'
   post '/dashboards/build' => 'dashboards#build', as: :dashboard_build
+  post '/dashboards/unlock_generate_button' => 'dashboards#unlock_generate_button', as: :dashboard_unlock_generate_button
   get '/dashboards/export/:csv_type' => 'dashboards#export', as: :dashboard_export, defaults: { format: 'csv' }
   get '/dashboards/api_fetch/:csv_type' => 'dashboards#api_fetch', as: :dashboard_api_fetch
   get '/dashboards/export/institutions/:number' => 'dashboards#export_version', as: :dashboard_export_version, defaults: { format: 'csv' }

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DashboardsController, type: :controller do
     end
   end
 
-  describe 'GET #build' do
+  describe 'POST #build' do
     login_user
 
     before do
@@ -72,6 +72,25 @@ RSpec.describe DashboardsController, type: :controller do
       initial_progress_count = PreviewGenerationStatusInformation.count
       post(:build)
       expect(PreviewGenerationStatusInformation.count).to be > initial_progress_count
+    end
+  end
+
+  describe 'POST unlock_generate_button' do
+    login_user
+
+    before do
+      create(:version, :preview)
+      create(:preview_generation_status_information)
+    end
+
+    it 'Clears the table related data and redirects to the dashboard' do
+      expect(Version.count).to eq(1)
+      expect(PreviewGenerationStatusInformation.count).to eq(1)
+      post(:unlock_generate_button)
+      expect(Version.count).to eq(0)
+      expect(PreviewGenerationStatusInformation.count).to eq(0)
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to('/dashboards')
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe DashboardsHelper, type: :helper do
       expect(helper.appears_to_be_stuck?([])).to eq(true)
     end
 
-    it 'returns true when there is a preview version that has not completed and is older than 10 minutes' do
-      preview_version = create(:version, :preview, created_at: Time.now.utc - 11.minutes)
+    it 'returns true when there is a preview version that has not completed and is older than 30 minutes' do
+      preview_version = create(:version, :preview, created_at: Time.now.utc - 31.minutes)
       expect(helper.appears_to_be_stuck?([preview_version])).to eq(true)
     end
   end

--- a/spec/views/dashboards/index.html.erb_spec.rb
+++ b/spec/views/dashboards/index.html.erb_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe 'dashboards/index', type: :view do
     expect(rendered).to match(/Enable locked Fetches/)
   end
 
-  # The default scenario actually has generation in progress but it is newer than 10 minutes
-  it 'does not show the unlock button if generation is in progress but newer than 10 minutes' do
+  # The default scenario actually has generation in progress but it is newer than 30 minutes
+  it 'does not show the unlock button if generation is in progress but newer than 30 minutes' do
     render
     expect(rendered).not_to match(/Unlock/)
   end
@@ -40,8 +40,8 @@ RSpec.describe 'dashboards/index', type: :view do
     expect(rendered).not_to match(/Unlock/)
   end
 
-  it 'does show the unlock button if generation is in progress and older than 10 minutes' do
-    Version.where(production: false).update(created_at: Time.now.utc - 11.minutes)
+  it 'does show the unlock button if generation is in progress and older than 30 minutes' do
+    Version.where(production: false).update(created_at: Time.now.utc - 31.minutes)
     render
     expect(rendered).to match(/Unlock/)
   end

--- a/spec/views/dashboards/index.html.erb_spec.rb
+++ b/spec/views/dashboards/index.html.erb_spec.rb
@@ -16,15 +16,33 @@ RSpec.describe 'dashboards/index', type: :view do
     expect(rendered).to match(/Institutions With No Accreditation/)
   end
 
-  it 'does not show the button if there are no failed fetches' do
+  it 'does not show the enable locked fetches button if there are no failed fetches' do
     create(:upload, :valid_upload)
     render
     expect(rendered).not_to match(/Enable locked Fetches/)
   end
 
-  it 'shows the button if there are failed fetches' do
+  it 'shows the enable locked fetches button if there are failed fetches' do
     create(:upload, :failed_upload)
     render
     expect(rendered).to match(/Enable locked Fetches/)
+  end
+
+  # The default scenario actually has generation in progress but it is newer than 10 minutes
+  it 'does not show the unlock button if generation is in progress but newer than 10 minutes' do
+    render
+    expect(rendered).not_to match(/Unlock/)
+  end
+
+  it 'does not show the unlock button if not generating a version' do
+    Version.where(production: false).delete_all
+    render
+    expect(rendered).not_to match(/Unlock/)
+  end
+
+  it 'does show the unlock button if generation is in progress and older than 10 minutes' do
+    Version.where(production: false).update(created_at: Time.now.utc - 11.minutes)
+    render
+    expect(rendered).to match(/Unlock/)
   end
 end


### PR DESCRIPTION
## Description
vebt-961 add code to unlock generate version button

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://jira.devops.va.gov/browse/VEBT-961)

## Testing done
Sandbox testing completed satisfactorily.
RSpec tests created and modified as needed.

## Screenshots


## Acceptance criteria
- [x] Generate Version button becomes unlocked when it is disabled and the unlock button is clicked.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

[VEBT-961.docx](https://github.com/user-attachments/files/18559220/VEBT-961.docx)
