### PR TITLE
Delete cache control header

### DIFF
--- a/app/controllers/v1/lcpe_base_controller.rb
+++ b/app/controllers/v1/lcpe_base_controller.rb
@@ -31,7 +31,7 @@ module V1
     end
 
     def set_headers(preload_version)
-      response.set_header('Cache-Control', 'private')
+      response.headers.delete('Cache-Control')
       response.headers.delete('Pragma')
       response.set_header('Expires', 1.week.since.to_s)
       response.set_header('ETag', "W/'#{preload_version}'")


### PR DESCRIPTION
Delete cache control header upstream from vets-api so that empty cache control header is not appearing after revproxy overrides on way from vets-api to browser