### PR TITLE
Move VA certificate installation earlier in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN groupadd -g $userid -r gi-bill-data-service && \
 RUN apt-get update -qq && apt-get install -y \
     build-essential git curl wget libpq-dev dumb-init shared-mime-info nodejs cron file
 
+# Clone platform-va-ca-certificate and copy certs
+WORKDIR /tmp
+RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/platform-va-ca-certificate && \
+    cp platform-va-ca-certificate/VA*.cer . && \
+    /bin/bash platform-va-ca-certificate/debian-ubuntu/install-certs.sh && \
+    rm -rf /tmp/*
+
 RUN mkdir -p /srv/gi-bill-data-service/src && \
     chown -R gi-bill-data-service:gi-bill-data-service /srv/gi-bill-data-service
 WORKDIR /srv/gi-bill-data-service/src
@@ -79,13 +86,6 @@ ENV RAILS_ENV="production"
 ENV PATH="/usr/local/bundle/bin:${PATH}"
 
 RUN whoami
-
-# Clone platform-va-ca-certificate and copy certs
-WORKDIR /tmp
-RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/platform-va-ca-certificate && \
-    cp platform-va-ca-certificate/VA*.cer . && \
-    /bin/bash platform-va-ca-certificate/debian-ubuntu/install-certs.sh && \
-    rm -rf /tmp/*
 
 WORKDIR /srv/gi-bill-data-service/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 USER root
 ENV BUNDLER_VERSION='2.6.0'
 
-# Copy all VA certs into Docker image
-COPY va-certs/*.crt /usr/local/share/ca-certificates/va/
-
-# Update system CA trust store
+# Reuse VA certs already installed in base and update system CA trust store
 RUN update-ca-certificates
 
 # Copy application code

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,13 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--", "./docker-entrypoint.sh"]
 ###
 FROM development AS builder
 
-ENV BUNDLER_VERSION='2.6.0'
+# Ensure SSL trust for bundler/rubygems
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
+
+# Install Bundler as root first to avoid user SSL inheritance issues
+USER root
+ENV BUNDLER_VERSION='2.6.0'
 
 ARG bundler_opts
 COPY --chown=gi-bill-data-service:gi-bill-data-service . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["/bin/bash", "-c"]
 RUN groupadd -g $userid -r gi-bill-data-service && \
     useradd -u $userid -r -g gi-bill-data-service -d /srv/gi-bill-data-service gi-bill-data-service
 RUN apt-get update -qq && apt-get install -y \
-    build-essential git curl wget libpq-dev dumb-init shared-mime-info nodejs cron file
+    build-essential git curl wget libpq-dev dumb-init shared-mime-info nodejs cron file ca-certificates
 
 # Clone platform-va-ca-certificate and copy certs
 WORKDIR /tmp
@@ -48,6 +48,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--", "./docker-entrypoint.sh"]
 FROM development AS builder
 
 ENV BUNDLER_VERSION='2.6.0'
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 ARG bundler_opts
 COPY --chown=gi-bill-data-service:gi-bill-data-service . .


### PR DESCRIPTION
Relocates the cloning and installation of VA CA certificates to an earlier stage in the Dockerfile, before application directory setup. This ensures certificates are available for subsequent build steps and improves Docker layer caching.

## Description

## Original issue(s)
department-of-veterans-affairs/va.gov-team#119897

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
