### PR TITLE
remove spec that makes real network call

### DIFF
--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -104,11 +104,4 @@ describe Common::Client::Base do
       end
     end
   end
-
-  describe '#get' do
-    it 'returns status 200' do
-      response = test_service.send(:perform, :get, '/', {})
-      expect(response.status).to eq(200)
-    end
-  end
 end


### PR DESCRIPTION
## Description

One of the specs was making a real network request to http://example.com. This has been causing intermittent failures (especially during Jenkins CI builds). The test doesn't really seem to _do_ anything other than check for a 200. We could stub the network call with WebMock or VCR or similar, but it seems like removing such a trivial spec might be the easier way to go.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
