### PR TITLE
EDM/use double quoted etag

### DIFF
--- a/app/controllers/v1/lcpe_base_controller.rb
+++ b/app/controllers/v1/lcpe_base_controller.rb
@@ -31,10 +31,10 @@ module V1
     end
 
     def set_headers(preload_version)
-      response.set_header('Cache-Control', 'private')
+      response.set_header('Cache-Control', 'private, max-age=0')
       response.headers.delete('Pragma')
       response.set_header('Expires', 1.week.since.to_s)
-      response.set_header('ETag', "W/'#{preload_version}'")
+      response.set_header('ETag', "W/\"#{preload_version}\"")
     end
 
     # If additional filter params present, bypass versioning


### PR DESCRIPTION
Change weak etag to use double instead of single quotes and add max-age=0 header
