### PR TITLE
EDM/disable no store for lcpe

### DIFF
--- a/app/controllers/v1/lcpe_base_controller.rb
+++ b/app/controllers/v1/lcpe_base_controller.rb
@@ -16,7 +16,7 @@ module V1
     def preload_dataset
       return if bypass_versioning?
 
-      set_etag(fresh_preload.id.to_s)
+      set_headers(fresh_preload.id.to_s)
       JSON.parse(fresh_preload.body)
     end
 
@@ -28,10 +28,8 @@ module V1
       "Lcpe::#{controller_name.singularize.titleize}"
     end
 
-    def set_etag(preload_version)
-      no_store_disabled = response.headers['Cache-Control'].remove('no-store, ')
-      response.set_header('Cache-Control', no_store_disabled)
-
+    def set_headers(preload_version)
+      response.set_header('Cache-Control', 'no-cache, max-age=0, must-revalidate')
       response.set_header('ETag', preload_version)
     end
 

--- a/app/controllers/v1/lcpe_base_controller.rb
+++ b/app/controllers/v1/lcpe_base_controller.rb
@@ -29,6 +29,9 @@ module V1
     end
 
     def set_etag(preload_version)
+      no_store_disabled = response.headers['Cache-Control'].remove('no-store, ')
+      response.set_header('Cache-Control', no_store_disabled)
+
       response.set_header('ETag', preload_version)
     end
 


### PR DESCRIPTION
Remove 'no-store' from 'Cache-Control' header when handling lcpe/lac or lcpe/exam request to enable proper caching with etag