### PR TITLE
add webmock and disallow rspec network requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'simplecov-single_file', require: false, group: :test
   gem 'vcr', '~> 6.3'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,9 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     csv (3.3.0)
     database_cleaner (2.1.0)
@@ -240,6 +243,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (1.2.0)
     headless (2.3.1)
     httparty (0.23.1)
       csv
@@ -562,6 +566,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -657,6 +665,7 @@ DEPENDENCIES
   virtus (~> 2.0.0)
   watir (~> 7.3)
   web-console (~> 4.2)
+  webmock
   will_paginate
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 
 require 'simplecov'
 require 'simplecov/single_file'
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!
+
 SimpleCov.start do
   SimpleCov.minimum_coverage_by_file 90
 

--- a/spec/utilities/no_key_apis/dynamic_download_source_spec.rb
+++ b/spec/utilities/no_key_apis/dynamic_download_source_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe NoKeyApis::DynamicDownloadSource do
   end
 
   describe '#cache_key' do
+    before do
+      stub_request(:get, "http://example.com/").to_return(status: 200, body: '', headers: {})
+    end
+
     it 'returns the CACHE_KEY constant if defined in subclass' do
       instance = CacheableDummyDownloadSource.new('http://example.com')
       expect(instance.send(:cache_key)).to eq('dummy_html_cache_key')
@@ -67,6 +71,10 @@ RSpec.describe NoKeyApis::DynamicDownloadSource do
   end
 
   describe '#parse_html when the subclass does not implement it' do
+    before do
+      stub_request(:get, "http://example.com/").to_return(status: 200, body: '', headers: {})
+    end
+
     it 'raises NotImplementedError when not implemented in subclass' do
       expect do
         BrokenDummyDownloadSource.new('http://example.com')

--- a/spec/utilities/no_key_apis/dynamic_download_source_spec.rb
+++ b/spec/utilities/no_key_apis/dynamic_download_source_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe NoKeyApis::DynamicDownloadSource do
 
   describe '#cache_key' do
     before do
-      stub_request(:get, "http://example.com/").to_return(status: 200, body: '', headers: {})
+      stub_request(:get, 'http://example.com/').to_return(status: 200, body: '', headers: {})
     end
 
     it 'returns the CACHE_KEY constant if defined in subclass' do
@@ -72,7 +72,7 @@ RSpec.describe NoKeyApis::DynamicDownloadSource do
 
   describe '#parse_html when the subclass does not implement it' do
     before do
-      stub_request(:get, "http://example.com/").to_return(status: 200, body: '', headers: {})
+      stub_request(:get, 'http://example.com/').to_return(status: 200, body: '', headers: {})
     end
 
     it 'raises NotImplementedError when not implemented in subclass' do


### PR DESCRIPTION
## Description

add the [webmock](https://github.com/bblimke/webmock) gem which allows us to mock requests during specs, but also has an option to throw an error if a real http request is made during rspec. In generally, it's not a good idea to do real network requests during specs, and in fact this was causing intermittent failures (one of which was fixed in a [recent PR](https://github.com/department-of-veterans-affairs/gibct-data-service/pull/1505)). This PR also managed to find a couple of spots where real requests were made. These were fixed by stubbing the response.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
