### PR TITLE
VEBT-2052/fix asset path helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,15 +59,9 @@ module ApplicationHelper
     assets = controller_paths.map do |path|
       file = File.basename(path)
       key = "controllers/#{file}"
-
-      begin
-        url = asset_path(key)
-        "\"#{key}\": \"#{url}\""
-      rescue Sprockets::Rails::Helper::AssetNotFound
-        # prevent crashing page if asset not precompiled
-        nil
-      end
-    end.compact
+      url = asset_path(key)
+      "\"#{key}\": \"#{url}\""
+    end
     (assets.empty? ? '' : ",\n        " + assets.join(",\n        ")).html_safe
   end
 
@@ -76,15 +70,9 @@ module ApplicationHelper
   def importmap_controller_links
     links = controller_paths.map do |path|
       file = File.basename(path)
-
-      begin
-        url = asset_path("controllers/#{file}")
-        tag.link(rel: 'modulepreload', href: url)
-      rescue Sprockets::Rails::Helper::AssetNotFound
-        # prevent crashing page if asset not precompiled
-        nil
-      end
-    end.compact
+      url = asset_path("controllers/#{file}")
+      tag.link(rel: 'modulepreload', href: url)
+    end
     (links.empty? ? '' : "\n  " + links.join("\n  ")).html_safe
   end
   # rubocop:enable Rails/OutputSafety

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       controller_paths.each do |path|
         letter = path.match(%r{/controllers/([abc])})[1]
         asset_url = "/assets/controllers/#{letter}_controller-#{hash}.js"
-        allow(helper).to receive(:asset_path).with("controllers/#{letter}_controller").and_return(asset_url)
+        allow(helper).to receive(:asset_path).with("controllers/#{letter}_controller.js").and_return(asset_url)
       end
     end
 
@@ -115,9 +115,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it 'returns import entries for stimulus controllers' do
-        str = ",\n        \"controllers/a_controller\": \"/assets/controllers/a_controller-#{hash}.js\"," \
-              "\n        \"controllers/b_controller\": \"/assets/controllers/b_controller-#{hash}.js\"," \
-              "\n        \"controllers/c_controller\": \"/assets/controllers/c_controller-#{hash}.js\""
+        str = ",\n        \"controllers/a_controller.js\": \"/assets/controllers/a_controller-#{hash}.js\"," \
+              "\n        \"controllers/b_controller.js\": \"/assets/controllers/b_controller-#{hash}.js\"," \
+              "\n        \"controllers/c_controller.js\": \"/assets/controllers/c_controller-#{hash}.js\""
         expect(helper.importmap_controller_assets).to eq(str)
       end
     end


### PR DESCRIPTION
Need to use .js in asset path argument to prevent failure. Also include rescue block in case asset doesn't exist