### PR TITLE
VEBT-3843: Fix IpedsHd fetch error

### DIFF
--- a/lib/common/shared.rb
+++ b/lib/common/shared.rb
@@ -29,8 +29,14 @@ module Common
     #
     # replace all spaces and dashes with underscores
     # then reduce duplicate underscores in a row to a single underscore
+    # Also strips BOM (Byte Order Mark) characters that may appear at the start of CSV files
     def self.convert_csv_header(header)
-      header.gsub(/\s+|-+/, '_').gsub(/_+/, '_')
+      # Remove BOM characters (UTF-8, UTF-16, UTF-32)
+      cleaned = header.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+      cleaned = cleaned.gsub(/\A\xEF\xBB\xBF/, '') # UTF-8 BOM (raw bytes)
+      cleaned = cleaned.gsub(/\A\uFEFF/, '')        # UTF-16/UTF-32 BOM
+      cleaned = cleaned.sub(/\Aï»¿/, '')            # UTF-8 BOM misread as ISO-8859-1
+      cleaned.gsub(/\s+|-+/, '_').gsub(/_+/, '_')
     end
 
     def self.display_csv_header(header)

--- a/lib/roo_helper/loader.rb
+++ b/lib/roo_helper/loader.rb
@@ -205,9 +205,9 @@ module RooHelper
         # Strip BOM (Byte Order Mark) when determining column mapping
         # The BOM may appear as raw bytes or as garbled characters when read with wrong encoding
         key_cleaned = key.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
-        key_cleaned = key_cleaned.gsub(/\A\xEF\xBB\xBF/, '')     # UTF-8 BOM (raw bytes)
-        key_cleaned = key_cleaned.gsub(/\A\uFEFF/, '')            # UTF-16/UTF-32 BOM
-        key_cleaned = key_cleaned.sub(/\Aï»¿/, '')               # UTF-8 BOM misread as ISO-8859-1
+        key_cleaned = key_cleaned.gsub(/\A\xEF\xBB\xBF/, '') # UTF-8 BOM (raw bytes)
+        key_cleaned = key_cleaned.gsub(/\A\uFEFF/, '') # UTF-16/UTF-32 BOM
+        key_cleaned = key_cleaned.sub(/\Aï»¿/, '') # UTF-8 BOM misread as ISO-8859-1
         col_info = converter_info(sheet_klass, key_cleaned)
         column = col_info.blank? ? key_cleaned.downcase.to_sym : col_info[:column]
         headers_mapping[column] = file_header

--- a/spec/lib/common/shared_spec.rb
+++ b/spec/lib/common/shared_spec.rb
@@ -39,21 +39,19 @@ describe Common::Shared do
       expect(described_class.convert_csv_header(header)).to eq('a_header_to_&_test')
     end
 
-    it 'strips UTF-8 BOM characters (raw bytes)' do
-      # UTF-8 BOM: \xEF\xBB\xBF
-      header_with_bom = "\xEF\xBB\xBFUnitId"
-      expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
-    end
+    it 'strips UTF-8 and UTF-16/UTF-32 BOM characters' do
+      # UTF-8 BOM (raw bytes): \xEF\xBB\xBF
+      header_with_utf8_bom = "\xEF\xBB\xBFUnitId"
+      expect(described_class.convert_csv_header(header_with_utf8_bom)).to eq('UnitId')
 
-    it 'strips UTF-16/UTF-32 BOM characters' do
-      # Unicode BOM: \uFEFF
-      header_with_bom = "\uFEFFUnitId"
-      expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
+      # Unicode BOM: \uFEFF (UTF-16/UTF-32)
+      header_with_unicode_bom = "\uFEFFUnitId"
+      expect(described_class.convert_csv_header(header_with_unicode_bom)).to eq('UnitId')
     end
 
     it 'strips UTF-8 BOM misread as ISO-8859-1' do
       # UTF-8 BOM misread as ISO-8859-1: ï»¿
-      header_with_bom = "ï»¿UnitId"
+      header_with_bom = 'ï»¿UnitId'
       expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
     end
 

--- a/spec/lib/common/shared_spec.rb
+++ b/spec/lib/common/shared_spec.rb
@@ -38,6 +38,35 @@ describe Common::Shared do
       header = 'a header to  &  test'
       expect(described_class.convert_csv_header(header)).to eq('a_header_to_&_test')
     end
+
+    it 'strips UTF-8 BOM characters (raw bytes)' do
+      # UTF-8 BOM: \xEF\xBB\xBF
+      header_with_bom = "\xEF\xBB\xBFUnitId"
+      expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
+    end
+
+    it 'strips UTF-16/UTF-32 BOM characters' do
+      # Unicode BOM: \uFEFF
+      header_with_bom = "\uFEFFUnitId"
+      expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
+    end
+
+    it 'strips UTF-8 BOM misread as ISO-8859-1' do
+      # UTF-8 BOM misread as ISO-8859-1: ï»¿
+      header_with_bom = "ï»¿UnitId"
+      expect(described_class.convert_csv_header(header_with_bom)).to eq('UnitId')
+    end
+
+    it 'handles BOM with spaces and dashes correctly' do
+      # BOM followed by header with spaces/dashes
+      header_with_bom = "\xEF\xBB\xBFUnit-Id Header"
+      expect(described_class.convert_csv_header(header_with_bom)).to eq('Unit_Id_Header')
+    end
+
+    it 'handles headers without BOM normally' do
+      header = 'UnitId'
+      expect(described_class.convert_csv_header(header)).to eq('UnitId')
+    end
   end
 
   describe 'display_csv_header' do

--- a/spec/lib/roo_helper/loader_spec.rb
+++ b/spec/lib/roo_helper/loader_spec.rb
@@ -120,4 +120,79 @@ describe RooHelper::Loader do
         .to raise_error(StandardError, error_message)
     end
   end
+
+  describe 'non_scorecard_header_mappings' do
+    let(:ipeds_hd) { IpedsHd }
+
+    it 'maps headers with UTF-8 BOM (raw bytes) correctly' do
+      # UTF-8 BOM: \xEF\xBB\xBF
+      file_headers = ["\xEF\xBB\xBFUnitId", 'InstNm', 'Addr']
+      headers_mapping = {}
+      file_options = { liberal_parsing: false }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq("\xEF\xBB\xBFUnitId")
+      expect(result[:institution]).to eq('InstNm')
+      expect(result[:addr]).to eq('Addr')
+    end
+
+    it 'maps headers with UTF-16/UTF-32 BOM correctly' do
+      # Unicode BOM: \uFEFF
+      file_headers = ["\uFEFFUnitId", 'InstNm']
+      headers_mapping = {}
+      file_options = { liberal_parsing: false }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq("\uFEFFUnitId")
+      expect(result[:institution]).to eq('InstNm')
+    end
+
+    it 'maps headers with UTF-8 BOM misread as ISO-8859-1 correctly' do
+      # UTF-8 BOM misread as ISO-8859-1: ï»¿
+      file_headers = ["ï»¿UnitId", 'InstNm']
+      headers_mapping = {}
+      file_options = { liberal_parsing: false }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq("ï»¿UnitId")
+      expect(result[:institution]).to eq('InstNm')
+    end
+
+    it 'maps headers with BOM when liberal_parsing is enabled' do
+      file_headers = ["\xEF\xBB\xBF\"UnitId\"", 'InstNm']
+      headers_mapping = {}
+      file_options = { liberal_parsing: true }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq("\xEF\xBB\xBF\"UnitId\"")
+      expect(result[:institution]).to eq('InstNm')
+    end
+
+    it 'maps headers without BOM normally' do
+      file_headers = ['UnitId', 'InstNm', 'Addr']
+      headers_mapping = {}
+      file_options = { liberal_parsing: false }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq('UnitId')
+      expect(result[:institution]).to eq('InstNm')
+      expect(result[:addr]).to eq('Addr')
+    end
+
+    it 'handles unknown headers by downcasing them' do
+      file_headers = ["\xEF\xBB\xBFUnitId", 'UnknownHeader']
+      headers_mapping = {}
+      file_options = { liberal_parsing: false }
+
+      result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
+
+      expect(result[:cross]).to eq("\xEF\xBB\xBFUnitId")
+      expect(result[:unknownheader]).to eq('UnknownHeader')
+    end
+  end
 end

--- a/spec/lib/roo_helper/loader_spec.rb
+++ b/spec/lib/roo_helper/loader_spec.rb
@@ -151,13 +151,13 @@ describe RooHelper::Loader do
 
     it 'maps headers with UTF-8 BOM misread as ISO-8859-1 correctly' do
       # UTF-8 BOM misread as ISO-8859-1: ï»¿
-      file_headers = ["ï»¿UnitId", 'InstNm']
+      file_headers = ['ï»¿UnitId', 'InstNm']
       headers_mapping = {}
       file_options = { liberal_parsing: false }
 
       result = ipeds_hd.send(:non_scorecard_header_mappings, file_headers, headers_mapping, ipeds_hd, file_options)
 
-      expect(result[:cross]).to eq("ï»¿UnitId")
+      expect(result[:cross]).to eq('ï»¿UnitId')
       expect(result[:institution]).to eq('InstNm')
     end
 
@@ -173,7 +173,7 @@ describe RooHelper::Loader do
     end
 
     it 'maps headers without BOM normally' do
-      file_headers = ['UnitId', 'InstNm', 'Addr']
+      file_headers = %w[UnitId InstNm Addr]
       headers_mapping = {}
       file_options = { liberal_parsing: false }
 


### PR DESCRIPTION
## Description
I fixed IpedsHd fetch so that when you press fetch and then export, it successfully retrieves the csv file.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000
](https://jira.devops.va.gov/browse/VEBT-3843)

## Testing done
You can run on local, fetch the file and export and you will have populated csv file. I also got full test coverage on the files changed (would show screenshot but SimpleCov wasn't updating).

## Screenshots
<img width="1900" height="503" alt="image" src="https://github.com/user-attachments/assets/19aa1f87-c176-4c2e-97b1-9c4e4fdd8973" />
