### PR TITLE
VEBT/add rate limiting to geocoding

### DIFF
--- a/app/concerns/geocoder_logic.rb
+++ b/app/concerns/geocoder_logic.rb
@@ -89,6 +89,7 @@ module GeocoderLogic
       throw_geocode_exception(data) if geocode_type.eql?('exception_test')
 
       timed_out = false
+      sleep 1 # nominatim enforces 1 request per second
       geocoded = Geocoder.send geocode_type.to_sym, data
     rescue Timeout::Error
       Rails.logger.info "  Geocode.#{geocode_type} timed out with #{data} retrying"

--- a/spec/models/search_geocoder_spec.rb
+++ b/spec/models/search_geocoder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SearchGeocoder, type: :model do
   let(:version) { create(:version, :preview) }
 
   before do
-    allow(Kernel).to receive(:sleep) # stub rate limiting
+    allow(Kernel).to receive(:sleep) # stub out rate limiting
     # rubocop:disable Style/ColonMethodCall
     Geocoder::configure(:lookup => :test)
     Geocoder::Lookup::Test.add_stub(

--- a/spec/models/search_geocoder_spec.rb
+++ b/spec/models/search_geocoder_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SearchGeocoder, type: :model do
   let(:version) { create(:version, :preview) }
 
   before do
+    allow(Kernel).to receive(:sleep) # stub rate limiting
     # rubocop:disable Style/ColonMethodCall
     Geocoder::configure(:lookup => :test)
     Geocoder::Lookup::Test.add_stub(


### PR DESCRIPTION
Geocoding service Nominatim enforces 1 request per second rate limit -- which we've been violating in staging and prod and slowing down version generation. Adding a `sleep 1` call inside geocoder logic. Due to recursive nature of method, adding the sleep to the beginning of the method instead of inside an ensure at end