### PR TITLE
VEBT-2052/reconfigure stimulus setup

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus";
+
+const application = Application.start();
+
+// Configure Stimulus development experience
+application.debug = false;
+window.Stimulus = application;
+
+export { application };

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,4 @@
-import { Application } from "@hotwired/stimulus"
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-
-const application = Application.start()
-eagerLoadControllersFrom("controllers", application)
+// Import and register all your controllers from the importmap via controllers/**/*_controller
+import { application } from "controllers/application";
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading";
+eagerLoadControllersFrom("controllers", application);

--- a/app/javascript/main.js
+++ b/app/javascript/main.js
@@ -1,6 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-
 // Renamed from application.js to main.js to avoid name collision with legacy app/assets/javascripts/application.js
 
-import "@hotwired/turbo-rails"
-import "./controllers"
+import "@hotwired/turbo-rails";
+import "controllers";


### PR DESCRIPTION
Fix import typo and reconfigure stimulus setup to closely align with boilerplate when you generate Rails 7 app with --javascript=importmap