### PR TITLE
Implement Procfile.dev & Foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,13 +97,15 @@ group :development, :test do
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 4.2', platforms: :ruby
-
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'foreman'
+
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring', platforms: :ruby
+
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console', '~> 4.2', platforms: :ruby
 end
 
 gem 'mission_control-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.4.1)
+    date (3.5.1)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     descendants_tracker (0.0.4)
@@ -174,6 +174,7 @@ GEM
     diff-lcs (1.6.0)
     docile (1.4.0)
     drb (2.2.1)
+    erb (6.0.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -215,6 +216,8 @@ GEM
       thor (>= 0.14.0, < 2)
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
+    foreman (0.90.0)
+      thor (~> 1.4)
     formatador (1.1.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
@@ -357,7 +360,7 @@ GEM
       method_source (~> 1.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
-    psych (5.2.3)
+    psych (5.3.0)
       date
       stringio
     public_suffix (5.0.4)
@@ -413,8 +416,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.13.0)
+    rdoc (6.17.0)
+      erb
       psych (>= 4.0.0)
+      tsort
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -547,7 +552,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.1.6)
+    stringio (3.1.9)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
     terminal-table (3.0.2)
@@ -558,6 +563,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.1.0)
     timeout (0.4.3)
+    tsort (0.2.0)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -625,6 +631,7 @@ DEPENDENCIES
   faraday_middleware
   figaro
   font-awesome-rails (= 4.7.0.9)
+  foreman
   geocoder (~> 1.8)
   govdelivery-tms (= 2.8.4)
   guard-rspec

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 4000
+jobs: bin/jobs

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ bin/jobs
 
 This will start the Solid Queue worker process and jobs enqueued in your development environment will be processed just like they would be in staging/production. If you do not run `bin/jobs` and only use the web server (e.g. `bin/rails s`) then jobs will still be enqueued just fine, but they won't be worked on until the worker process is started. You can always check on the status of any jobs by going to `http://localhost:3000/jobs`.
 
+To start both the server and solid queue at the same time run this in your terminal window:
+
+```
+bin/dev
+```
+
 ## Commands
 - `bundle exec rake lint` - Run the full suite of linters on the codebase.
 - `bundle exec guard` - Runs the guard test server that reruns your tests after files are saved. Useful for TDD!

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+exec "foreman start -f Procfile.dev"


### PR DESCRIPTION
## Description
Add functionality to enable starting both the server and solid queue with one command for sandbox development.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Sandbox testing completed. Does not affect live code.

## Screenshots


## Acceptance criteria
- [x] command bin/dev starts everything up.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
