### PR TITLE
VEBT-1461 do not import or export case_id and case_owner columns

### DIFF
--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -62,10 +62,8 @@ class Complaint < ImportableRecord
   }.freeze
 
   CSV_CONVERTER_INFO = {
-    'case_id' => { column: :case_id, converter: Converters::BaseConverter },
     'escalation_level' => { column: :level, converter: Converters::BaseConverter },
     'status' => { column: :status, converter: Converters::DowncaseConverter },
-    'case_owner' => { column: :case_owner, converter: Converters::BaseConverter },
     'school_name' => { column: :institution, converter: Converters::InstitutionConverter },
     'opeid' => { column: :ope, converter: Converters::OpeConverter },
     'facility_code' => { column: :facility_code, converter: Converters::FacilityCodeConverter },

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Complaint, type: :model do
   end
 
   describe 'importing' do
-    let(:csv_file) { "./spec/fixtures/complaint.csv" }
+    let(:csv_file) { './spec/fixtures/complaint.csv' }
 
     it 'ignores case_id and case_owner columns in the upload file' do
       load_options = Common::Shared.file_type_defaults('complaint', { skip_lines: 7 })
@@ -152,29 +152,29 @@ RSpec.describe Complaint, type: :model do
           }]
         }
 
-      results = Complaint.load_with_roo(csv_file, file_options).first[:results]
-      expect(Complaint.count).to eq(2)
-      expect(Complaint.pluck(:case_id)).to eq([nil, nil]) # There are actual case ids in the fixture file
-      expect(Complaint.pluck(:case_owner)).to eq([nil, nil]) # There are actual case owners in the fixture file
+      described_class.load_with_roo(csv_file, file_options).first[:results]
+      expect(described_class.count).to eq(2)
+      expect(described_class.pluck(:case_id)).to eq([nil, nil]) # There are actual case ids in the fixture file
+      expect(described_class.pluck(:case_owner)).to eq([nil, nil]) # There are actual case owners in the fixture file
     end
   end
 
   describe 'exporting' do
-    let!(:complaints) {
+    let!(:complaints) do
       [
         create(:complaint, case_id: 'ABC', case_owner: 'Frank'),
         create(:complaint, case_id: 'DEF', case_owner: 'Joan')
       ]
-    }
+    end
 
     it 'does not export case_id or case_owner columns' do
-      csv_string = Complaint.export
+      csv_string = described_class.export
       csv = CSV.parse(csv_string, headers: true)
       expect(csv.size).to eq(complaints.size)
-      expect(csv.headers).to_not include('case_id')
-      expect(csv.headers).to_not include('case id')
-      expect(csv.headers).to_not include('case_owner')
-      expect(csv.headers).to_not include('case owner')
+      expect(csv.headers).not_to include('case_id')
+      expect(csv.headers).not_to include('case id')
+      expect(csv.headers).not_to include('case_owner')
+      expect(csv.headers).not_to include('case owner')
     end
   end
 end

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -136,4 +136,45 @@ RSpec.describe Complaint, type: :model do
       end
     end
   end
+
+  describe 'importing' do
+    let(:csv_file) { "./spec/fixtures/complaint.csv" }
+
+    it 'ignores case_id and case_owner columns in the upload file' do
+      load_options = Common::Shared.file_type_defaults('complaint', { skip_lines: 7 })
+
+      file_options = {
+        liberal_parsing: load_options[:liberal_parsing],
+        sheets: [{
+          klass: described_class,
+          skip_lines: load_options[:skip_lines].try(:to_i),
+          clean_rows: load_options[:clean_rows]
+          }]
+        }
+
+      results = Complaint.load_with_roo(csv_file, file_options).first[:results]
+      expect(Complaint.count).to eq(2)
+      expect(Complaint.pluck(:case_id)).to eq([nil, nil]) # There are actual case ids in the fixture file
+      expect(Complaint.pluck(:case_owner)).to eq([nil, nil]) # There are actual case owners in the fixture file
+    end
+  end
+
+  describe 'exporting' do
+    let!(:complaints) {
+      [
+        create(:complaint, case_id: 'ABC', case_owner: 'Frank'),
+        create(:complaint, case_id: 'DEF', case_owner: 'Joan')
+      ]
+    }
+
+    it 'does not export case_id or case_owner columns' do
+      csv_string = Complaint.export
+      csv = CSV.parse(csv_string, headers: true)
+      expect(csv.size).to eq(complaints.size)
+      expect(csv.headers).to_not include('case_id')
+      expect(csv.headers).to_not include('case id')
+      expect(csv.headers).to_not include('case_owner')
+      expect(csv.headers).to_not include('case owner')
+    end
+  end
 end

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -143,14 +143,11 @@ RSpec.describe Complaint, type: :model do
     it 'ignores case_id and case_owner columns in the upload file' do
       load_options = Common::Shared.file_type_defaults('complaint', { skip_lines: 7 })
 
-      file_options = {
-        liberal_parsing: load_options[:liberal_parsing],
-        sheets: [{
-          klass: described_class,
-          skip_lines: load_options[:skip_lines].try(:to_i),
-          clean_rows: load_options[:clean_rows]
-          }]
-        }
+      file_options = { liberal_parsing: load_options[:liberal_parsing], sheets: [{
+        klass: described_class,
+        skip_lines: load_options[:skip_lines].try(:to_i),
+        clean_rows: load_options[:clean_rows]
+      }] }
 
       described_class.load_with_roo(csv_file, file_options).first[:results]
       expect(described_class.count).to eq(2)


### PR DESCRIPTION
## Description

We no longer want to import or export or track the case_id or case_owner columns for Complaints. This PR removes those fields from the import/export machinery so even if an uploaded complaint file has those columns present they will not be parsed and saved. Similarly, any exports done on the Complaint table will not include those columns. Of note: I have not removed the columns from the database. If that is something that is necessary, please leave feedback indicating such.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
- Automated rspecs for import and export

## Screenshots


## Acceptance criteria
- [X] case_id and case_owner columns are no longer processed/imported/exported for Complaints

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
