### PR TITLE
VEBT-1165 Fix EightKeys file download URL

### DIFF
--- a/app/utilities/no_key_apis/no_key_api_downloader.rb
+++ b/app/utilities/no_key_apis/no_key_api_downloader.rb
@@ -22,7 +22,7 @@ module  NoKeyApis
       'AccreditationAction' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
       'AccreditationInstituteCampus' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
       'AccreditationRecord' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
-      'EightKey' => [' -X GET', 'https://www2.ed.gov/documents/military/8-keys-sites.xls'],
+      'EightKey' => [' -X GET', 'https://www.ed.gov/sites/ed/files/documents/military/8-keys-sites.xls'],
       'Hcm' => ['', 'https://studentaid.gov/sites/default/files/Schools-on-HCM-December2023.xlsx'],
       'IpedsHd' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/HD2022.zip'],
       'IpedsIc' => [' -X GET', 'https://nces.ed.gov/ipeds/datacenter/data/IC2022.zip'],

--- a/spec/utilities/no_key_apis/no_key_api_downloader_spec.rb
+++ b/spec/utilities/no_key_apis/no_key_api_downloader_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe NoKeyApis::NoKeyApiDownloader do
       expect(nkad.class_nm).to eq('EightKey')
       expect(nkad.curl_command).to include('-X GET')
       expect(nkad.curl_command).to include('tmp/eight_key.xls')
-      expect(nkad.curl_command).to include('https://www2.ed.gov/documents/military/8-keys-sites.xls')
+      expect(nkad.curl_command).to include('https://www.ed.gov/sites/ed/files/documents/military/8-keys-sites.xls')
       expect(nkad.curl_command).not_to include('-d')
     end
 


### PR DESCRIPTION
## Description

The current URL for the Eight Keys file requires following several redirects before the file is actually delivered. Since curl doesn't follow redirects by default, the wrong data is 'downloaded'. I.e. is the html of a 301 redirect page that is downloaded and treated as a xls file, which of course breaks things. The easy fix is to update the URL to the end of the redirect chain that actually delivers the file.

https://jira.devops.va.gov/browse/VEBT-1165

## Testing done
Tested locally that relevant `curl` command returns expected file. I don't believe that automated testing can be done (easily) since the pass/fail criteria relies on the result of a real-world http call.

## Screenshots
<img width="791" alt="VEBT-1165-screenshot" src="https://github.com/user-attachments/assets/82e22210-bb9e-43fa-ac9e-c57962314eb7" />


## Acceptance criteria
- [X] Actual eight keys file is downloaded and processed correctly.

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
