### PR TITLE
ci: fix Build And Publish & Tf Plan workflow

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -6,6 +6,10 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     uses: department-of-veterans-affairs/prt-github-workflows/.github/workflows/build-and-publish.yaml@main

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,7 +1,6 @@
 name: "Build And Publish"
 run-name: "Build And Publish"
 
-# Trigger on push and also allow manual run
 on:
   push:
 

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -4,7 +4,6 @@ run-name: "Build And Publish"
 # Trigger on push and also allow manual run
 on:
   push:
-  workflow_dispatch:
 
 permissions:
   actions: write

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,7 +1,10 @@
 name: "Build And Publish"
 run-name: "Build And Publish"
 
-on: [push]
+# Trigger on push and also allow manual run
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -7,9 +7,20 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
-  contents: read
-
+  actions: write
+  attestations: write
+  checks: write
+  contents: write
+  deployments: write
+  discussions: write
+  issues: write
+  models: read
+  packages: write
+  pages: write
+  pull-requests: write
+  repository-projects: write
+  statuses: write
+  security-events: write
 jobs:
   build:
     uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/build-and-publish.yaml@main

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -7,20 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
-  attestations: write
-  checks: write
   contents: write
-  deployments: write
-  discussions: write
-  issues: write
-  models: read
   packages: write
-  pages: write
-  pull-requests: write
-  repository-projects: write
-  statuses: write
-  security-events: write
+  id-token: write
 jobs:
   build:
     uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/build-and-publish.yaml@main

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   build:
-    uses: department-of-veterans-affairs/prt-github-workflows/.github/workflows/build-and-publish.yaml@main
+    uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/build-and-publish.yaml@main
     secrets: inherit

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -7,8 +7,20 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
+  attestations: write
+  checks: write
   contents: write
+  deployments: write
+  discussions: write
+  issues: write
+  models: read
   packages: write
+  pages: write
+  pull-requests: write
+  repository-projects: write
+  statuses: write
+  security-events: write
   id-token: write
 jobs:
   build:

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -5,5 +5,5 @@ on: [pull_request]
 
 jobs:
   pr-tf-plan:
-    uses: department-of-veterans-affairs/prt-github-workflows/.github/workflows/tf-plan.yaml@main
+    uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/tf-plan.yaml@main
     secrets: inherit


### PR DESCRIPTION
## Description
Need the ability to build and push images to the ECR repo. Permissions added to the `prt-gha-oidc-role` role to allow AWS OIDC for shared workflows. This pull request updates GitHub Actions workflow configurations to use a new shared workflow repository and expands the permissions required by the build and publish workflow. These changes help standardize CI/CD processes and provide more granular control over workflow permissions.

**Workflow configuration updates:**

* Updated the `build-and-publish.yaml` workflow to use shared workflows from the `vsp-github-actions` repository instead of `prt-github-workflows`, and enabled manual triggering via `workflow_dispatch`. Also added explicit permissions for various GitHub Actions features. (.github/workflows/build-and-publish.yaml)
* Updated the `tf-plan.yaml` workflow to use the `vsp-github-actions` shared workflow instead of `prt-github-workflows`. (.github/workflows/tf-plan.yaml)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#119897


## Screenshots
Build & Publish - https://github.com/department-of-veterans-affairs/gibct-data-service/actions/runs/18562656142
TF Plan - https://github.com/department-of-veterans-affairs/gibct-data-service/actions/runs/18562657052
<img width="1041" height="422" alt="image" src="https://github.com/user-attachments/assets/a9ed53c9-82ab-41f7-b0ba-e30d170fc4c8" />
