### PR TITLE
change timeout parameter to 20 minutes, fix bug in seeding process

### DIFF
--- a/app/models/institution_builder.rb
+++ b/app/models/institution_builder.rb
@@ -88,7 +88,7 @@ module InstitutionBuilder
       begin
         Institution.transaction do
           # to fix 'cancelling statement due to statement timeout' issue
-          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '600s';")
+          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '1200s';")
           if staging?
             # Skipping validation here because of the scale of this query (it will timeout updating all 70k records)
             # rubocop:disable Rails/SkipsModelValidations

--- a/db/seeds/99_build.rb
+++ b/db/seeds/99_build.rb
@@ -1,19 +1,10 @@
-if ENV['CI'].blank?
-  user = User.first
+return unless ENV['CI'].blank?
 
-  puts 'Building Institutions'
-  InstitutionBuilder.run(user)
+user = User.first
 
-  version = Version.current_preview
-  if version
-    puts "Setting version: #{version.number} as production"
-    version.update(production: true)
+puts 'Building Institutions'
+InstitutionBuilder.run(user)
 
-    puts 'Building CrosswalkIssues'
-    CrosswalkIssue.rebuild
-
-    puts "Done ... Woo Hoo!!"
-  else
-    puts "Error occurred - check the logs"
-  end
-end
+puts 'Building CrosswalkIssues'
+CrosswalkIssue.rebuild
+puts "Done ... Woo Hoo!!"


### PR DESCRIPTION
## Description
Generate Version is timing out in production after database encryption was applied. The timeout parameter has been increased from 10 to 20 minutes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
The issue is happening in production. We will know if this fixed the issue after it is pushed.

## Screenshots


## Acceptance criteria
- [x] All Rspec tests passing

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [  ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
