### PR TITLE
fix: Add artifact-metadata permission to workflow

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   actions: write
+  artifact-metadata: write
   attestations: write
   checks: write
   contents: write


### PR DESCRIPTION
## Description

This pull request makes a minor update to the workflow permissions in `.github/workflows/build-and-publish.yaml`, adding write access for `artifact-metadata`.

Working Action - https://github.com/department-of-veterans-affairs/gibct-data-service/actions/runs/20761695273