### PR TITLE
VEBT-5013/revert create archives to raw sql

### DIFF
--- a/app/models/archiver.rb
+++ b/app/models/archiver.rb
@@ -114,10 +114,13 @@ module Archiver # rubocop:disable Metrics/ModuleLength
 
     benchmark_start("create_#{archive.table_name}")
     orig_count = archive.count
-    base_query.in_batches(of: 1000) do |relation|
-      attributes = relation.as_json(only: archive.column_names)
-      archive.insert_all(attributes) if attributes.present? # rubocop:disable Rails/SkipsModelValidations
-    end
+
+    cols = archive.column_names
+    insert_cols = cols.map { |col| "\"#{col}\"" }.join(', ')
+    select_cols = cols.map { |col| "s.#{col}" }.join(', ')
+
+    sql = "INSERT INTO #{archive.table_name}(#{insert_cols}) SELECT #{select_cols} FROM (#{base_query.to_sql}) s"
+    ApplicationRecord.connection.execute(sql)
 
     benchmark_end("create_#{archive.table_name}", archive.count - orig_count)
     Rails.logger.info "*** Done archiving #{source.table_name}"


### PR DESCRIPTION
Previously tried to speed up archiver by using `in_batches` instead of `find_in_batches` [here](https://github.com/department-of-veterans-affairs/gibct-data-service/pull/1615). But what we gained there was lost with `as_json` call. Trying raw sql to avoid all unnecessary Ruby processes. Using combination of original sql implementation plus updates made by Noah

https://jira.devops.va.gov/browse/VEBT-5103