### PR TITLE
EDM-864/additional specs seq upload

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -17,6 +17,7 @@ class UploadsController < ApplicationController
 
   def create
     @upload = find_or_create_upload
+
     begin
       data = load_file
       alert_messages(data)

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -67,7 +67,7 @@ class UploadsController < ApplicationController
   def update_upload(results)
     return if sequence_incomplete?
 
-    @upload.update(ok: data_results.present? && data_results.ids.present?)
+    @upload.update(ok: results.present? && results.ids.present?)
     @upload.update(completed_at: Time.now.utc.to_fs(:db)) unless needs_retry?
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -118,7 +118,6 @@ class Upload < ApplicationRecord
   def lcpe_normalizable?
     top_most = csv_type&.split('::')&.first&.constantize
     subject = csv_type&.constantize
-
     top_most == Lcpe && subject.respond_to?(:normalize)
   rescue StandardError
     nil

--- a/config/csv_file_defaults.yml
+++ b/config/csv_file_defaults.yml
@@ -4,6 +4,7 @@ generic:
   clean_rows: true
   multiple_files: false
   liberal_parsing: false
+  first_line: 2
   sequential_upload:
     enabled: false
     chunk_size: 100_000

--- a/lib/roo_helper/loader.rb
+++ b/lib/roo_helper/loader.rb
@@ -232,11 +232,12 @@ module RooHelper
     #                 add 1 for the difference in indexes and 1 for the header row itself.
     #   - :skip_lines defaults to 0
     def merge_options(file_options)
+      Common::Shared.file_type_defaults(klass.name) => { skip_lines:, first_line: }
       file_options[:sheets] = if file_options[:sheets].present?
                                 file_options[:sheets]
-                                  .map { |sheet| sheet.reverse_merge(skip_lines: 0, first_line: 2) }
+                                  .map { |sheet| sheet.reverse_merge(skip_lines:, first_line:) }
                               else
-                                [{ klass: klass, skip_lines: 0, first_line: 2, clean_rows: true,
+                                [{ klass: klass, skip_lines:, first_line:, clean_rows: true,
                                    multiple_files: false }]
                               end
 

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -6,6 +6,8 @@ require 'support/devise'
 require 'controllers/shared_examples/shared_examples_for_authentication'
 
 RSpec.describe UploadsController, type: :controller do
+  let(:klass) { Weam }
+
   it_behaves_like 'an authenticating controller', :index, 'uploads'
 
   describe 'GET index' do
@@ -87,7 +89,7 @@ RSpec.describe UploadsController, type: :controller do
 
     describe 'requirements_messages for Weam' do
       before do
-        get :new, params: { csv_type: Weam.name }
+        get :new, params: { csv_type: klass.name }
       end
 
       it 'returns validates presence messages' do
@@ -129,58 +131,169 @@ RSpec.describe UploadsController, type: :controller do
   end
 
   describe 'POST create' do
+    RSpec::Matchers.define_negated_matcher :not_change, :change
+
     let(:upload_file) { build(:upload).upload_file }
+    let(:upload) { { upload_file:, skip_lines: 0, comment: 'Test', csv_type: klass.name } }
+    let(:total) { '3' }
+    let(:retries) { '5' }
+    let(:first_upload) { { **upload, sequence: { current: '1', total:, retries: } } }
+    let(:second_upload) { { **upload, sequence: { current: '2', total:, retries: }, multiple_file_upload: true } }
+    let(:third_upload) { { **upload, sequence: { current: '3', total:, retries: }, multiple_file_upload: true } }
+
+    def load_sequence(*uploads)
+      uploads.map do |upload|
+        upload[:sequence].merge!(id: Upload.last.id.to_s) unless Upload.last.nil?
+        post :create, params: { upload: }
+      end
+    end
 
     login_user
 
     context 'with having valid form input' do
-      it 'Uploads a csv file' do
-        expect do
-          post :create,
-               params: {
-                 upload: { upload_file: upload_file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' }
-               }
-        end.to change(Weam, :count).by(2)
+      context 'when non-sequential' do
+        it 'Uploads a csv file' do
+          expect { post :create, params: { upload: } }.to change(klass, :count).by(2)
+        end
+
+        it 'sets multiple_files on the Upload row to false when not checked on the form' do
+          post :create, params: { upload: }
+          # some goofiness with the column name multiple_files
+          expect(Upload.where(multiple_file_upload: true).last).to be nil
+        end
+
+        it 'sets multiple_file_upload on the Upload row to true when checked on the form' do
+          post :create, params: { upload: { **upload, multiple_file_upload: true } }
+          # some goofiness with the column name multiple_files
+          expect(Upload.where(multiple_file_upload: true).last).not_to be nil
+        end
+
+        it 'redirects to show' do
+          expect(post(:create, params: { upload: })).to redirect_to(action: :show, id: assigns(:upload).id)
+        end
+
+        it 'formats an notice message when some records do not validate' do
+          upload[:upload_file] = build(:upload, csv_name: 'weam_invalid.csv').upload_file
+          post :create, params: { upload: }
+          expect(flash[:warning].key?(:'The following rows should be checked: ')).to be true
+        end
       end
 
-      it 'sets multiple_files on the Upload row to false when not checked on the form' do
-        post :create,
-             params: { upload: { upload_file: upload_file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' } }
-        # some goofiness with the column name multiple_files
-        expect(Upload.where(multiple_file_upload: true).last).to be nil
+      context 'when first upload in sequence' do
+        it 'Uploads a csv file and returns upload id' do
+          expect { load_sequence(first_upload) }.to change(klass, :count).by(2)
+          upload = JSON.parse(response.body)['upload']
+          expect(upload['id']).to eq(Upload.last.id)
+        end
+
+        it 'does not update :ok or :completed_at column on upload' do
+          load_sequence(first_upload)
+          upload = Upload.find(JSON.parse(response.body)['upload']['id'])
+          expect(upload.attributes).to include('ok' => false, 'completed_at' => nil)
+        end
+
+        it 'does not redirect to show' do
+          expect(load_sequence(first_upload)).not_to redirect_to(action: :show, id: assigns(:upload).id)
+        end
+
+        it 'formats a success message' do
+          load_sequence(first_upload)
+          flash[:warning][:'The following rows should be checked: ']
+          expect(flash[:csv_success].key?(:total_rows_count)).to be true
+        end
+
+        it 'formats an notice message when some records do not validate' do
+          upload[:upload_file] = build(:upload, csv_name: 'weam_invalid.csv').upload_file
+          load_sequence(first_upload)
+          expect(flash[:warning].key?(:'The following rows should be checked: ')).to be true
+        end
       end
 
-      it 'sets multiple_file_upload on the Upload row to true when checked on the form' do
-        post :create,
-             params: {
-               upload: {
-                 upload_file: upload_file,
-                 skip_lines: 0,
-                 comment: 'Test',
-                 csv_type: 'Weam',
-                 multiple_file_upload: 'true'
-               }
-             }
-        # some goofiness with the column name multiple_files
-        expect(Upload.where(multiple_file_upload: true).last).not_to be nil
+      context 'when middle upload in sequence' do
+        it 'uploads a csv file without creating new upload and returns existing upload id' do
+          load_sequence(first_upload)
+          expect { load_sequence(second_upload) }.to not_change(Upload, :count)
+            .and change(klass, :count).by(2)
+          body = JSON.parse(response.body)
+          expect(body['upload']['id']).to eq(Upload.last.id)
+        end
+
+        it 'does not update :ok or :completed_at column on upload' do
+          load_sequence(first_upload, second_upload)
+          upload = Upload.find(JSON.parse(response.body)['upload']['id'])
+          expect(upload.attributes).to include('ok' => false, 'completed_at' => nil)
+        end
+
+        it 'sets csv_row of importable record relative to the original upload file' do
+          load_sequence(first_upload, second_upload)
+          # expect consecutive integers for row numbers
+          expect(klass.pluck(:csv_row)).to eq([*klass.first.csv_row..klass.count + 1])
+        end
+
+        it 'does not redirect to show' do
+          load_sequence(first_upload)
+          expect(load_sequence(second_upload)).not_to redirect_to(action: :show, id: assigns(:upload).id)
+        end
+
+        it 'concats success message onto existing success message' do
+          load_sequence(first_upload)
+          total = flash[:csv_success][:total_rows_count]
+          new_total = (total.to_i * 2).to_s
+          expect { load_sequence(second_upload) }.to change { flash[:csv_success][:total_rows_count] }
+            .from(total).to(new_total)
+        end
+
+        it 'formats an notice message when some records do not validate' do
+          upload[:upload_file] = build(:upload, csv_name: 'weam_invalid.csv').upload_file
+          load_sequence(first_upload)
+          warnings = flash[:warning][:'The following rows should be checked: '].length
+          expect { load_sequence(second_upload) }
+            .to change { flash[:warning][:'The following rows should be checked: '].length }.from(warnings).to(warnings * 2)
+        end
       end
 
-      it 'redirects to show' do
-        expect(
-          post(:create,
-               params: {
-                 upload: { upload_file: upload_file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' }
-               })
-        ).to redirect_to(action: :show, id: assigns(:upload).id)
-      end
+      context 'when last upload in sequence' do
+        it 'uploads a csv file without creating new upload and returns existing upload id' do
+          load_sequence(first_upload, second_upload)
+          expect { load_sequence(third_upload) }.to not_change(Upload, :count)
+            .and change(klass, :count).by(2)
+          body = JSON.parse(response.body)
+          expect(body['upload']['id']).to eq(Upload.last.id)
+        end
 
-      it 'formats an notice message when some records do not validate' do
-        file = build(:upload, csv_name: 'weam_invalid.csv').upload_file
-        post(:create,
-             params: {
-               upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' }
-             })
-        expect(flash[:warning].key?(:'The following rows should be checked: ')).to be true
+        it 'updates :ok or :completed_at column on upload' do
+          load_sequence(first_upload, second_upload, third_upload)
+          upload = Upload.find(JSON.parse(response.body)['upload']['id'])
+          expect(upload.ok).to be true
+          expect(upload.completed_at).not_to be nil
+        end
+
+        it 'sets csv_row of importable record relative to the original upload file' do
+          load_sequence(first_upload, second_upload, third_upload)
+          # expect consecutive integers for row numbers
+          expect(klass.pluck(:csv_row)).to eq([*klass.first.csv_row..klass.count + 1])
+        end
+
+        it 'does not redirect to show' do
+          load_sequence(first_upload, second_upload)
+          expect(load_sequence(third_upload)).not_to redirect_to(action: :show, id: assigns(:upload).id)
+        end
+
+        it 'concats success message onto existing success message' do
+          load_sequence(first_upload, second_upload)
+          total = flash[:csv_success][:total_rows_count]
+          new_total = (total.to_i / 2 * 3).to_s
+          expect { load_sequence(third_upload) }.to change { flash[:csv_success][:total_rows_count] }
+            .from(total).to(new_total)
+        end
+
+        it 'formats an notice message when some records do not validate' do
+          upload[:upload_file] = build(:upload, csv_name: 'weam_invalid.csv').upload_file
+          load_sequence(first_upload, second_upload)
+          warnings = flash[:warning][:'The following rows should be checked: '].length
+          expect { load_sequence(third_upload) }.to change { flash[:warning][:'The following rows should be checked: '].length }
+            .from(warnings).to(warnings / 2 * 3)
+        end
       end
     end
 
@@ -203,7 +316,7 @@ RSpec.describe UploadsController, type: :controller do
           expect(
             post(:create,
                  params: {
-                   upload: { upload_file: nil, skip_lines: 0, comment: 'Test', csv_type: 'Weam' }
+                   upload: { upload_file: nil, skip_lines: 0, comment: 'Test', csv_type: klass.name }
                  })
           ).to render_template(:new)
         end
@@ -217,7 +330,7 @@ RSpec.describe UploadsController, type: :controller do
         expect(
           post(:create,
                params: {
-                 upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' }
+                 upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: klass.name }
                })
         ).to redirect_to(action: :show, id: assigns(:upload).id)
       end
@@ -225,7 +338,7 @@ RSpec.describe UploadsController, type: :controller do
       it 'formats a notice message in the flash' do
         file = build(:upload, csv_name: 'weam_missing_column.csv').upload_file
         post(:create,
-             params: { upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' } })
+             params: { upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: klass.name } })
 
         message = flash[:warning][:'The following headers should be checked: '].try(:first)
         expect(message).to match(/Independent study is a missing header/)
@@ -237,7 +350,7 @@ RSpec.describe UploadsController, type: :controller do
         file = build(:upload, csv_name: 'weam_caret_col_sep.csv').upload_file
         expect(
           post(:create,
-               params: { upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: 'Weam' } })
+               params: { upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: klass.name } })
         ).to render_template(:new)
         error_message = 'Unable to determine column separators, valid separators equal "|" and ","'
         expect(flash[:danger]).to include(error_message)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Upload, type: :model do
       let(:csv_type) { Lcpe::Feed::Lac.name }
 
       it 'returns true' do
-        expect(subject.lcpe_normalizable?).to be true
+        expect(upload.lcpe_normalizable?).to be true
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Upload, type: :model do
       let(:csv_type) { Lcpe::Lac.name }
 
       it 'returns true' do
-        expect(subject.lcpe_normalizable?).to be false
+        expect(upload.lcpe_normalizable?).to be false
       end
     end
 
@@ -142,29 +142,33 @@ RSpec.describe Upload, type: :model do
       let(:csv_type) { Weam.name }
 
       it 'returns true' do
-        expect(subject.lcpe_normalizable?).to be false
+        expect(upload.lcpe_normalizable?).to be false
       end
     end
   end
-  
+
   describe '#normalize_lcpe!' do
     context 'when upload fails' do
-      subject(:upload) { build :upload,:failed_upload }
+      subject(:upload) { build :upload, :failed_upload }
+
+      let(:csv_klass) { Lcpe::Feed::Lac }
 
       it 'does not receive #normalize_lcpe! after save' do
-        expect(subject).not_to receive(:normalize_lcpe!)
-        subject.save
+        allow(csv_klass).to receive(:normalize)
+        upload.save
+        expect(csv_klass).not_to have_received(:normalize)
       end
     end
 
     context 'when upload ok but not normalizable' do
       subject(:upload) { build :upload, :valid_upload, user: user, csv_type: csv_klass.name }
 
-      let(:csv_klass) { Lcpe::Lac }
+      let(:csv_klass) { Weam }
 
       it 'does not receive #normalize_lcpe! after save' do
-        expect(subject).not_to receive(:normalize_lcpe!)
-        subject.save
+        allow(Lcpe::PreloadDataset).to receive(:build)
+        upload.save
+        expect(Lcpe::PreloadDataset).not_to have_received(:build)
       end
     end
 
@@ -172,23 +176,26 @@ RSpec.describe Upload, type: :model do
       subject(:upload) { build :upload, :valid_upload, user: user, csv_type: csv_klass.name }
 
       let(:csv_klass) { Lcpe::Feed::Lac }
-      let(:sql_context) { double('Lcpe::SqlContext::Sql') }
+      let(:sql_context) { instance_double('Lcpe::SqlContext::Sql') }
       let(:normalized_klass) { csv_klass.const_get(:NORMALIZED_KLASS) }
 
       it 'receives #normalize_lcpe!' do
-        expect(subject).to receive(:normalize_lcpe!)
-        subject.save
+        allow(csv_klass).to receive(:normalize)
+        upload.save
+        expect(csv_klass).to have_received(:normalize)
       end
 
       it 'generates and executes SQL context' do
         allow(csv_klass).to receive(:normalize).and_return(sql_context)
-        expect(sql_context).to receive(:execute)
-        subject.normalize_lcpe!
+        allow(sql_context).to receive(:execute)
+        upload.normalize_lcpe!
+        expect(sql_context).to have_received(:execute)
       end
 
       it 'builds preload dataset' do
-        expect(Lcpe::PreloadDataset).to receive(:build).with(normalized_klass)
-        subject.normalize_lcpe!
+        allow(Lcpe::PreloadDataset).to receive(:build)
+        upload.normalize_lcpe!
+        expect(Lcpe::PreloadDataset).to have_received(:build).with(normalized_klass)
       end
     end
   end


### PR DESCRIPTION
Additional specs to improve coverage for GIDS sequential program file upload. In process noticed bug where :csv_row was being saved a row relative to the intermediate sequential file but needed to reflect original file row. So offset was implemented for sequential upload