### PR TITLE
Add RSpec tests for HcmUrlFetcher & address brakeman issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -246,6 +246,9 @@ RSpec/LeakyConstantDeclaration:
 RSpec/NestedGroups:
   Max: 4
 
+RSpec/MessageSpies:
+  Enabled: false
+
 # Determined to be too benign and/or numerous to justify changing
 RSpec/MultipleExpectations:
   Enabled: false

--- a/app/models/dashboard_institution_importer.rb
+++ b/app/models/dashboard_institution_importer.rb
@@ -140,7 +140,7 @@ class DashboardInstitutionImporter
   end
 
   def calculate_lines_per_subfile(file)
-    linecount = `wc -l < #{file}`.to_i
+    linecount = File.foreach(file).count
     # It's necessary to add some lines to the total count to account for the header row in each file
     # Not doing this causes an array out of bounds error when trying to write to the last file
     (linecount + INSTITUTION_FILES.size).div(INSTITUTION_FILES.size)

--- a/app/models/dashboard_weam_importer.rb
+++ b/app/models/dashboard_weam_importer.rb
@@ -120,7 +120,7 @@ class DashboardWeamImporter
   end
 
   def calculate_lines_per_subfile
-    linecount = `wc -l < #{@download_dir}/Weam.csv`.to_i
+    linecount = File.foreach("#{@download_dir}/Weam.csv").count
     # It's necessary to add some lines to the total count to account for the header row in each file
     # Not doing this causes an array out of bounds error when trying to write to the last file
     (linecount + WEAM_FILES.size).div(WEAM_FILES.size)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,22 +1,155 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Missing Encryption",
-      "warning_code": 109,
-      "fingerprint": "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
-      "check_name": "ForceSSL",
-      "message": "The application does not force use of HTTPS: `config.force_ssl` is not enabled",
-      "file": "config/environments/production.rb",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/missing_encryption/",
-      "code": null,
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "38c825e527239d81823b792ab9084eb4351d5e731083fa9a7f609d34e4cbbe8f",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/dashboards/_version.html.erb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Show GIBCT\", (Unresolved Model).new.gibct_link, :target => \"_blank\", :rel => \"noopener noreferrer\", :class => \"btn dashboard-btn-success btn-xs\", :role => \"button\")",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "dashboards/_versions_table",
+          "line": 15,
+          "file": "app/views/dashboards/_versions_table.html.erb",
+          "rendered": {
+            "name": "dashboards/_version",
+            "file": "app/views/dashboards/_version.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "dashboards/_version"
+      },
+      "user_input": "(Unresolved Model).new.gibct_link",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "54c71a820ef183388fa94bffe63adaa34c76c8f8a44d4453fff6178cf24dc67e",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/dashboard_exporter_importer.rb",
+      "line": 82,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`gnome-terminal --title=\"Tail log #{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}\" -- bash -c \"tail -f #{Rails.root.join(\"log\", \"export_import_#{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}.log\")}; exec bash -i\"`",
       "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "High",
-      "note": "We terminate SSL before traffic gets to the gi data service elb and traffic from the elb to the service is over http."
+      "location": {
+        "type": "method",
+        "class": "DashboardExporterImporter",
+        "method": "set_logger"
+      },
+      "user_input": "Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Denial of Service",
+      "warning_code": 76,
+      "fingerprint": "608e27e0f4dc186258464c75db90711d09b67f2745475aba1642cbabc87099fb",
+      "check_name": "RegexDoS",
+      "message": "Model attribute used in regular expression",
+      "file": "app/models/calculator_constant.rb",
+      "line": 44,
+      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
+      "code": "/(?:Chapter|Ch\\.?) (#{RateAdjustment.pluck(:benefit_type).join(\"|\")})/",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CalculatorConstant",
+        "method": "matched_benefit_types"
+      },
+      "user_input": "RateAdjustment.pluck(:benefit_type).join(\"|\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        20,
+        185
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "73a80c17389b3906bdaa6c46e2b842343a0616f86ffaec53436eef065e15fc26",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/utilities/no_key_apis/no_key_api_downloader.rb",
+      "line": 43,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(\"curl#{rest_command} #{url} #{h_parm} #{o_parm} #{d_parm}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NoKeyApis::NoKeyApiDownloader",
+        "method": "download_csv"
+      },
+      "user_input": "rest_command",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "b50fa272244dad3808a69f40815073723c39452d7a052e1a58e9082bdab5637b",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/dashboard_institution_importer.rb",
+      "line": 73,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`gnome-terminal --title=\"Tail log #{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}\" -- bash -c \"tail -f #{Rails.root.join(\"log\", \"import_institution_#{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}.log\")}; exec bash -i\"`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DashboardInstitutionImporter",
+        "method": "set_logger"
+      },
+      "user_input": "Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "ba8d1fec86ca7fd5ec7ed9d9cd55d233e484162efd58f7b9c5440a6b381291de",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/dashboard_weam_importer.rb",
+      "line": 66,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`gnome-terminal --title=\"Tail log #{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}\" -- bash -c \"tail -f #{Rails.root.join(\"log\", \"import_weam_#{Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")}.log\")}; exec bash -i\"`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DashboardWeamImporter",
+        "method": "set_logger"
+      },
+      "user_input": "Time.now.getlocal.strftime(\"%Y%m%d_%H%M%S\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
     }
   ],
-  "updated": "2019-10-21 15:40:56 -0400",
-  "brakeman_version": "4.6.1"
+  "updated": "2026-01-21 15:04:44 -0600",
+  "brakeman_version": "6.1.2"
 }

--- a/lib/hcm_url_fetcher.rb
+++ b/lib/hcm_url_fetcher.rb
@@ -11,10 +11,8 @@ module HcmUrlFetcher
     Rails.logger.info "Fetching HCM URL from #{HCM_JSON_URL}"
     response = conn.get(HCM_JSON_URL)
     unless response.success?
-      # :nocov:
       Rails.logger.error "Failed to fetch HCM URL: #{response.status} - #{response.reason_phrase}"
       return DEFAULT_URL
-      # :nocov:
     end
 
     json = JSON.parse(response.body)
@@ -26,9 +24,7 @@ module HcmUrlFetcher
 
     href.start_with?('http') ? href : "#{BASE_URL}#{href}"
   rescue StandardError => e
-    # :nocov:
     Rails.logger.error "Failed to fetch HCM URL: #{e.message}"
     DEFAULT_URL
-    # :nocov:
   end
 end

--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -57,7 +57,6 @@ describe Common::Client::Base do
   end
 
   # rubocop:disable RSpec/SubjectStub
-  # rubocop:disable RSpec/MessageSpies
   describe '#perform' do
     let(:path) { '/' }
     let(:params) { {} }
@@ -267,6 +266,5 @@ describe Common::Client::Base do
         .to raise_error(Common::Client::Errors::NotAuthenticated)
     end
   end
-  # rubocop:enable RSpec/MessageSpies
   # rubocop:enable RSpec/SubjectStub
 end

--- a/spec/lib/hcm_url_fetcher_spec.rb
+++ b/spec/lib/hcm_url_fetcher_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HcmUrlFetcher do
+  describe '.fetch_latest_url' do
+    let(:faraday_connection) { instance_double(Faraday::Connection) }
+    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body, status: 200) }
+    let(:response_body) { { 'mainContent' => [nil, nil, nil, nil, nil, nil, main_content_item] }.to_json }
+    let(:main_content_item) { { 'data' => [{ 'data' => [{ 'href' => href }] }] } }
+    let(:href) { 'https://studentaid.gov/sites/default/files/Schools-on-HCM-January-2025.xlsx' }
+
+    before do
+      allow(Faraday).to receive(:new).and_yield(faraday_connection).and_return(faraday_connection)
+      allow(faraday_connection).to receive(:headers).and_return({})
+      allow(faraday_connection).to receive(:get).with(described_class::HCM_JSON_URL).and_return(response)
+    end
+
+    context 'when the request is successful with an absolute URL' do
+      it 'returns the href from the JSON response' do
+        expect(described_class.fetch_latest_url).to eq(href)
+      end
+    end
+
+    context 'when the request is successful with a relative URL' do
+      let(:href) { '/sites/default/files/Schools-on-HCM-January-2025.xlsx' }
+
+      it 'prepends the base URL' do
+        expect(described_class.fetch_latest_url).to eq("#{described_class::BASE_URL}#{href}")
+      end
+    end
+
+    context 'when the HTTP request fails' do
+      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, reason_phrase: 'Internal Server Error') }
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to fetch HCM URL: 500/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+
+    context 'when the href is not found in the JSON structure' do
+      let(:main_content_item) { { 'data' => [] } }
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to find HCM URL parsing/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+
+    context 'when the href is nil' do
+      let(:href) { nil }
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to find HCM URL parsing/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+
+    context 'when JSON parsing fails' do
+      let(:response) { instance_double(Faraday::Response, success?: true, body: 'not valid json') }
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to fetch HCM URL/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+
+    context 'when a network error occurs' do
+      before do
+        allow(faraday_connection).to receive(:get).and_raise(Faraday::ConnectionFailed.new('Connection refused'))
+      end
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to fetch HCM URL: Connection refused/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+
+    context 'when a timeout occurs' do
+      before do
+        allow(faraday_connection).to receive(:get).and_raise(Faraday::TimeoutError.new('Request timed out'))
+      end
+
+      it 'logs an error and returns the default URL' do
+        expect(Rails.logger).to receive(:error).with(/Failed to fetch HCM URL/)
+        expect(described_class.fetch_latest_url).to eq(described_class::DEFAULT_URL)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
We needed to get a fix working quickly in the prior sprint and pushed it through without writing the tests. We circled back in this sprint to write the tests.

While running Brakeman, a few warnings popped up which could have been ignored. We decided to address them since the refactors don't affect live code and some of them were false positives that could be safely ignored.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
These are the tests

## Screenshots


## Acceptance criteria
- [x] Tests are representative of behavior and pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
  [VEBT-4173](https://jira.devops.va.gov/browse/VEBT-4173)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
