### PR TITLE
Add SBOM generation workflow

### DIFF
--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -5,7 +5,6 @@ on:
     branches: [master]
     paths:
       - 'Gemfile.lock'
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -1,0 +1,20 @@
+name: Library SBOM Generation
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'Gemfile.lock'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-sbom:
+    uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/library-sbom-generation.yml@main
+    with:
+      artifact_name: sbom
+      output_bucket: s3://vagov-infra-sbom-bucket/software/gibct-data-service


### PR DESCRIPTION
## Summary

Adds automated SBOM (Software Bill of Materials) generation using Trivy.

- Generates SBOM when Gemfile.lock changes on master
- Uploads to S3 bucket for Platform Security/CSOC
- Can be manually triggered via workflow_dispatch

## Related Issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129925