### PR TITLE
preload associations for version public exports to cut down on n+1 qu…

### DIFF
--- a/app/models/version_public_export.rb
+++ b/app/models/version_public_export.rb
@@ -21,7 +21,11 @@ class VersionPublicExport < ApplicationRecord
   def self.write_compressed_institution_data(version, writer, progress_callback: nil)
     total_count = Institution.approved_institutions(version).count
     i = 0
-    Institution.approved_institutions(version).find_each do |institution|
+    Institution.approved_institutions(version)
+               .includes(:yellow_ribbon_programs, :institution_programs,
+                         :versioned_school_certifying_officials, :caution_flags,
+                         :institution_rating)
+               .find_each do |institution|
       progress_callback.call("VersionPublicExport: processed #{i}/#{total_count}") if progress_callback && (i % 100).zero?
       begin
         writer << InstitutionProfileSerializer.new(institution).to_json << "\n"


### PR DESCRIPTION
## Description

When building the version export for a version, we have to iterate through and serialize all active institutions. This can take a while. This PR hopefully helps reduce that time a bit by eliminating several N+1 queries associated with serializing an institution. Benchmarking it locally, it reduced the number of sql queries from 297541 to 201507, and the total run time from 737 seconds to 408 seconds.