### PR TITLE
VEBT/archive code climate binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /srv/gi-bill-data-service/src
 # this stage is used for local development with docker-compose.yml
 ###
 FROM base AS development
-RUN curl -L -o /usr/local/bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 && \
-    chmod +x /usr/local/bin/cc-test-reporter && \
-    cc-test-reporter --version
+# RUN curl -L -o /usr/local/bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 && \
+#     chmod +x /usr/local/bin/cc-test-reporter && \
+#     cc-test-reporter --version
 
 COPY --chown=gi-bill-data-service:gi-bill-data-service docker-entrypoint.sh ./
 USER gi-bill-data-service

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -10,7 +10,7 @@ namespace :spec do
   task with_codeclimate_coverage: :environment do
     if ENV['CC_TEST_REPORTER_ID']
       puts 'notifying CodeClimate of test run'
-      system('/cc-test-reporter before-build')
+      system('lib/cc-test-reporter before-build')
     end
     exit_status = begin
       Rake::Task['spec'].invoke
@@ -22,7 +22,7 @@ namespace :spec do
 
     if ENV['CC_TEST_REPORTER_ID']
       puts 'reporting coverage to CodeClimate'
-      system('/cc-test-reporter after-build -t simplecov')
+      system('lib/cc-test-reporter after-build -t simplecov')
     end
     exit exit_status
   end


### PR DESCRIPTION
Code climate test reporter has been deprecated. Our dockerfile is downloading binary from their site but it's returning 404. This issue has happened in past and resolved itself. But given that it's happening again, we need to find alternative otherwise pipeline will fail. We got binary from code climate and from [releases](https://github.com/codeclimate/test-reporter/releases/tag/v0.11.1) and added it to lib. This will unblock pipeline for time being. But we should migrate away from code climate. (vets-api uses simplecov and github actions)