### PR TITLE
enable solid_queue in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,9 +83,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  if ENV['DEPLOYMENT_ENV'] == 'vagov-staging'
-    config.active_job.queue_adapter =  :solid_queue
-  end
+  config.active_job.queue_adapter =  :solid_queue
   # config.active_job.queue_name_prefix = "gibct_data_service_production"
   
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
## Description

Background job workers are up and running in production. As such, we can start using the real solid_queue adapter in production.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
