### PR TITLE
activate solid queue in staging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,9 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :solid_queue
+  if ENV['DEPLOYMENT_ENV'] == 'vagov-staging'
+    config.active_job.queue_adapter =  :solid_queue
+  end
   # config.active_job.queue_name_prefix = "gibct_data_service_production"
   
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
## Description

solid queue workers are currently running in staging, and we want to test out that jobs get processed as expected. There is no "staging" environment for this app though, as the only environment files are `test.rb`, `development.rb`, and `production.rb`. So the 'staging' instances we have in AWS are actually running as production (i.e. `RAILS_ENV==production`). But, there is still a way to tell the difference between staging-production and real-production: the `DEPLOYMENT_ENV` env var. Using that, we can use the new solid_queue active job adapter in staging, and leave production untouched. This should give us the ability to play around (and possibly break things) in staging and not worry about messing up production.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
