### PR TITLE
EDM/use filter params constant to bypass versioning

### DIFF
--- a/app/controllers/v1/lcpe/lacs_controller.rb
+++ b/app/controllers/v1/lcpe/lacs_controller.rb
@@ -43,7 +43,7 @@ class V1::Lcpe::LacsController < V1::LcpeBaseController
   def index_params
     return @index_params if defined?(@index_params)
 
-    @index_params = params.permit(:edu_lac_type_nm, :state, :lac_nm, :page, :per_page)
+    @index_params = params.permit(*FILTER_PARAMS)
   end
 
   def page

--- a/app/controllers/v1/lcpe_base_controller.rb
+++ b/app/controllers/v1/lcpe_base_controller.rb
@@ -6,6 +6,8 @@ module V1
 
     rescue_from PreloadVersionStaleError, with: :version_invalid
 
+    FILTER_PARAMS = %i[edu_lac_type_nm state lac_nm page per_page].freeze
+
     private
 
     def validate_preload_version
@@ -35,11 +37,7 @@ module V1
 
     # If additional filter params present, bypass versioning
     def bypass_versioning?
-      scrubbed_params.present?
-    end
-
-    def scrubbed_params
-      params.except(:format, :controller, :action, controller_name.singularize.to_sym)
+      params.keys.map(&:to_sym).intersect?(FILTER_PARAMS)
     end
 
     def version_invalid


### PR DESCRIPTION
Account for additional params in higher environments otherwise browser caching won't work for lcpe/lacs and exams. Instead, hardcode filter params and check if any provided params intersect.