### PR TITLE
VEBT-3366/Multi-user version generation bug fix

### DIFF
--- a/app/controllers/preview_statuses_controller.rb
+++ b/app/controllers/preview_statuses_controller.rb
@@ -3,20 +3,16 @@
 class PreviewStatusesController < ApplicationController
   include CommonInstitutionBuilder::VersionGeneration
 
-  before_action :check_status, only: :poll
-
   def poll
+    @preview_status = PreviewGenerationStatusInformation.latest
+    @preview_generation_completed = @preview_status.nil? || check_completion
+
     respond_to do |format|
       format.turbo_stream { render template: 'messages/update' }
     end
   end
 
   private
-
-  def check_status
-    @preview_status = PreviewGenerationStatusInformation.latest
-    @preview_generation_completed = @preview_status.nil? || check_completion
-  end
 
   def check_completion
     return false unless @preview_status.current_progress.start_with?(PUBLISH_COMPLETE_TEXT) ||

--- a/app/views/messages/update.turbo_stream.erb
+++ b/app/views/messages/update.turbo_stream.erb
@@ -1,9 +1,11 @@
-<%= turbo_stream.replace "preview_status" do %>
-  <div id="preview_status">
-    <aside class="alert alert-info">
-      <%= @preview_status&.current_progress&.html_safe %>
-    </aside>
-  </div>
+<% if @preview_status.present? %>
+  <%= turbo_stream.replace "preview_status" do %>
+    <div id="preview_status">
+      <aside class="alert alert-info">
+        <%= @preview_status.current_progress.html_safe %>
+      </aside>
+    </div>
+  <% end %>
 <% end %>
 
 <% if @preview_generation_completed %>


### PR DESCRIPTION
Due to quirk if more than one user polling version generation status, other users will render an empty blue aside after version generation completed. Use guard clause in turbo stream to prevent this from happening

https://jira.devops.va.gov/browse/VEBT-3366