### PR TITLE
VEBT-1297 change xls/csv parsing logic for EightKey file to ensure ip…

### DIFF
--- a/app/utilities/file_type_converters/xls_to_csv.rb
+++ b/app/utilities/file_type_converters/xls_to_csv.rb
@@ -14,16 +14,6 @@ module FileTypeConverters
       book = Spreadsheet.open(@xls_file_name)
       sheet = book.worksheet(0)
 
-      # rubocop:disable Rails/Output
-      if Dir.exist?('tmp')
-        puts "\n\n\n***\ntmp directory exists"
-        permissions = File.stat('tmp').mode.to_s(8)
-        puts "permissions for tmp directory are #{permissions[-3, 3]} \n***\n\n\n"
-      else
-        puts 'tmp directory does not exist'
-      end
-      # rubocop:enable Rails/Output
-
       CSV.open(@csv_file_name, 'wb') do |csv|
         sheet.each do |row|
           formatted_row = row.to_a.map do |cell|

--- a/app/utilities/file_type_converters/xls_to_csv.rb
+++ b/app/utilities/file_type_converters/xls_to_csv.rb
@@ -14,6 +14,16 @@ module FileTypeConverters
       book = Spreadsheet.open(@xls_file_name)
       sheet = book.worksheet(0)
 
+      # rubocop:disable Rails/Output
+      if Dir.exist?('tmp')
+        puts "\n\n\n***\ntmp directory exists"
+        permissions = File.stat('tmp').mode.to_s(8)
+        puts "permissions for tmp directory are #{permissions[-3, 3]} \n***\n\n\n"
+      else
+        puts 'tmp directory does not exist'
+      end
+      # rubocop:enable Rails/Output
+
       CSV.open(@csv_file_name, 'wb') do |csv|
         sheet.each do |row|
           formatted_row = row.to_a.map do |cell|

--- a/app/utilities/file_type_converters/xls_to_csv.rb
+++ b/app/utilities/file_type_converters/xls_to_csv.rb
@@ -17,14 +17,7 @@ module FileTypeConverters
       CSV.open(@csv_file_name, 'wb') do |csv|
         sheet.each do |row|
           formatted_row = row.to_a.map do |cell|
-            cell_value = cell.is_a?(Float) ? format('%.0f', cell) : cell.to_s.strip
-            if cell_value =~ /^\d+$/ && cell_value.length <= 8
-              # Format the number to be exactly eight digits
-              formatted_number = cell_value.rjust(8, '0')
-              formatted_number
-            else
-              cell_value
-            end
+            cell.is_a?(Float) ? format('%.0f', cell) : cell.to_s.strip
           end
           csv << formatted_row
         end

--- a/spec/utilities/file_type_converters/xls_to_csv_spec.rb
+++ b/spec/utilities/file_type_converters/xls_to_csv_spec.rb
@@ -17,13 +17,5 @@ RSpec.describe FileTypeConverters::XlsToCsv do
       described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
       expect(File.exist?('tmp/eight_key.csv')).to be true
     end
-
-    it 'convert numbers to strings, but does not pad them with zeros' do
-      File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
-      described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
-      expect(File.exist?('tmp/eight_key.csv')).to be true
-      csv_data = CSV.read('tmp/eight_key.csv')
-      expect(csv_data[2][4]).to eq('100200')
-    end
   end
 end

--- a/spec/utilities/file_type_converters/xls_to_csv_spec.rb
+++ b/spec/utilities/file_type_converters/xls_to_csv_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe FileTypeConverters::XlsToCsv do
       expect(File.exist?('tmp/eight_key.csv')).to be true
     end
 
+    # Not having the sleep 1 here causes both this test and the above test to fail in Jenkins. It's not clear why
+    # other than that there seems to be a timing issue. Combining the two tests into one also works.
     it 'convert numbers to strings, but does not pad them with zeros' do
       sleep 1
       File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')

--- a/spec/utilities/file_type_converters/xls_to_csv_spec.rb
+++ b/spec/utilities/file_type_converters/xls_to_csv_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe FileTypeConverters::XlsToCsv do
       File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
       described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
       expect(File.exist?('tmp/eight_key.csv')).to be true
+    end
+
+    it 'convert numbers to strings, but does not pad them with zeros' do
+      sleep 1
+      File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
+      described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
+      expect(File.exist?('tmp/eight_key.csv')).to be true
       csv_data = CSV.read('tmp/eight_key.csv')
       expect(csv_data[2][4]).to eq('100200')
     end

--- a/spec/utilities/file_type_converters/xls_to_csv_spec.rb
+++ b/spec/utilities/file_type_converters/xls_to_csv_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe FileTypeConverters::XlsToCsv do
       File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
       described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
       expect(File.exist?('tmp/eight_key.csv')).to be true
-    end
-
-    it 'convert numbers to strings, but does not pad them with zeros' do
-      File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
-      described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
-      expect(File.exist?('tmp/eight_key.csv')).to be true
       csv_data = CSV.read('tmp/eight_key.csv')
       expect(csv_data[2][4]).to eq('100200')
     end

--- a/spec/utilities/file_type_converters/xls_to_csv_spec.rb
+++ b/spec/utilities/file_type_converters/xls_to_csv_spec.rb
@@ -17,5 +17,13 @@ RSpec.describe FileTypeConverters::XlsToCsv do
       described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
       expect(File.exist?('tmp/eight_key.csv')).to be true
     end
+
+    it 'convert numbers to strings, but does not pad them with zeros' do
+      File.delete('tmp/eight_key.csv') if File.exist?('tmp/eight_key.csv')
+      described_class.new('spec/fixtures/download_8_keys_sites.xls', 'tmp/eight_key.csv').convert_xls_to_csv
+      expect(File.exist?('tmp/eight_key.csv')).to be true
+      csv_data = CSV.read('tmp/eight_key.csv')
+      expect(csv_data[2][4]).to eq('100200')
+    end
   end
 end


### PR DESCRIPTION
## Description
When fetching and parsing the EightKey xls file, it was noticed that only a small fraction of the institutions were being marked as eight key participants (on the order of 33 or so). There should have been a couple of thousand. The issue turned out to be how `EightKey` records and `Institution` records are matched. The assignment is done here:

https://github.com/department-of-veterans-affairs/gibct-data-service/blob/cb9fc59e1956e1c5183d11739c5ddab76231f099/app/models/institution_builder.rb#L205-L217

Notice that it is comparing `institutions.cross` with `eight_keys.cross` to do the join. But, when importing the eight keys xls file, the `opeid` and `ipedsid` columns from that file have extra processing done, and are _left-padded with zeros_ to ensure the string is 8 characters long:

https://github.com/department-of-veterans-affairs/gibct-data-service/blob/cb9fc59e1956e1c5183d11739c5ddab76231f099/app/utilities/file_type_converters/xls_to_csv.rb#L20-L29

So you end up in the situation where `eight_keys.cross` is `"00123456"` and `institutions.cross` is `"123456"`. Since these are strings, the string comparison fails and the `eight_keys` field is not set to `true` on the `institutions` table.

The fix proposed is to simple stop padding the eight keys values with zeros. The `FileTypeConverters::XlsToCsv#convert_xls_to_csv` function is currently used only in one place, and only to process eight_keys files, so modifying it should have no impact on anything else:

https://github.com/department-of-veterans-affairs/gibct-data-service/blob/cb9fc59e1956e1c5183d11739c5ddab76231f099/app/controllers/dashboards_controller.rb#L191-L193

I have tested locally, and can confirm that after fetching the eight keys xls file, my local database is showing several thousand eight-keys institutions rather than the 33 or so before the fix.

## Original issue(s)
VEBT-1297

## Testing done

Fetched eight keys xls file from dashboard on local machine. Then checked database to confirm that `eight_keys` column of `institutions` table was set correctly.

## Screenshots


## Acceptance criteria
- [ ] All expected eight keys institutions are marked as such.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
