### PR TITLE
add background job dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,4 +106,5 @@ group :development do
   gem 'spring', platforms: :ruby
 end
 
+gem 'mission_control-jobs'
 gem 'solid_queue', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,16 @@ GEM
     mini_racer (0.12.0)
       libv8-node (~> 21.7.2.0)
     minitest (5.25.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.7.5)
     multi_json (1.15.0)
     multi_xml (0.7.1)
@@ -535,6 +545,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
     stringio (3.1.6)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
@@ -625,6 +637,7 @@ DEPENDENCIES
   json_matchers
   libv8-node (= 21.7.2.0)
   mini_racer
+  mission_control-jobs
   mutex_m (~> 0.3.0)
   net-imap (~> 0.5.8)
   newrelic_rpm

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -23,6 +23,7 @@
         <li class="<%= li_active_class(archives_path) %>"><%= link_if_not_active 'Archives', archives_path %></li>
         <li class="<%= li_active_class(calculator_constants_path) %>"><%= link_if_not_active 'Calculator Constants', calculator_constants_path  %></li>
         <li class="<%= li_active_class(yellow_ribbon_degree_level_translations_path) %>"><%= link_if_not_active 'YRP Degree Levels', yellow_ribbon_degree_level_translations_path %></li>
+        <li class="<%= li_active_class(mission_control_jobs_path) %>"><%= link_if_not_active 'Background Jobs', mission_control_jobs_path %></li>
       </ul>
 
       <ul class="nav navbar-nav navbar-right">

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,7 @@ module GibctDataService
   class Application < Rails::Application
     config.load_defaults '7.0' # enables zeitwerk mode in CRuby
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
+    # Please, add to the `ignore` list any other `lib` subdirectories that do # not contain `.rb` files, or that should not be reloaded or eager loaded.  # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
 
     # Configuration for the application, engines, and railties goes here.
@@ -44,6 +42,8 @@ module GibctDataService
 
     # YAML Defaults for CSV
     config.csv_defaults = YAML.load_file(Rails.root.join('config', 'csv_file_defaults.yml'))
+
+    config.mission_control.jobs.http_basic_auth_enabled = false
 
     # Rails 7 upgrade - turn off warnings
     # https://stackoverflow.com/questions/76347365/how-do-i-set-legacy-connection-handling-to-false-in-my-rails-application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   end
 
   resources :yellow_ribbon_degree_level_translations, except: [:create, :new, :destroy], path: :degree_levels
+  mount MissionControl::Jobs::Engine, at: "/jobs"
 
   post '/calculator_constants/apply_rate_adjustments/:rate_adjustment_id', to: 'calculator_constants#apply_rate_adjustments'
 


### PR DESCRIPTION
## Description

Now that solid_queue is live and doing it's thing, it'd be nice to have a UI to manage any background jobs (similar to what Sidekiq UI offers). Fortunately, there's a [gem for that](https://github.com/rails/mission_control-jobs). This PR add the gem and a couple of config params to get it working.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots
<img width="1543" height="936" alt="jobs_ui" src="https://github.com/user-attachments/assets/c398a2a3-1bb8-43d9-8c72-547dfa0c2aba" />


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
