### PR TITLE
VEBT-2052/fix apply rates route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,10 +48,10 @@ Rails.application.routes.draw do
 
   resources :calculator_constants, only: [:index] do
     post :update, on: :collection
-    post 'apply_rate_adjustments/:rate_adjustment_id', on: :collection, to: 'calculator_constants#apply_rate_adjustments'
     get 'export' => 'calculator_constants#export', on: :collection, defaults: { format: 'csv' }
-
   end
+
+  post '/calculator_constants/apply_rate_adjustments/:rate_adjustment_id', to: 'calculator_constants#apply_rate_adjustments'
 
   resources :rate_adjustments, only: [] do
     post :update, on: :collection


### PR DESCRIPTION
The POST calculator_constants/apply_rate_adjustments/:rate_adjustment_id route was defined as on: :collection because it updates entire collection of calculator constants. This was fine locally but under the hood on: :collection with a post request with dynamic rate_adjustment_id does not resolve as you would expect in staging/production. So redefined the route outside of the resources block and removed on collection