### PR TITLE
migration to create version_public_exports

### DIFF
--- a/db/migrate/20250610181818_create_version_public_exports.rb
+++ b/db/migrate/20250610181818_create_version_public_exports.rb
@@ -1,0 +1,11 @@
+class CreateVersionPublicExports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :version_public_exports do |t|
+      t.bigint :version_id
+      t.string :file_type
+      t.binary :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_15_154210) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_10_181818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
   enable_extension "earthdistance"
@@ -1802,6 +1802,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_15_154210) do
     t.string "settlement_link"
     t.string "school_closing_date"
     t.boolean "sec_702"
+  end
+
+  create_table "version_public_exports", force: :cascade do |t|
+    t.bigint "version_id"
+    t.string "file_type"
+    t.binary "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "versioned_complaints", force: :cascade do |t|


### PR DESCRIPTION
## Description

This is the migration-only portion of https://github.com/department-of-veterans-affairs/gibct-data-service/pull/1429/commits. This way we can do the migrations in one deploy, before doing the full code push.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
