### PR TITLE
VEBT/Fix upload error handling redirect

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -34,7 +34,7 @@ class UploadsController < ApplicationController
     rescue StandardError => e
       handle_upload_error(e)
 
-      return render :new unless sequential?
+      return redirect_to new_upload_path(@upload.csv_type) unless sequential?
 
       render json: { error: e }, status: :internal_server_error
     end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe UploadsController, type: :controller do
                      upload_file: upload_file, skip_lines: 0, comment: 'Test', csv_type: 'Blah'
                    }
                  })
-          ).to render_template(:new)
+          ).to redirect_to(new_upload_path('Blah'))
         end
       end
 
@@ -321,7 +321,7 @@ RSpec.describe UploadsController, type: :controller do
                  params: {
                    upload: { upload_file: nil, skip_lines: 0, comment: 'Test', csv_type: klass.name }
                  })
-          ).to render_template(:new)
+          ).to redirect_to(new_upload_path(klass.name))
         end
       end
     end
@@ -354,7 +354,7 @@ RSpec.describe UploadsController, type: :controller do
         expect(
           post(:create,
                params: { upload: { upload_file: file, skip_lines: 0, comment: 'Test', csv_type: klass.name } })
-        ).to render_template(:new)
+        ).to redirect_to(new_upload_path(klass.name))
         error_message = 'Unable to determine column separators, valid separators equal "|" and ","'
         expect(flash[:danger]).to include(error_message)
       end


### PR DESCRIPTION
With turbo enabled, form POST requests expect a redirect or turbo stream in response. So return :new was raising browser error and needs to be refactored as return redirect_to. It seemed like an issue with HCM file but that was because HCM file itself was blank in staging and it was the error handling that wasn't working properly