### PR TITLE
use a nightly job to generate public exports

### DIFF
--- a/app/jobs/generate_public_export_job.rb
+++ b/app/jobs/generate_public_export_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class GeneratePublicExportJob < ApplicationJob
-  def perform(version_id)
-    version = Version.find(version_id)
+  def perform
+    version = Version.current_production
     existing_export = VersionPublicExport.find_by(version: version)
 
     return if existing_export

--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -69,10 +69,6 @@ module InstitutionBuilder
       # TO-DO: enable public export
       # build_public_export(version.id) if production? || ENV['CI'].blank?
 
-      # Do not build in unless production or local environment
-      # Ultimately we're pulling this out and putting it in a batch job overnite
-      # GeneratePublicExportJob.perform_later(version.id) if production? || ENV['CI']
-
       rate_institutions(version.id) if
         ENV['DEPLOYMENT_ENV'].eql?('vagov-dev') || ENV['DEPLOYMENT_ENV'].eql?('vagov-staging')
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,4 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+production:
+  nightly_export_build:
+    class: GeneratePublicExportJob
+    schedule: at 4am every day

--- a/spec/jobs/generate_public_export_job_spec.rb
+++ b/spec/jobs/generate_public_export_job_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe GeneratePublicExportJob, type: :job do
       end
 
       it 'just returns' do
-        job.perform(version.id)
+        job.perform
         expect(VersionPublicExport).not_to have_received(:build)
       end
     end
 
     context 'without an existing export' do
       it 'creates an export' do
-        expect { job.perform(version.id) }.to change(VersionPublicExport, :count).by(1)
+        expect { job.perform }.to change(VersionPublicExport, :count).by(1)
       end
     end
   end


### PR DESCRIPTION
## Description

Use the built-in 'recurring' config file that comes with solid_queue to run a job every night to generate a public export (if needed).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
