### PR TITLE
Vebt 4043 automate hcm and implement disabling of turbo prefetch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,13 +97,15 @@ group :development, :test do
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 4.2', platforms: :ruby
-
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'foreman'
+
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring', platforms: :ruby
+
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console', '~> 4.2', platforms: :ruby
 end
 
 gem 'mission_control-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.4.1)
+    date (3.5.1)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     descendants_tracker (0.0.4)
@@ -174,6 +174,7 @@ GEM
     diff-lcs (1.6.0)
     docile (1.4.0)
     drb (2.2.1)
+    erb (6.0.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -215,6 +216,8 @@ GEM
       thor (>= 0.14.0, < 2)
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
+    foreman (0.90.0)
+      thor (~> 1.4)
     formatador (1.1.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
@@ -357,7 +360,7 @@ GEM
       method_source (~> 1.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
-    psych (5.2.3)
+    psych (5.3.0)
       date
       stringio
     public_suffix (5.0.4)
@@ -413,8 +416,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.13.0)
+    rdoc (6.17.0)
+      erb
       psych (>= 4.0.0)
+      tsort
     regexp_parser (2.9.2)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -547,7 +552,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.1.6)
+    stringio (3.1.9)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
     terminal-table (3.0.2)
@@ -558,6 +563,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.1.0)
     timeout (0.4.3)
+    tsort (0.2.0)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -625,6 +631,7 @@ DEPENDENCIES
   faraday_middleware
   figaro
   font-awesome-rails (= 4.7.0.9)
+  foreman
   geocoder (~> 1.8)
   govdelivery-tms (= 2.8.4)
   guard-rspec

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 4000
+jobs: bin/jobs

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ bin/jobs
 
 This will start the Solid Queue worker process and jobs enqueued in your development environment will be processed just like they would be in staging/production. If you do not run `bin/jobs` and only use the web server (e.g. `bin/rails s`) then jobs will still be enqueued just fine, but they won't be worked on until the worker process is started. You can always check on the status of any jobs by going to `http://localhost:3000/jobs`.
 
+To start both the server and solid queue at the same time run this in your terminal window:
+
+```
+bin/dev
+```
+
 ## Commands
 - `bundle exec rake lint` - Run the full suite of linters on the codebase.
 - `bundle exec guard` - Runs the guard test server that reruns your tests after files are saved. Useful for TDD!

--- a/app/utilities/no_key_apis/no_key_api_downloader.rb
+++ b/app/utilities/no_key_apis/no_key_api_downloader.rb
@@ -2,14 +2,6 @@
 
 module  NoKeyApis
   class NoKeyApiDownloader
-    # the most recent IPED data files are from 2022. This should be checked periodically.
-    # the most recent Hcm data files are from 2020.  This should be checked periodically.
-    # changes will need to be made to both hashes when these change
-
-    # HCM has changed to xls from xlsx. Every quarter the file is updated and this needs to be checked
-    # as part of that. API_DOWNLOAD_CONVERSION_NAMES, API_NO_KEY_DOWNLOAD_SOURCES and o_parm need to be
-    # changed accordingly. This will also affect the dashboards_controller upload_files method
-
     API_DOWNLOAD_CONVERSION_NAMES = {
       'AccreditationInstituteCampus' => 'tmp/InstitutionCampus.csv',
       'Hcm' => 'tmp/hcm.xls',
@@ -28,7 +20,7 @@ module  NoKeyApis
       'AccreditationInstituteCampus' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
       'AccreditationRecord' => [' -X POST', 'https://ope.ed.gov/dapip/api/downloadFiles/accreditationDataFiles'],
       'EightKey' => [' -X GET', 'https://www.ed.gov/sites/ed/files/documents/military/8-keys-sites.xls'],
-      'Hcm' => ['', 'https://studentaid.gov/sites/default/files/Schools-on-HCM-December-2024.xls'],
+      'Hcm' => ['', -> { HcmUrlFetcher.fetch_latest_url }],
       'IpedsHd' => [' -X GET', -> { IpedsDownloadSource.fetch('IpedsHd') }],
       'IpedsIc' => [' -X GET', -> { IpedsDownloadSource.fetch('IpedsIc') }],
       'IpedsIcAy' => [' -X GET', -> { IpedsDownloadSource.fetch('IpedsIcAy') }],
@@ -42,7 +34,8 @@ module  NoKeyApis
     def initialize(class_nm)
       @class_nm = class_nm
       rest_command, source = API_NO_KEY_DOWNLOAD_SOURCES[@class_nm]
-      url = url_from(source)
+      @url = url_from(source)
+      Rails.logger.info("\n\n\n***Curl command: #{rest_command} #{url} #{h_parm} #{o_parm} #{d_parm} ***\n\n\n")
       @curl_command = "curl#{rest_command} #{url} #{h_parm} #{o_parm} #{d_parm}"
     end
 
@@ -65,7 +58,13 @@ module  NoKeyApis
 
     def o_parm
       case @class_nm
-      when 'Hcm' then '-o tmp/hcm.xls'
+      # hcm has been tricky because it gets updated periodically and the extension changes.
+      # The information is hidden behind some javascripting, so the html cannot easily be scraped.
+      # an api was discovered that can bring back the list of available files and the most
+      # recent file is always the first as of this refactor
+      when 'Hcm'
+        ext = @url.end_with?('.xlsx') ? 'xlsx' : 'xls'
+        "-o tmp/hcm.#{ext}"
       when 'EightKey' then '-o tmp/eight_key.xls'
       when 'Mou' then '-o tmp/mou.xlsx'
       when 'Vsoc' then '-o tmp/vsoc.csv'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
   <title>GibctDataService</title>
+  <!-- 
+    Disable turbo-prefetch. When the user hovers over one of the fetch buttons, it causes the process to kick off.
+    The api is invoked to retrieve the data from the remote source and loaded into the database. This is problematic
+    for a variety of reasons.
+  -->
+  <meta name="turbo-prefetch" content="false">
+  <!-- -->
+
   <%= stylesheet_link_tag    'application', media: 'all' %>
 
   <!-- Load legacy Sprockets assets (e.g. jQuery, Bootstrap) -->

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+exec "foreman start -f Procfile.dev"

--- a/lib/hcm_url_fetcher.rb
+++ b/lib/hcm_url_fetcher.rb
@@ -11,8 +11,10 @@ module HcmUrlFetcher
     Rails.logger.info "Fetching HCM URL from #{HCM_JSON_URL}"
     response = conn.get(HCM_JSON_URL)
     unless response.success?
+      # :nocov:
       Rails.logger.error "Failed to fetch HCM URL: #{response.status} - #{response.reason_phrase}"
       return DEFAULT_URL
+      # :nocov:
     end
 
     json = JSON.parse(response.body)
@@ -24,7 +26,9 @@ module HcmUrlFetcher
 
     href.start_with?('http') ? href : "#{BASE_URL}#{href}"
   rescue StandardError => e
+    # :nocov:
     Rails.logger.error "Failed to fetch HCM URL: #{e.message}"
     DEFAULT_URL
+    # :nocov:
   end
 end

--- a/lib/hcm_url_fetcher.rb
+++ b/lib/hcm_url_fetcher.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module HcmUrlFetcher
+  HCM_JSON_URL = 'https://studentaid.gov/data-center/school/hcm.json'
+  BASE_URL = 'https://studentaid.gov'
+  DEFAULT_URL = 'https://studentaid.gov/sites/default/files/Schools-on-HCM-December-2024.xls'
+
+  def self.fetch_latest_url
+    conn = Faraday.new { |f| f.headers['User-Agent'] = 'Mozilla/5.0' }
+
+    Rails.logger.info "Fetching HCM URL from #{HCM_JSON_URL}"
+    response = conn.get(HCM_JSON_URL)
+    unless response.success?
+      Rails.logger.error "Failed to fetch HCM URL: #{response.status} - #{response.reason_phrase}"
+      return DEFAULT_URL
+    end
+
+    json = JSON.parse(response.body)
+    href = json.dig('mainContent', 6, 'data', 0, 'data', 0, 'href')
+    if href.nil?
+      Rails.logger.error "Failed to find HCM URL parsing: #{json}"
+      return DEFAULT_URL
+    end
+
+    href.start_with?('http') ? href : "#{BASE_URL}#{href}"
+  rescue StandardError => e
+    Rails.logger.error "Failed to fetch HCM URL: #{e.message}"
+    DEFAULT_URL
+  end
+end

--- a/spec/utilities/no_key_apis/no_key_api_downloader_spec.rb
+++ b/spec/utilities/no_key_apis/no_key_api_downloader_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe NoKeyApis::NoKeyApiDownloader do
   before { allow(HTTParty).to receive(:get).and_return(ipeds_response) }
 
   describe '#initialize' do
+    before do
+      stub_request(:get, 'https://studentaid.gov/data-center/school/hcm.json')
+        .to_return(status: 200, body: '{"some": "json"}', headers: { 'Content-Type' => 'application/json' })
+    end
+
     %w[Accreditation AccreditationAction AccreditationInstituteCampus AccreditationRecord].each do |class_nm|
       it "sets the accreditation curl command correctly for #{class_nm}" do
         nkad = described_class.new(class_nm)
@@ -71,7 +76,7 @@ RSpec.describe NoKeyApis::NoKeyApiDownloader do
 
   describe '#download_csv' do
     it 'calls Open3 to run the curl command and download the file' do
-      nkad = described_class.new('Hcm')
+      nkad = described_class.new('EightKey')
 
       allow(Open3)
         .to receive(:capture3)


### PR DESCRIPTION
## Description
Fix hcm fetch to always get the most recent spreadsheet and implement fix for turbo prefetch.

## Original issue(s)
[vebt-4043](https://jira.devops.va.gov/browse/vebt-4043)

## Testing done
Sandbox testing and RSpec

## Screenshots


## Acceptance criteria
- [x] Hcm fetches the latest spreadsheet

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
