### PR TITLE
VEBT-1249 ignore complaints with generic ope6 code during rollup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'base64', '~> 0.2.0' # ruby 3.4.0 warning said to add
 gem 'bcrypt', '~> 3.1.20'
 gem 'bootsnap', require: false
 gem 'cancancan', '~> 1.13', '>= 1.13.1' # Use cancancan for authorization
+gem 'cgi', '>= 0.4.2'
 gem 'config'
 gem 'csv', '~> 3.3' # ruby 3.4.0 warning said to add
 gem 'devise' # Use devise for authentication
@@ -48,7 +49,6 @@ gem 'terser'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus', '~> 2.0.0'
 gem 'will_paginate'
-gem 'cgi', '>= 0.4.2'
 
 group :production do
   gem 'sass-rails', '6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'terser'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus', '~> 2.0.0'
 gem 'will_paginate'
+gem 'cgi', '>= 0.4.2'
 
 group :production do
   gem 'sass-rails', '6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    cgi (0.4.1)
+    cgi (0.4.2)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -552,6 +552,7 @@ DEPENDENCIES
   byebug
   cancancan (~> 1.13, >= 1.13.1)
   capybara (= 3.40.0)
+  cgi (>= 0.4.2)
   config
   csv (~> 3.3)
   database_cleaner

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -106,7 +106,7 @@ class Complaint < ImportableRecord
     # in complaints being attributed to institutions that have nothing to do with the offending
     # location. So, when doing ope6 rollups, we ignore anything that start with an 'A'. This
     # seems to be a reliable enough pattern to filter out these ephemeral ope ids.
-    ope6_format_clause = on_column == :ope6 ? "AND NOT institutions.#{on_column} LIKE 'A%'" : ""
+    ope6_format_clause = on_column == :ope6 ? "AND NOT institutions.#{on_column} LIKE 'A%'" : ''
 
     rollup_sums.each_pair do |sum_column, complaint_column|
       set_clause << %("#{sum_column}" = sums.#{sum_column})

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -100,6 +100,13 @@ class Complaint < ImportableRecord
 
     set_clause = []
     sum_clause = []
+    # some ope codes are placeholders (e.g. 'VA000200', 'VA000300') and are assigned while
+    # an institution is in the process of being assigned a 'real' ope id. These temporary
+    # ope ids _should not_ be used to roll up complaints, since it will inevitably result
+    # in complaints being attributed to institutions that have nothing to do with the offending
+    # location. So, when doing ope6 rollups, we ignore anything that start with an 'A'. This
+    # seems to be a reliable enough pattern to filter out these ephemeral ope ids.
+    ope6_format_clause = on_column == :ope6 ? "AND NOT institutions.#{on_column} LIKE 'A%'" : ""
 
     rollup_sums.each_pair do |sum_column, complaint_column|
       set_clause << %("#{sum_column}" = sums.#{sum_column})
@@ -112,6 +119,7 @@ class Complaint < ImportableRecord
         (SELECT "#{on_column}", #{sum_clause.join(', ')} FROM complaints GROUP BY #{on_column}) AS sums
         WHERE institutions.#{on_column} = sums.#{on_column} AND
           institutions.version_id = #{version_id} AND institutions.#{on_column} IS NOT NULL
+          #{ope6_format_clause}
     SQL
 
     Complaint.connection.update(str)

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -118,5 +118,22 @@ RSpec.describe Complaint, type: :model do
         end
       end
     end
+
+    describe 'by ope6 with temporary ope ids' do
+      before do
+        create :version, :production
+        institution = create :institution, :institution_builder, version_id: Version.last.id, ope: 'VA000200', ope6: 'A0002'
+
+        create :complaint, :all_issues, ope: 'VA000200'
+        described_class.rollup_sums(:ope6, institution.version_id)
+      end
+
+      it 'ignores the temporary ope id complaint(s)' do
+        institution = Institution.first
+        Complaint::OPE6_ROLL_UP_SUMS.each_key do |ope6_sum|
+          expect(institution[ope6_sum]).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
`Complaint` counts are computed and stored on `Institution` models as one of the many `complaints_*` attributes that exist on that model. The rollups are done twice, once based on facility code (which should be a unique identifier for that institution), and once based on ope id (which can technically span multiple campuses and is used as a way to group related institutions). The issue arises that some ope codes are temporary or placeholder. For example, while an institution is waiting to be assigned a real ope id, it might be assigned a dummy one. These dummy ope ids are generally of the form "VA000200", "VA000300", "VA000400", etc. If any complaints exist with one of these ope ids, then that complain will (erroneously) be counted against _all_ institutions with that temporary ope id.

The fix proposed in this PR, based on a conversation with Brian Grubb, is to ignore any complaints that have a dummy ope id, and not include them in any rollup calculation. In the code, this manifests as filtering away anything that has an `ope6` which starts with an 'A'. `ope6` is just a field computed from `ope` by taking the second through fifth characters, so e.g. an `ope` of "VA000200" becomes a `ope6` of "A0002". The rollup calculations are done by `ope6`.


## Original issue(s)
VEBT-1294

## Testing done
Local testing and rspec

## Screenshots


## Acceptance criteria
- [X] Complaints with dummy ope codes are not included in rollup calculations

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
