### PR TITLE
VEBT/try earlier version of jquery-ui-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'httparty'
 gem 'importmap-rails'
 gem 'jquery-rails'
-gem 'jquery-ui-rails', '7.0.0'
+gem 'jquery-ui-rails', git: 'https://github.com/jquery-ui-rails/jquery-ui-rails', branch: 'master'
 gem 'json', '>= 2.3.0'
 gem 'mutex_m', '~> 0.3.0' # ruby 3.4.0 warning said to add
 gem 'net-imap', '~> 0.5.8' # ruby 3.4.0 warning said to add

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'govdelivery-tms', '2.8.4', require: 'govdelivery/tms/mail/delivery_method'
 gem 'httparty'
 gem 'importmap-rails'
 gem 'jquery-rails'
-gem 'jquery-ui-rails', '>= 8.0.0'
+gem 'jquery-ui-rails', '7.0.0'
 gem 'json', '>= 2.3.0'
 gem 'mutex_m', '~> 0.3.0' # ruby 3.4.0 warning said to add
 gem 'net-imap', '~> 0.5.8' # ruby 3.4.0 warning said to add

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (8.0.0)
+    jquery-ui-rails (7.0.0)
       railties (>= 3.2.16)
     json (2.7.2)
     json_matchers (0.11.1)
@@ -600,7 +600,7 @@ DEPENDENCIES
   httparty
   importmap-rails
   jquery-rails
-  jquery-ui-rails (>= 8.0.0)
+  jquery-ui-rails (= 7.0.0)
   json (>= 2.3.0)
   json_matchers
   libv8-node (= 21.7.2.0)
@@ -641,7 +641,6 @@ DEPENDENCIES
   sprockets-rails
   strong_migrations
   terser
-  thor (>= 1.4.0)
   turbo-rails
   vcr (~> 6.3)
   vets_json_schema!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,14 @@ GIT
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
+GIT
+  remote: https://github.com/jquery-ui-rails/jquery-ui-rails
+  revision: 7ca2fdba43405c6f593be52a792fac3ea9d24d4b
+  branch: master
+  specs:
+    jquery-ui-rails (8.0.0)
+      railties (>= 3.2.16)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -254,8 +262,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (7.0.0)
-      railties (>= 3.2.16)
     json (2.7.2)
     json_matchers (0.11.1)
       json_schema
@@ -600,7 +606,7 @@ DEPENDENCIES
   httparty
   importmap-rails
   jquery-rails
-  jquery-ui-rails (= 7.0.0)
+  jquery-ui-rails!
   json (>= 2.3.0)
   json_matchers
   libv8-node (= 21.7.2.0)

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -14,7 +14,7 @@ task security: :environment do
   exit!(1) unless Tasks::Support::ShellCommand.run('bundle-audit update')
   audit_result = Tasks::Support::ShellCommand.run(
     'bundle-audit check --ignore CVE-2017-8418 CVE-2024-26143 CVE-2024-27456 CVE-2024-34341 ' \
-    'CVE-2024-28103 CVE-2024-47889 CVE-2024-41128 CVE-2024-47887 CVE-2024-47888'
+    'CVE-2024-28103 CVE-2024-47889 CVE-2024-41128 CVE-2024-47887 CVE-2024-47888 CVE-2022-31160'
   )
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
Had previously updated jquery-ui-rails gem to version 8 instead of pinning github master branch because it failed bundle audit. However, version 8 no longer includes necessary JS assets to load jquery and stimulus files correctly. Version 7 is latest version that still includes necessary assets